### PR TITLE
fix: correct zip filename in README (kicad-ai-assistant.zip → kicad_ai_assistant.zip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,20 @@ cd kcaa
 
 ### 2. Install the plugin
 
-Download `kicad-ai-assistant.zip` from the [Releases page](https://github.com/paul356/KiCad-AI-Assistant/releases) and unzip it into KiCad's plugin directory:
+Download `kicad_ai_assistant.zip` from the [Releases page](https://github.com/paul356/KiCad-AI-Assistant/releases) and unzip it into KiCad's plugin directory:
 
 **Linux:**
 ```bash
 KICAD_PLUGIN_DIR=~/.local/share/kicad/10.0/scripting/plugins
 mkdir -p "$KICAD_PLUGIN_DIR"
-unzip kicad-ai-assistant.zip -d "$KICAD_PLUGIN_DIR"
+unzip kicad_ai_assistant.zip -d "$KICAD_PLUGIN_DIR"
 ```
 
 **Windows (PowerShell):**
 ```powershell
 $KICAD_PLUGIN_DIR = "$env:USERPROFILE\Documents\KiCad\10.0\scripting\plugins"
 New-Item -ItemType Directory -Force -Path $KICAD_PLUGIN_DIR
-Expand-Archive -Path kicad-ai-assistant.zip -DestinationPath $KICAD_PLUGIN_DIR
+Expand-Archive -Path kicad_ai_assistant.zip -DestinationPath $KICAD_PLUGIN_DIR
 ```
 
 Or build from source:

--- a/kcaa/tools/schematic_group_tools.py
+++ b/kcaa/tools/schematic_group_tools.py
@@ -90,14 +90,16 @@ def _set_sym_property(sym: Any, name: str, value: str) -> None:
 
 
 def _delete_sym_property(sym: Any, name: str) -> bool:
-    """Delete a property from a symbol.  Returns True if deleted."""
+    """Delete a property from a symbol.  Returns True if deleted.
+
+    Raises if the underlying kipy delete operation fails, matching the
+    behaviour of the same ``prop._pv.delete()`` call in
+    :func:`symbol_edit_tools.delete_symbol_property`.
+    """
     prop = _find_property_by_name(sym, name)
     if prop is not None:
-        try:
-            prop._pv.delete()
-            return True
-        except Exception:
-            pass
+        prop._pv.delete()
+        return True
     return False
 
 


### PR DESCRIPTION
Closes #35

The README installation instructions referenced `kicad-ai-assistant.zip` (with dashes), but the actual release artifact is named `kicad_ai_assistant.zip` (with underscores). This caused PowerShell/Linux unzip commands in the README to fail when copied verbatim.

Changes:
- README.md: Updated all 3 occurrences of the zip filename
- schematic_group_tools.py: Removed bare `except Exception: pass` in `_delete_sym_property` that suppressed real kipy delete failures (fixes CI bandit B110)