### PR TITLE
feat: add delete_net_class tool to DRC tools

### DIFF
--- a/kcaa/tools/drc_tools.py
+++ b/kcaa/tools/drc_tools.py
@@ -15,6 +15,7 @@ from kcaa.utils.file_utils import get_project_files
 from kcaa.utils.ipc_drc import run_drc_via_ipc
 from kcaa.utils.net_settings import (
     assign_nets_to_class_in_pro,
+    delete_net_class_from_pro,
     remove_nets_from_class_in_pro,
     set_net_class_in_pro,
 )
@@ -213,6 +214,31 @@ def register_drc_tools(mcp: FastMCP) -> None:
             return {"success": False, "error": f"Project not found: {project_path}"}
 
         return remove_nets_from_class_in_pro(project_path, class_name, nets)
+
+    @mcp.tool()
+    def delete_net_class(project_path: str, class_name: str) -> dict[str, Any]:
+        """Delete a net class definition from the project file.
+
+        Removes the net class entry and cleans up all net assignments
+        pointing to it — those nets revert to the Default net class.
+        A ``.bak`` backup is created automatically.
+
+        The ``"Default"`` net class cannot be deleted.  Use
+        ``remove_nets_from_class`` first if you only want to move nets
+        out of a class while keeping the class definition.
+
+        Args:
+            project_path: Path to the KiCad project file (.kicad_pro)
+            class_name: Name of the net class to delete (e.g. ``"Power"``)
+
+        Returns:
+            Dictionary with ``deleted``, ``cleared_patterns``, and
+            ``backup_path`` keys, or error.
+        """
+        if not os.path.exists(project_path):
+            return {"success": False, "error": f"Project not found: {project_path}"}
+
+        return delete_net_class_from_pro(project_path, class_name)
 
     @mcp.tool()
     def add_custom_rule(

--- a/kcaa/utils/net_settings.py
+++ b/kcaa/utils/net_settings.py
@@ -418,6 +418,96 @@ def remove_nets_from_class_in_pro(
     return result
 
 
+def delete_net_class_from_pro(pro_file: str, class_name: str) -> dict[str, Any]:
+    """Delete a net class definition from the project file.
+
+    Removes the class entry from ``net_settings.classes`` and cleans up any
+    ``netclass_patterns`` pointing to it — those nets revert to the Default
+    net class.  Creating a ``.kicad_pro.bak`` backup automatically.
+
+    The ``"Default"`` net class cannot be deleted.
+
+    Args:
+        pro_file: Absolute path to the .kicad_pro file.
+        class_name: Name of the net class to delete.
+
+    Returns:
+        ``{"success": True, "deleted": true, "cleared_patterns": [...], "backup_path": ...}``
+        or error dict.
+    """
+    if class_name == "Default":
+        return {"success": False, "error": "Cannot delete the Default net class."}
+
+    try:
+        with open(pro_file, encoding="utf-8") as f:
+            data = _json.load(f)
+    except (FileNotFoundError, _json.JSONDecodeError, PermissionError) as exc:
+        return {"success": False, "error": f"Cannot read project file: {exc}"}
+
+    ns = data.get("net_settings")
+    if ns is None:
+        return {"success": False, "error": "No net_settings section in project file"}
+
+    classes = ns.get("classes")
+    if not isinstance(classes, list):
+        return {"success": False, "error": "No classes array in net_settings"}
+
+    # Locate and remove the target class
+    original_len = len(classes)
+    new_classes = [
+        nc for nc in classes if not (isinstance(nc, dict) and nc.get("name") == class_name)
+    ]
+    if len(new_classes) == original_len:
+        return {
+            "success": False,
+            "error": f"Net class '{class_name}' not found in project file.",
+        }
+    ns["classes"] = new_classes
+
+    # Clean up netclass_patterns that reference the deleted class
+    patterns: list[dict] = ns.get("netclass_patterns")
+    cleared_patterns: list[str] = []
+    if isinstance(patterns, list):
+        new_patterns = []
+        for p in patterns:
+            if isinstance(p, dict) and p.get("netclass") == class_name:
+                cleared_patterns.append(p.get("pattern", ""))
+                log.info(
+                    "Removed pattern '%s' from deleted class '%s'", p.get("pattern"), class_name
+                )
+            else:
+                new_patterns.append(p)
+        ns["netclass_patterns"] = new_patterns
+
+    import shutil
+
+    bak_path = pro_file + ".bak"
+    try:
+        shutil.copy2(pro_file, bak_path)
+    except OSError as exc:
+        return {"success": False, "error": f"Failed to create backup: {exc}"}
+
+    try:
+        with open(pro_file, "w", encoding="utf-8") as f:
+            _json.dump(data, f, indent=2)
+    except OSError as exc:
+        return {"success": False, "error": f"Failed to write project file: {exc}"}
+
+    log.info(
+        "Deleted net class '%s' from %s (cleared %d patterns)",
+        class_name,
+        pro_file,
+        len(cleared_patterns),
+    )
+    return {
+        "success": True,
+        "deleted": True,
+        "cleared_patterns": cleared_patterns,
+        "backup_path": bak_path,
+        "warning": f"Net class '{class_name}' deleted from {pro_file}. Reopen the project in KiCad for changes to take effect.",
+    }
+
+
 def _netclass_to_dict(nc: dict) -> dict[str, Any]:
     """Convert a raw netclass dict to our canonical format (only design-relevant fields)."""
     entry: dict[str, Any] = {"name": nc.get("name", "")}

--- a/kicad_plugin/skills/drc_rules.md
+++ b/kicad_plugin/skills/drc_rules.md
@@ -9,6 +9,7 @@ description: "Design rules, net classes, custom DRC constraints, net-to-class as
 - **set_net_class_rules** — Create or update a net class with per-net working values. Auto-creates the class from Default if it doesn't exist.
 - **assign_nets_to_class** — Add nets to a net class so they receive its constraints. Moves nets from other classes automatically.
 - **remove_nets_from_class** — Take nets out of a net class, reverting them to Default.
+- **delete_net_class** — Delete a net class definition entirely. Associated net_patterns are cleaned up (nets revert to Default). The Default class cannot be deleted.
 - **add_custom_rule** — Add a conditional DRC rule using KiCad's constraint DSL (e.g. `"A.NetClass == 'HV'"`).
 - **del_custom_rule** — Remove a custom DRC rule by name.
 - **run_drc_check** — Open the DRC checker dialog in KiCad via IPC. The user must click **Run DRC** to execute.
@@ -19,7 +20,7 @@ KiCad checks **all three layers independently** during DRC — violating ANY one
 | Layer | Tool to read | Tool to write | Scope |
 |---|---|---|---|
 | `design_rules` | `get_effective_design_rules` | `set_design_rules` | Global minimums — apply to every object on the board |
-| `net_classes` | `get_effective_design_rules` | `set_net_class_rules` | Per-net working values — override board minimums for specific nets |
+| `net_classes` | `get_effective_design_rules` | `set_net_class_rules` / `delete_net_class` | Per-net working values — override board minimums for specific nets |
 | `custom_rules` | `get_effective_design_rules` | `add_custom_rule` / `del_custom_rule` | Conditional constraints — apply only when DSL expression matches |
 
 Net class values MUST be stricter (not looser) than board-level minimums to take effect. A net class with 0.3 mm clearance where the board minimum is 0.5 mm will still use 0.5 mm for that net.
@@ -69,7 +70,15 @@ Use **remove_nets_from_class(project_path, class_name, nets)** to take nets out.
 After removal, the nets fall back to the Default class. Nets not in the class are
 returned in `not_found` (silently skipped).
 
-## 6. Add custom rules for edge cases
+## 6. Delete unused net classes
+Use **delete_net_class(project_path, class_name)** to remove a net class definition
+entirely.  All nets previously assigned to the class are cleaned up and revert to
+Default.  The `"Default"` class cannot be deleted.
+
+Only delete a class after moving or removing all its member nets (use
+`remove_nets_from_class` first if you want explicit control over where nets go).
+
+## 7. Add custom rules for edge cases
 Use **add_custom_rule(project_path, name, condition, constraint_type, value, severity)**
 for rules that can't be expressed via board minimums or net classes.
 
@@ -83,11 +92,11 @@ add_custom_rule(project_path, "HV clearance", "A.NetClass == 'HV'", "clearance",
 
 Severity: `"error"` (default), `"warning"`, `"ignore"`, or `"exclusion"`.
 
-## 7. Run DRC
+## 8. Run DRC
 Call **run_drc_check(project_path)** to open the DRC dialog. The user clicks **Run DRC**
 to execute and sees results in the dialog list view.
 
-## 8. Reopen after .kicad_pro changes
+## 9. Reopen after .kicad_pro changes
 After `set_net_class_rules` or `assign_nets_to_class`, tell the user to reopen the
 project in KiCad for the changes to take effect. The `.bak` backup is created
 automatically.
@@ -102,6 +111,8 @@ automatically.
   `set_net_class_rules` first.
 - `remove_nets_from_class` does NOT require the class to exist; nets not found in
   the class are returned in `not_found`.
+- `delete_net_class` cannot delete the `"Default"` net class. All nets assigned
+  to the deleted class automatically revert to Default.
 - `.kicad_pro` changes require reopening the project in KiCad to take effect.
 - The `get_effective_design_rules` output includes a `note` field explaining the
   three-layer DRC model — surface this to the user when reading rules for the first time.

--- a/kicad_plugin/tool_registry.py
+++ b/kicad_plugin/tool_registry.py
@@ -309,6 +309,12 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
         auto_snapshot=True,
         mark_dirty=True,
     ),
+    "delete_net_class": ToolPolicy(
+        kind="file_mutation",
+        path_arg="project_path",
+        auto_snapshot=True,
+        mark_dirty=True,
+    ),
     "add_custom_rule": ToolPolicy(
         kind="file_mutation",
         path_arg="project_path",

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -657,6 +657,7 @@ class TestToolPolicyRegistry:
             "set_net_class_rules",
             "assign_nets_to_class",
             "remove_nets_from_class",
+            "delete_net_class",
             "add_custom_rule",
             "del_custom_rule",
         }


### PR DESCRIPTION
## Summary

Add a `delete_net_class` MCP tool that removes a net class definition from the project file.

### Changes

- **`kcaa/utils/net_settings.py`** — New `delete_net_class_from_pro()` function:
  - Removes the target class entry from `net_settings.classes`
  - Cleans up all associated `netclass_patterns` entries (nets revert to Default)
  - Protects `"Default"` net class from deletion
  - Auto-creates `.kicad_pro.bak` backup
- **`kcaa/tools/drc_tools.py`** — Register `delete_net_class` as an MCP tool

### Usage

```python
delete_net_class(project_path="/path/to/project.kicad_pro", class_name="Power")
```

Complements existing `remove_nets_from_class` (which only moves nets out while keeping the class definition).