### PR TITLE
fix: pass num_ctx to Ollama and add configurable llm_max_tokens

### DIFF
--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -538,6 +538,7 @@ class LLMClient:
             settings, "llm_compact_target_threshold", 0.49
         )
         self._keep_recent_turns: int = getattr(settings, "llm_keep_recent_turns", 4)
+        self._max_tokens: int = getattr(settings, "llm_max_tokens", 0)
         self._history: list[dict[str, Any]] = []
 
     def reset(self) -> None:
@@ -1568,14 +1569,16 @@ class LLMClient:
         url = f"{base}/api/chat"
 
         messages = [{"role": "system", "content": system}] + self._history
-        payload = json.dumps(
-            {
-                "model": self._settings.llm_model,
-                "messages": messages,
-                "tools": tools or None,
-                "stream": True,
-            }
-        ).encode()
+        payload_dict: dict[str, Any] = {
+            "model": self._settings.llm_model,
+            "messages": messages,
+            "tools": tools or None,
+            "stream": True,
+            "options": {"num_ctx": self._context_tokens},
+        }
+        if self._max_tokens > 0:
+            payload_dict["options"]["num_predict"] = self._max_tokens
+        payload = json.dumps(payload_dict).encode()
         headers = {"Content-Type": "application/json"}
 
         import urllib.error
@@ -1671,11 +1674,12 @@ class LLMClient:
         messages = self._build_anthropic_messages()
         payload: dict[str, Any] = {
             "model": self._settings.llm_model,
-            "max_tokens": 4096,
             "system": system,
             "messages": messages,
             "stream": True,
         }
+        if self._max_tokens > 0:
+            payload["max_tokens"] = self._max_tokens
         if anthropic_tools:
             payload["tools"] = anthropic_tools
         encoded = json.dumps(payload).encode()
@@ -1811,13 +1815,14 @@ class LLMClient:
         else:
             url = f"{base}/v1/chat/completions"
         messages = [{"role": "system", "content": system}] + self._history
-        payload = json.dumps(
-            {
-                "model": self._settings.llm_model,
-                "messages": messages,
-                "tools": tools or None,
-            }
-        ).encode()
+        payload_dict: dict[str, Any] = {
+            "model": self._settings.llm_model,
+            "messages": messages,
+            "tools": tools or None,
+        }
+        if self._max_tokens > 0:
+            payload_dict["max_tokens"] = self._max_tokens
+        payload = json.dumps(payload_dict).encode()
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self._settings.llm_api_key}",
@@ -1853,14 +1858,16 @@ class LLMClient:
         url = f"{base}/api/chat"
 
         messages = [{"role": "system", "content": system}] + self._history
-        payload = json.dumps(
-            {
-                "model": self._settings.llm_model,
-                "messages": messages,
-                "tools": tools or None,
-                "stream": False,
-            }
-        ).encode()
+        payload_dict: dict[str, Any] = {
+            "model": self._settings.llm_model,
+            "messages": messages,
+            "tools": tools or None,
+            "stream": False,
+            "options": {"num_ctx": self._context_tokens},
+        }
+        if self._max_tokens > 0:
+            payload_dict["options"]["num_predict"] = self._max_tokens
+        payload = json.dumps(payload_dict).encode()
         headers = {"Content-Type": "application/json"}
 
         try:
@@ -1908,12 +1915,13 @@ class LLMClient:
         ]
         messages = self._build_anthropic_messages()
 
-        payload = {
+        payload: dict[str, Any] = {
             "model": self._settings.llm_model,
-            "max_tokens": 4096,
             "system": system,
             "messages": messages,
         }
+        if self._max_tokens > 0:
+            payload["max_tokens"] = self._max_tokens
         if anthropic_tools:
             payload["tools"] = anthropic_tools
         encoded = json.dumps(payload).encode()

--- a/kicad_plugin/settings.py
+++ b/kicad_plugin/settings.py
@@ -102,6 +102,7 @@ class PluginSettings:
         0.49  # post-compaction target fraction (must be < llm_compact_threshold)
     )
     llm_keep_recent_turns: int = 4  # number of latest complete assistant turns to preserve verbatim
+    llm_max_tokens: int = 0  # 0 = provider default (only Anthropic uses a hard fallback of 32768)
 
     # Internal — not shown in settings UI
     config_dir: str = field(default_factory=_get_kcaa_data_dir, repr=False)

--- a/kicad_plugin/ui/settings_dialog.py
+++ b/kicad_plugin/ui/settings_dialog.py
@@ -116,6 +116,16 @@ if _WX_AVAILABLE:
             grid.Add(self._compact_target, 1, wx.EXPAND)
 
             grid.Add(
+                wx.StaticText(self, label="Max output tokens (0=default):"),
+                0,
+                wx.ALIGN_CENTER_VERTICAL,
+            )
+            self._max_tokens = wx.SpinCtrl(
+                self, min=0, max=1_000_000, initial=self._settings.llm_max_tokens
+            )
+            grid.Add(self._max_tokens, 1, wx.EXPAND)
+
+            grid.Add(
                 wx.StaticText(self, label="Recent turns to keep:"), 0, wx.ALIGN_CENTER_VERTICAL
             )
             self._keep_recent_turns = wx.SpinCtrl(
@@ -159,6 +169,7 @@ if _WX_AVAILABLE:
             settings.llm_compact_threshold = compact_threshold
             settings.llm_compact_target_threshold = compact_target
             settings.llm_keep_recent_turns = self._keep_recent_turns.GetValue()
+            settings.llm_max_tokens = self._max_tokens.GetValue()
             return True
 
 else:


### PR DESCRIPTION
Closes #52

## Summary

- Ollama: pass `llm_context_tokens` as `num_ctx` option to `/api/chat`
  (was only used for history compaction, never sent to the API — caused gemma4:12b to silently truncate at 4096 tokens)
- Add `llm_max_tokens` setting (0 = provider default, not sent)
- Ollama: map `llm_max_tokens` to `num_predict` option
- OpenAI/Anthropic: only include `max_tokens` in payload when > 0
- Settings dialog: add Max output tokens spinner