### PR TITLE
fix: remove -dr clearance override when calling freerouting

### DIFF
--- a/kcaa/utils/pcb_design_rules.py
+++ b/kcaa/utils/pcb_design_rules.py
@@ -9,11 +9,11 @@ or kicad-cli is required.
 
 import json as _json
 import logging
+import os
+import shutil
 from typing import Any
 
 import sexpdata
-
-from kcaa.utils.pcb_sexp_utils import load_pcb, save_pcb
 
 log = logging.getLogger(__name__)
 
@@ -80,6 +80,58 @@ def _find_section(tree: list[Any], tag: str) -> list[Any] | None:
         if isinstance(item, list) and len(item) > 0 and item[0] == tag_sym:
             return item
     return None
+
+
+def _dru_path(pcb_file: str) -> str:
+    """Derive the .kicad_dru path from a .kicad_pcb path."""
+    return pcb_file.replace(".kicad_pcb", ".kicad_dru")
+
+
+def _load_dru(dru_file: str) -> list[Any]:
+    """Parse a .kicad_dru file and return its S-expression tree.
+
+    Uses ``sexpdata.parse`` because dru files contain multiple top-level
+    forms (``(version 1)`` + ``(rule ...)`` etc.), unlike .kicad_pcb
+    which has a single ``(kicad_pcb ...)`` wrapper.
+    """
+    with open(dru_file, encoding="utf-8") as f:
+        return sexpdata.parse(f.read())
+
+
+def _save_dru(dru_file: str, data: list[Any]) -> str | None:
+    """Write *data* to *dru_file*, creating a .bak backup first if file exists.
+
+    Each top-level form in *data* is serialised on its own line so that
+    the file can be round-tripped with ``sexpdata.parse``.
+
+    Returns the backup path or None if the file didn't exist yet.
+    """
+    bak_path = None
+    if os.path.exists(dru_file):
+        bak_path = dru_file + ".bak"
+        shutil.copy2(dru_file, bak_path)
+
+    lines = [sexpdata.dumps(item) for item in data]
+    text = "\n".join(lines) + "\n"
+    tmp_path = dru_file + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write(text)
+    os.replace(tmp_path, dru_file)
+    return bak_path
+
+
+def _parse_dru_value(val: Any) -> float:
+    """Parse a dru constraint value, stripping unit suffix (e.g. '0.4mm' → 0.4)."""
+    s = _str_symbol(val)
+    for unit in ("mm", "mil", "um", "nm", "inch", "in"):
+        if s.endswith(unit):
+            return float(s[: -len(unit)])
+    return float(s)
+
+
+def _format_dru_value(value: float) -> sexpdata.Symbol:
+    """Format a constraint value for dru output, adding mm suffix."""
+    return sexpdata.Symbol(f"{value}mm")
 
 
 def _str_symbol(val: Any) -> str:
@@ -262,34 +314,31 @@ def update_design_rules_in_file(pro_file: str, updates: dict[str, float]) -> dic
 
 
 def get_custom_rules_from_file(pcb_file: str) -> dict[str, Any]:
-    """Read custom design rules from a ``.kicad_pcb`` file.
+    """Read custom design rules from the ``.kicad_dru`` file.
+
+    KiCad 10.0 stores custom DRC rules in the .kicad_dru file, not in
+    .kicad_pcb.  This function derives the dru path from the pcb path.
 
     Args:
-        pcb_file: Absolute path to the ``.kicad_pcb`` file.
+        pcb_file: Absolute path to the ``.kicad_pcb`` file (used to
+                  derive the ``.kicad_dru`` path).
 
     Returns:
         ``{"success": True, "rules": [...]}`` with a list of custom
         rule dicts, or an error dict.
     """
+    dru_file = _dru_path(pcb_file)
+
+    if not os.path.exists(dru_file):
+        return {"success": True, "rules": [], "message": "No .kicad_dru file found."}
+
     try:
-        tree = load_pcb(pcb_file)
+        tree = _load_dru(dru_file)
     except (FileNotFoundError, ValueError) as exc:
         return {"success": False, "error": str(exc)}
 
-    setup = _find_section(tree, "setup")
-    if setup is None:
-        return {
-            "success": True,
-            "rules": [],
-            "message": "No (setup ...) section found in PCB file.",
-        }
-
-    cr_section = _find_section(setup, "custom_rules")
-    if cr_section is None:
-        return {"success": True, "rules": [], "message": "No (custom_rules ...) subsection found."}
-
     rules: list[dict[str, Any]] = []
-    for item in cr_section[1:]:
+    for item in tree:
         if isinstance(item, list) and len(item) >= 2 and _str_symbol(item[0]) == "rule":
             rule = _parse_custom_rule(item)
             if rule:
@@ -306,11 +355,15 @@ def add_custom_rule_to_file(
     value: float,
     severity: str = "error",
 ) -> dict[str, Any]:
-    """Append a custom design rule to the ``(custom_rules ...)`` section.
+    """Append a custom design rule to the ``.kicad_dru`` file.
+
+    KiCad 10.0 stores custom DRC rules in .kicad_dru.  If the file does
+    not exist yet, it is created with a ``(version 1)`` header.
 
     Args:
-        pcb_file: Absolute path to the ``.kicad_pcb`` file.
-        name: Human-readable rule name.
+        pcb_file: Absolute path to the ``.kicad_pcb`` file (used to
+                  derive the ``.kicad_dru`` path).
+        name: Human-readable rule name (a Symbol, no quotes).
         condition: Lisp-style condition expression (e.g.
                    ``"A.NetClass == 'HV'"``).
         constraint_type: One of ``clearance``, ``track_width``, ``hole_size``,
@@ -328,42 +381,36 @@ def add_custom_rule_to_file(
             "error": f"Invalid severity '{severity}'. Must be one of {sorted(valid_severities)}.",
         }
 
-    try:
-        tree = load_pcb(pcb_file)
-    except (FileNotFoundError, ValueError) as exc:
-        return {"success": False, "error": str(exc)}
+    dru_file = _dru_path(pcb_file)
 
-    # Find or create (setup ...)
-    setup = _find_section(tree, "setup")
-    if setup is None:
-        setup = [sexpdata.Symbol("setup")]
-        tree.append(setup)
+    # Load existing dru or create new tree
+    if os.path.exists(dru_file):
+        try:
+            tree = _load_dru(dru_file)
+        except (FileNotFoundError, ValueError) as exc:
+            return {"success": False, "error": str(exc)}
+    else:
+        tree = [sexpdata.Symbol("version"), 1]
 
-    # Find or create (custom_rules ...)
-    cr_section = _find_section(setup, "custom_rules")
-    if cr_section is None:
-        cr_section = [sexpdata.Symbol("custom_rules")]
-        setup.append(cr_section)
-
-    # Build the new rule sexp
+    # Build the new rule sexp in dru format:
+    # (rule Name (condition "...") (constraint type (min 0.4mm)) (severity error))
     rule_sexp: list[Any] = [
         sexpdata.Symbol("rule"),
-        name,
+        sexpdata.Symbol(name),
         [sexpdata.Symbol("condition"), condition],
         [
             sexpdata.Symbol("constraint"),
             sexpdata.Symbol(constraint_type),
-            sexpdata.Symbol("min"),
-            value,
+            [sexpdata.Symbol("min"), _format_dru_value(value)],
         ],
         [sexpdata.Symbol("severity"), sexpdata.Symbol(severity)],
     ]
-    cr_section.append(rule_sexp)
+    tree.append(rule_sexp)
 
     try:
-        bak_path = save_pcb(pcb_file, tree)
+        bak_path = _save_dru(dru_file, tree)
     except OSError as exc:
-        return {"success": False, "error": f"Failed to save PCB file: {exc}"}
+        return {"success": False, "error": f"Failed to save dru file: {exc}"}
 
     rule_dict = {
         "name": name,
@@ -375,58 +422,60 @@ def add_custom_rule_to_file(
 
 
 def remove_custom_rule_from_file(pcb_file: str, rule_name: str) -> dict[str, Any]:
-    """Remove a custom design rule by name from the ``(custom_rules ...)`` section.
+    """Remove a custom design rule by name from the ``.kicad_dru`` file.
 
     A ``.bak`` backup is created automatically.
 
     Args:
-        pcb_file: Absolute path to the ``.kicad_pcb`` file.
+        pcb_file: Absolute path to the ``.kicad_pcb`` file (used to
+                  derive the ``.kicad_dru`` path).
         rule_name: Name of the custom rule to remove (matches the ``name`` argument
                    from ``add_custom_rule``).
 
     Returns:
         ``{"success": True, "removed": rule_name, "backup_path": ...}`` or error.
     """
+    dru_file = _dru_path(pcb_file)
+
+    if not os.path.exists(dru_file):
+        return {"success": False, "error": "No .kicad_dru file found."}
+
     try:
-        tree = load_pcb(pcb_file)
+        tree = _load_dru(dru_file)
     except (FileNotFoundError, ValueError) as exc:
         return {"success": False, "error": str(exc)}
 
-    setup = _find_section(tree, "setup")
-    if setup is None:
-        return {"success": False, "error": "No (setup ...) section found in PCB file."}
-
-    cr_section = _find_section(setup, "custom_rules")
-    if cr_section is None:
-        return {"success": False, "error": "No (custom_rules ...) section found."}
-
     removed = None
-    new_children = [cr_section[0]]  # keep the "custom_rules" Symbol header
-    for item in cr_section[1:]:
+    new_tree: list[Any] = []
+    for item in tree:
         if isinstance(item, list) and len(item) >= 2 and _str_symbol(item[0]) == "rule":
             if _str_symbol(item[1]) == rule_name:
                 removed = item
                 continue
-        new_children.append(item)
+        new_tree.append(item)
 
     if removed is None:
         return {"success": False, "error": f"Custom rule '{rule_name}' not found."}
 
-    # Replace cr_section contents in-place
-    cr_section.clear()
-    cr_section.extend(new_children)
+    # Replace tree in-place
+    tree.clear()
+    tree.extend(new_tree)
 
     try:
-        bak_path = save_pcb(pcb_file, tree)
+        bak_path = _save_dru(dru_file, tree)
     except OSError as exc:
-        return {"success": False, "error": f"Failed to save PCB file: {exc}"}
+        return {"success": False, "error": f"Failed to save dru file: {exc}"}
 
-    log.info("Removed custom rule '%s' from %s", rule_name, pcb_file)
+    log.info("Removed custom rule '%s' from %s", rule_name, dru_file)
     return {"success": True, "removed": rule_name, "backup_path": bak_path}
 
 
 def _parse_custom_rule(rule_sexp: list[Any]) -> dict[str, Any] | None:
-    """Parse a single ``(rule ...)`` sexp into a dict."""
+    """Parse a single ``(rule ...)`` sexp into a dict.
+
+    Handles both the dru format ``(constraint type (min 0.4mm))`` and
+    the legacy PCB format ``(constraint type min 0.4)``.
+    """
     if len(rule_sexp) < 2:
         return None
     rule: dict[str, Any] = {"name": _str_symbol(rule_sexp[1])}
@@ -438,11 +487,19 @@ def _parse_custom_rule(rule_sexp: list[Any]) -> dict[str, Any] | None:
         if tag == "condition" and len(item) >= 2:
             rule["condition"] = item[1]
         elif tag == "constraint":
-            # (constraint <type> min|max|opt <value>)
+            # Dru format:   (constraint <type> (min 0.4mm))  → 3 top-level items
+            # Legacy format: (constraint <type> min <value>)  → 4 top-level items
             if len(item) >= 4:
                 rule["constraint"] = {
                     "type": _str_symbol(item[1]),
-                    _str_symbol(item[2]): item[3],
+                    _str_symbol(item[2]): _parse_dru_value(item[3]),
+                }
+            elif len(item) >= 3 and isinstance(item[2], list) and len(item[2]) >= 2:
+                # Dru format: third element is (min|max|opt <val_mm>)
+                sub = item[2]
+                rule["constraint"] = {
+                    "type": _str_symbol(item[1]),
+                    _str_symbol(sub[0]): _parse_dru_value(sub[1]),
                 }
             elif len(item) >= 3:
                 rule["constraint"] = {

--- a/kicad_plugin/autorouter.py
+++ b/kicad_plugin/autorouter.py
@@ -273,7 +273,7 @@ def start_freerouting_thread(
     on_done: Callable[[bool, str, str, str], None],
     on_progress: Callable[[str], None] | None = None,
     ignore_nets: list[str] | None = None,
-    max_passes: int = 50,
+    max_passes: int = 100,
     clearance_mm: float | None = None,
 ) -> threading.Thread:
     """Start FreeRouting in a background daemon thread.

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -1073,7 +1073,6 @@ if _WX_AVAILABLE:
 
             # ---- 2. Read design rules for constraint pass-through ----
             board_path = board.GetFileName()
-            clearance_mm = None
             constraint_hint = ""
             if board_path and os.path.isfile(board_path):
                 try:
@@ -1087,7 +1086,6 @@ if _WX_AVAILABLE:
                         ce_clear = rules.get("copper_edge_clearance")
                         parts = []
                         if min_clear is not None:
-                            clearance_mm = min_clear
                             parts.append(f"Clearance: {min_clear} mm")
                         if min_track is not None:
                             parts.append(f"Min Track: {min_track} mm")
@@ -1240,7 +1238,6 @@ if _WX_AVAILABLE:
                 on_done=_routing_done,
                 on_progress=_progress,
                 ignore_nets=ignore_nets,
-                clearance_mm=clearance_mm,
             )
 
         def _on_autoroute_done(

--- a/tests/unit/plugin/test_autorouter.py
+++ b/tests/unit/plugin/test_autorouter.py
@@ -260,7 +260,7 @@ class TestStartFreeroutingThread:
         call_args = mock_run.call_args
         assert call_args is not None
         # positional: dsn_path, ses_path, on_progress, ignore_nets, max_passes, clearance_mm
-        assert call_args[0][4] == 50  # max_passes (default)
+        assert call_args[0][4] == 100  # max_passes (default)
         assert call_args[0][5] == 0.3  # clearance_mm
 
     def test_clearance_none_not_passed_explicitly(self, tmp_path):

--- a/tests/unit/tools/test_pcb_design_rules.py
+++ b/tests/unit/tools/test_pcb_design_rules.py
@@ -19,7 +19,7 @@ from kcaa.utils.pcb_design_rules import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-# A minimal-but-realistic .kicad_pcb template (still needed for custom_rules tests).
+# A minimal-but-realistic .kicad_pcb template (no longer embeds custom_rules).
 _PCB_TEMPLATE = """(kicad_pcb
 \t(version 20260206)
 \t(generator "pcbnew")
@@ -37,25 +37,25 @@ _PCB_TEMPLATE = """(kicad_pcb
 \t\t\t(hole_clearance 0.25)
 \t\t\t(silk_clearance 0.15)
 \t\t)
-\t\t{custom_rules_block}
 \t)
 \t(net "VCC")
 \t(net "GND")
 )
 """
 
-_CUSTOM_RULES_BLOCK = """(custom_rules
-\t\t\t(rule "High voltage"
-\t\t\t\t(condition "A.NetClass == 'HV'")
-\t\t\t\t(constraint clearance min 1.0)
-\t\t\t\t(severity error)
-\t\t\t)
-\t\t\t(rule "Fine tracks"
-\t\t\t\t(condition "A.Type == 'track'")
-\t\t\t\t(constraint track_width min 0.1)
-\t\t\t\t(severity warning)
-\t\t\t)
-\t\t)"""
+# A .kicad_dru template with two custom rules (KiCad 10.0+ format).
+_DRU_WITH_RULES = """(version 1)
+(rule "High voltage"
+\t(condition "A.NetClass == 'HV'")
+\t(constraint clearance (min 1.0mm))
+\t(severity error)
+)
+(rule "Fine tracks"
+\t(condition "A.Type == 'track'")
+\t(constraint track_width (min 0.1mm))
+\t(severity warning)
+)
+"""
 
 # A PCB file with NO setup section at all.
 _PCB_NO_SETUP = """(kicad_pcb
@@ -76,8 +76,8 @@ _PCB_SETUP_NO_DR = """(kicad_pcb
 )
 """
 
-# A PCB file with setup + design_rules but NO custom_rules.
-_PCB_NO_CUSTOM = """(kicad_pcb
+# A PCB file with setup + design_rules section.
+_PCB_WITH_SETUP = """(kicad_pcb
 \t(version 20260206)
 \t(generator "pcbnew")
 \t(setup
@@ -93,6 +93,14 @@ _PCB_NO_CUSTOM = """(kicad_pcb
 def _write_pcb(content: str, dir_: str) -> str:
     """Write *content* to a temp .kicad_pcb file and return its path."""
     path = os.path.join(dir_, "test_board.kicad_pcb")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    return path
+
+
+def _write_dru(content: str, dir_: str, stem: str = "test_board") -> str:
+    """Write *content* to a temp .kicad_dru file and return its path."""
+    path = os.path.join(dir_, f"{stem}.kicad_dru")
     with open(path, "w", encoding="utf-8") as fh:
         fh.write(content)
     return path
@@ -180,8 +188,7 @@ class TestGetEffectiveDesignRules:
 
     def test_reads_all_known_fields(self, tmp_path):
         """All design_rule fields from the .kicad_pro JSON are parsed."""
-        content = _PCB_TEMPLATE.format(custom_rules_block="")
-        pcb = _write_pcb_and_pro(content, str(tmp_path))
+        pcb = _write_pcb_and_pro(_PCB_TEMPLATE, str(tmp_path))
 
         result = get_effective_design_rules_from_file(pcb)
 
@@ -318,8 +325,8 @@ class TestGetCustomRules:
 
     def test_reads_multiple_rules(self, tmp_path):
         """Two custom rules are parsed with all fields."""
-        content = _PCB_TEMPLATE.format(custom_rules_block=_CUSTOM_RULES_BLOCK)
-        pcb = _write_pcb(content, str(tmp_path))
+        pcb = _write_pcb(_PCB_TEMPLATE, str(tmp_path))
+        _write_dru(_DRU_WITH_RULES, str(tmp_path))
 
         result = get_custom_rules_from_file(pcb)
 
@@ -338,17 +345,17 @@ class TestGetCustomRules:
         assert r1["severity"] == "warning"
 
     def test_no_custom_rules(self, tmp_path):
-        """When no custom_rules subsection, returns empty list."""
-        pcb = _write_pcb(_PCB_NO_CUSTOM, str(tmp_path))
+        """When no .kicad_dru file, returns empty list."""
+        pcb = _write_pcb(_PCB_WITH_SETUP, str(tmp_path))
 
         result = get_custom_rules_from_file(pcb)
 
         assert result["success"] is True
         assert result["rules"] == []
-        assert "No (custom_rules" in result.get("message", "")
+        assert ".kicad_dru" in result.get("message", "")
 
-    def test_no_setup_section(self, tmp_path):
-        """When no setup section, returns empty list."""
+    def test_no_dru_file(self, tmp_path):
+        """When no .kicad_dru file at all, returns empty list."""
         pcb = _write_pcb(_PCB_NO_SETUP, str(tmp_path))
 
         result = get_custom_rules_from_file(pcb)
@@ -365,10 +372,10 @@ class TestGetCustomRules:
 class TestAddCustomRule:
     """Tests for add_custom_rule_to_file."""
 
-    def test_adds_rule_to_existing_custom_rules(self, tmp_path):
-        """Rule is appended when custom_rules section already exists."""
-        content = _PCB_TEMPLATE.format(custom_rules_block=_CUSTOM_RULES_BLOCK)
-        pcb = _write_pcb(content, str(tmp_path))
+    def test_adds_rule_to_existing_dru(self, tmp_path):
+        """Rule is appended when .kicad_dru already has rules."""
+        pcb = _write_pcb(_PCB_TEMPLATE, str(tmp_path))
+        _write_dru(_DRU_WITH_RULES, str(tmp_path))
 
         result = add_custom_rule_to_file(
             pcb, "Test rule", "A.NetName == 'CLK'", "clearance", 0.5, "warning"
@@ -376,7 +383,8 @@ class TestAddCustomRule:
 
         assert result["success"] is True
         assert result["rule"]["name"] == "Test rule"
-        assert result["backup_path"].endswith(".bak")
+        backup = result.get("backup_path")
+        assert backup is not None and backup.endswith(".bak")
 
         # Re-read and verify
         rules = get_custom_rules_from_file(pcb)
@@ -386,22 +394,24 @@ class TestAddCustomRule:
         assert new_rule["condition"] == "A.NetName == 'CLK'"
         assert new_rule["severity"] == "warning"
 
-    def test_adds_rule_when_no_custom_rules_section(self, tmp_path):
-        """Creates the custom_rules section if it doesn't exist."""
-        pcb = _write_pcb(_PCB_NO_CUSTOM, str(tmp_path))
+    def test_creates_dru_when_no_file(self, tmp_path):
+        """Creates .kicad_dru when it doesn't exist."""
+        pcb = _write_pcb(_PCB_WITH_SETUP, str(tmp_path))
 
         result = add_custom_rule_to_file(
             pcb, "New rule", "A.NetClass == 'Power'", "track_width", 0.25, "error"
         )
 
         assert result["success"] is True
+        # No backup when file didn't exist
+        assert result.get("backup_path") is None
 
         rules = get_custom_rules_from_file(pcb)
         assert len(rules["rules"]) == 1
         assert rules["rules"][0]["name"] == "New rule"
 
-    def test_adds_rule_when_no_setup_section(self, tmp_path):
-        """Creates both setup and custom_rules sections."""
+    def test_creates_dru_when_no_setup(self, tmp_path):
+        """Creates .kicad_dru even when PCB has no setup section."""
         pcb = _write_pcb(_PCB_NO_SETUP, str(tmp_path))
 
         result = add_custom_rule_to_file(
@@ -409,13 +419,14 @@ class TestAddCustomRule:
         )
 
         assert result["success"] is True
+        assert result.get("backup_path") is None
 
         rules = get_custom_rules_from_file(pcb)
         assert len(rules["rules"]) == 1
 
     def test_rejects_invalid_severity(self, tmp_path):
         """Invalid severity value is rejected."""
-        pcb = _write_pcb(_PCB_TEMPLATE.format(custom_rules_block=""), str(tmp_path))
+        pcb = _write_pcb(_PCB_TEMPLATE, str(tmp_path))
 
         result = add_custom_rule_to_file(
             pcb, "Bad rule", "A.NetClass == 'X'", "clearance", 1.0, "critical"


### PR DESCRIPTION
Freerouting should rely solely on the DSN-embedded rules from ExportSpecctraDSN. The -dr CLI flag was a redundant override that could conflict with DSN rules and added no value since min_clearance is already exported in the DSN.