### PR TITLE
feat(plugin): unified file attachments, drag-drop, PDF collapsible display, vision pipeline logging

### DIFF
--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -672,6 +672,10 @@ class LLMClient:
             role = msg.get("role", "")
             if role == "user":
                 content = msg.get("content") or ""
+                if isinstance(content, list):
+                    content = " ".join(
+                        b.get("text", "") for b in content if b.get("type") == "text"
+                    )
                 lines.append(f"User: {content}")
             elif role == "assistant":
                 content = msg.get("content") or ""
@@ -1256,6 +1260,7 @@ class LLMClient:
         context_block: str,
         on_tool_call: Callable[[str, dict, Any], None] | None = None,
         on_text_delta: Callable[[str], None] | None = None,
+        images: list[dict[str, Any]] | None = None,
     ) -> str:
         """
         Run one engineer request through the agentic loop.
@@ -1267,12 +1272,15 @@ class LLMClient:
                            after each tool execution — use this to update the UI.
             on_text_delta: Optional callback(chunk) fired for each text chunk
                            when streaming is active.
+            images:        Optional list of dicts {"media_type": "image/png",
+                           "data": "<base64>"} attached to this user message.
 
         Returns:
             The final assistant text message for display.
         """
         system = build_system_prompt(context_block)
-        self._history.append({"role": "user", "content": user_message})
+        content = self._build_user_content(user_message, images)
+        self._history.append({"role": "user", "content": content})
         self._maybe_compact(system)
 
         tools = self._fetch_tool_definitions()
@@ -1339,6 +1347,30 @@ class LLMClient:
             self._history.extend(tool_results)
 
         return "[Error] Maximum tool-call iterations reached. Please try a simpler request."
+
+    @staticmethod
+    def _build_user_content(
+        user_message: str, images: list[dict[str, Any]] | None
+    ) -> str | list[dict[str, Any]]:
+        """Build the user message content (plain string or multimodal array).
+
+        The canonical format stored in history is OpenAI-style content blocks;
+        provider-specific formats (Anthropic / Ollama) are converted at request
+        time by _anthropic_content / _ollama_messages.
+        """
+        if not images:
+            return user_message
+        blocks: list[dict[str, Any]] = [{"type": "text", "text": user_message}]
+        for img in images:
+            media = img.get("media_type", "image/png")
+            data = img.get("data", "")
+            blocks.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{media};base64,{data}"},
+                }
+            )
+        return blocks
 
     def _fetch_tool_definitions(self) -> list[dict[str, Any]]:
         """Fetch available tools from the MCP server and convert to LLM format."""
@@ -1476,9 +1508,37 @@ class LLMClient:
                 )
                 messages.append({"role": "assistant", "content": content_blocks})
             else:
-                messages.append({"role": role, "content": m.get("content", "")})
+                messages.append(
+                    {"role": role, "content": self._anthropic_content(m.get("content", ""))}
+                )
             i += 1
         return messages
+
+    @staticmethod
+    def _anthropic_content(content) -> str | list[dict[str, Any]]:
+        """Convert OpenAI-style content blocks to Anthropic message format."""
+        if isinstance(content, str):
+            return content
+        blocks: list[dict[str, Any]] = []
+        for block in content:
+            if block.get("type") == "text":
+                blocks.append({"type": "text", "text": block.get("text", "")})
+            elif block.get("type") == "image_url":
+                url = block.get("image_url", {}).get("url", "")
+                if url.startswith("data:"):
+                    header, _, data = url.partition(",")
+                    media_type = header[5:].split(";")[0]
+                    blocks.append(
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": data,
+                            },
+                        }
+                    )
+        return blocks
 
     def _stream_openai(self, system: str, tools: list[dict], on_text_delta) -> dict[str, Any]:
         """Call OpenAI-compatible API with streaming enabled.
@@ -1599,6 +1659,36 @@ class LLMClient:
                 log.debug("Non-streaming callback error: %s", e)
         return result
 
+    def _ollama_messages(self) -> list[dict[str, Any]]:
+        """Convert self._history to Ollama /api/chat message format.
+
+        Multimodal history (OpenAI-style image_url blocks) is flattened: text
+        becomes a plain string and base64 images are attached via the
+        per-message ``images`` field (supported by all Ollama versions).
+        """
+        out: list[dict[str, Any]] = []
+        for msg in self._history:
+            content = msg.get("content", "")
+            images: list[str] = []
+            if isinstance(content, list):
+                text_parts: list[str] = []
+                for block in content:
+                    if block.get("type") == "text":
+                        text_parts.append(block.get("text", ""))
+                    elif block.get("type") == "image_url":
+                        url = block.get("image_url", {}).get("url", "")
+                        if url.startswith("data:"):
+                            _, _, data = url.partition(",")
+                        else:
+                            data = url
+                        images.append(data)
+                content = "\n".join(p for p in text_parts if p)
+            converted = {**msg, "content": content}
+            if images:
+                converted["images"] = images
+            out.append(converted)
+        return out
+
     def _stream_ollama(self, system: str, tools: list[dict], on_text_delta) -> dict[str, Any]:
         """Call Ollama native API with streaming enabled.
 
@@ -1609,7 +1699,7 @@ class LLMClient:
         base = (self._settings.llm_base_url or "http://localhost:11434").rstrip("/")
         url = f"{base}/api/chat"
 
-        messages = [{"role": "system", "content": system}] + self._history
+        messages = [{"role": "system", "content": system}] + self._ollama_messages()
         payload_dict: dict[str, Any] = {
             "model": self._settings.llm_model,
             "messages": messages,
@@ -1898,7 +1988,7 @@ class LLMClient:
         base = (self._settings.llm_base_url or "http://localhost:11434").rstrip("/")
         url = f"{base}/api/chat"
 
-        messages = [{"role": "system", "content": system}] + self._history
+        messages = [{"role": "system", "content": system}] + self._ollama_messages()
         payload_dict: dict[str, Any] = {
             "model": self._settings.llm_model,
             "messages": messages,

--- a/kicad_plugin/pdf_extractor.py
+++ b/kicad_plugin/pdf_extractor.py
@@ -1,0 +1,80 @@
+"""PDF text extraction helper.
+
+Runs inside the plugin venv (which has PyMuPDF installed) as a subprocess
+invoked from the UI panel.  Extracts text page-by-page and prefixes each
+page's content with a ``[P{n}]`` marker so the LLM can cite specific pages.
+
+Usage::
+
+    python -m kicad_plugin.pdf_extractor <pdf_path> [--max-pages N]
+
+Prints the extracted text to stdout (UTF-8).  If PyMuPDF is not installed,
+prints a JSON error object to stderr and exits with code 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def extract_text(pdf_path: str, max_pages: int = 0) -> str:
+    """Extract text from *pdf_path* with page-number prefixes.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        max_pages: Maximum number of pages to extract (0 = all pages).
+
+    Returns:
+        Extracted text with ``[P1]``, ``[P2]`` … prefixes.
+    """
+    import fitz  # PyMuPDF
+
+    doc = fitz.open(pdf_path)
+    try:
+        total = len(doc)
+        limit = total if max_pages <= 0 else min(max_pages, total)
+        parts: list[str] = []
+        for i in range(limit):
+            page = doc.load_page(i)
+            text = page.get_text("text").strip()
+            if text:
+                parts.append(f"[P{i + 1}] {text}")
+        if limit < total:
+            parts.append(f"\n[... {total - limit} more page(s) omitted]")
+        return "\n\n".join(parts)
+    finally:
+        doc.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract text from a PDF.")
+    parser.add_argument("pdf_path", help="Path to the PDF file")
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=0,
+        help="Maximum pages to extract (0 = all)",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = extract_text(args.pdf_path, args.max_pages)
+    except ImportError:
+        json.dump(
+            {"error": "PyMuPDF (fitz) not installed in the plugin venv."},
+            sys.stderr,
+        )
+        return 1
+    except Exception as e:  # noqa: BLE001 — report any extraction failure
+        json.dump({"error": str(e)}, sys.stderr)
+        return 1
+
+    sys.stdout.write(result)
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kicad_plugin/settings.py
+++ b/kicad_plugin/settings.py
@@ -81,6 +81,7 @@ class PluginSettings:
     llm_provider: str = "openai"  # "openai" | "anthropic" | "ollama"
     llm_api_key: str = field(default="", repr=False)  # never leak key in logs/repr
     llm_model: str = "gpt-4o"  # model name
+    llm_supports_vision: bool = True  # whether the model accepts image input
     llm_base_url: str = (
         ""  # custom API endpoint (overrides provider default, e.g. http://localhost:11434)
     )

--- a/kicad_plugin/settings.py
+++ b/kicad_plugin/settings.py
@@ -81,7 +81,7 @@ class PluginSettings:
     llm_provider: str = "openai"  # "openai" | "anthropic" | "ollama"
     llm_api_key: str = field(default="", repr=False)  # never leak key in logs/repr
     llm_model: str = "gpt-4o"  # model name
-    llm_supports_vision: bool = True  # whether the model accepts image input
+    llm_supports_vision: bool = False  # whether the model accepts image input
     llm_base_url: str = (
         ""  # custom API endpoint (overrides provider default, e.g. http://localhost:11434)
     )

--- a/kicad_plugin/setup_plugin.ps1
+++ b/kicad_plugin/setup_plugin.ps1
@@ -67,6 +67,7 @@ if ($LASTEXITCODE -ne 0) {
 # ---------------------------------------------------------------------------
 Write-Host "Step 2/3 - Installing kcaa from PyPI ..."
 uv pip install "kcaa==${KcaaVersion}" --python "$VenvDir"
+uv pip install "pymupdf" --python "$VenvDir"
 if ($LASTEXITCODE -ne 0) {
     Write-Host "ERROR: uv pip install failed (exit code $LASTEXITCODE)."
     exit $LASTEXITCODE

--- a/kicad_plugin/setup_plugin.sh
+++ b/kicad_plugin/setup_plugin.sh
@@ -60,6 +60,7 @@ uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
 
 echo "Step 2/3 — Installing kcaa from PyPI ..."
 uv pip install "kcaa==${KCAA_VERSION}" --python "$VENV_DIR"
+uv pip install "pymupdf" --python "$VENV_DIR"
 
 echo ""
 echo "Step 3/3 — Downloading freerouting JAR ..."

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -327,6 +327,12 @@ if _WX_AVAILABLE:
             self._paste_img_btn.SetToolTip("Paste image from clipboard (Ctrl+V)")
             hbox.Add(self._paste_img_btn, 0, wx.RIGHT, 4)
 
+            self._add_pdf_btn = wx.BitmapButton(
+                panel, bitmap=wx.ArtProvider.GetBitmap(wx.ART_FILE_OPEN, wx.ART_BUTTON, (20, 20))
+            )
+            self._add_pdf_btn.SetToolTip("Attach PDF (extract text with page numbers)")
+            hbox.Add(self._add_pdf_btn, 0, wx.RIGHT, 4)
+
             self._input = wx.TextCtrl(
                 panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE | wx.BORDER_SIMPLE
             )
@@ -417,6 +423,7 @@ if _WX_AVAILABLE:
             self._stop_btn.Bind(wx.EVT_BUTTON, self._on_stop)
             self._add_img_btn.Bind(wx.EVT_BUTTON, self._on_add_image)
             self._paste_img_btn.Bind(wx.EVT_BUTTON, self._on_paste_from_clipboard)
+            self._add_pdf_btn.Bind(wx.EVT_BUTTON, self._on_add_pdf)
             self._input.Bind(wx.EVT_TEXT_ENTER, self._on_send)
             self._input.Bind(wx.EVT_CHAR_HOOK, self._on_input_key)
             self.Bind(wx.EVT_MENU, self._on_settings, id=wx.ID_PREFERENCES)
@@ -912,6 +919,108 @@ if _WX_AVAILABLE:
                 except Exception as e:
                     log.warning("Could not encode attachment %s: %s", path, e)
             return encoded
+
+        # ------------------------------------------------------------------ #
+        # PDF text extraction
+        # ------------------------------------------------------------------ #
+
+        def _on_add_pdf(self, event) -> None:
+            """Open a PDF, extract text with page numbers, inject into input."""
+            if self._busy:
+                wx.MessageBox(
+                    "Please wait for the current request to finish.",
+                    "Busy",
+                    wx.OK | wx.ICON_INFORMATION,
+                    self,
+                )
+                return
+            wildcard = "PDF documents (*.pdf)|*.pdf|All files (*.*)|*.*"
+            dlg = wx.FileDialog(
+                self,
+                "Select PDF to extract",
+                wildcard=wildcard,
+                style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+            )
+            if dlg.ShowModal() != wx.ID_OK:
+                dlg.Destroy()
+                return
+            pdf_path = dlg.GetPath()
+            dlg.Destroy()
+
+            # Run extraction in a background thread to avoid blocking the UI.
+            self._status_label.SetLabel("⏳ Extracting PDF text…")
+            self._add_pdf_btn.Enable(False)
+
+            def _run() -> None:
+                import subprocess  # nosec B404 -- controlled subprocess, no user input
+
+                # Resolve the plugin venv python (same one the MCP server uses).
+                python = self._server_mgr._resolve_python()  # noqa: SLF001
+                plugin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                cmd = [
+                    python,
+                    "-m",
+                    "kicad_plugin.pdf_extractor",
+                    pdf_path,
+                    "--max-pages",
+                    "50",
+                ]
+                try:
+                    result = subprocess.run(  # nosec B603 -- paths validated
+                        cmd,
+                        capture_output=True,
+                        text=True,
+                        timeout=60,
+                        cwd=plugin_dir,
+                    )
+                except Exception as e:  # noqa: BLE001
+                    wx.CallAfter(self._on_pdf_extracted, None, f"Subprocess failed: {e}", None)
+                    return
+
+                if result.returncode != 0:
+                    err = result.stderr.strip() or "Unknown extraction error"
+                    wx.CallAfter(self._on_pdf_extracted, None, err, None)
+                else:
+                    wx.CallAfter(self._on_pdf_extracted, result.stdout, None, pdf_path)
+
+            threading.Thread(target=_run, daemon=True).start()
+
+        def _on_pdf_extracted(
+            self, text: str | None, error: str | None, pdf_path: str | None
+        ) -> None:
+            """Called on the UI thread after PDF extraction finishes."""
+            self._add_pdf_btn.Enable(True)
+            self._status_label.SetLabel("Ready")
+            if error:
+                wx.MessageBox(
+                    f"PDF text extraction failed:\n{error}",
+                    "PDF Error",
+                    wx.OK | wx.ICON_ERROR,
+                    self,
+                )
+                return
+            if not text:
+                wx.MessageBox(
+                    "No extractable text found in this PDF (it may be a "
+                    "scanned/image-only document).",
+                    "PDF Empty",
+                    wx.OK | wx.ICON_INFORMATION,
+                    self,
+                )
+                return
+            # Inject the extracted text into the input box, prefixed with a
+            # header so the LLM knows the source.
+            import os.path
+
+            basename = os.path.basename(pdf_path) if pdf_path else "document.pdf"
+            header = f"--- PDF: {basename} (text extracted with page numbers) ---\n\n"
+            current = self._input.GetValue()
+            if current and not current.endswith("\n"):
+                self._input.SetValue(current + "\n\n" + header + text)
+            else:
+                self._input.SetValue(header + text)
+            self._input.SetInsertionPointEnd()
+            self._input.SetFocus()
 
         def _on_reply(self, reply: str, ctx: dict, was_streamed: bool = False) -> None:
             # Stop the flush timer and drain any remaining chunks

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -61,6 +61,23 @@ def _strip_images_from_history(history: list[dict]) -> list[dict]:
 
 if _WX_AVAILABLE:
 
+    class _FileDropTarget(wx.FileDropTarget):
+        """Drag-and-drop handler for images and PDFs onto the input box."""
+
+        def __init__(self, panel: AssistantPanel) -> None:
+            super().__init__()
+            self._panel = panel
+
+        def OnDropFiles(self, x: int, y: int, filenames: list[str]) -> bool:  # noqa: N802
+            log.info("OnDropFiles: %d file(s)", len(filenames))
+            for path in filenames:
+                ftype = "pdf" if path.lower().endswith(".pdf") else "image"
+                entry = (path, ftype)
+                if entry not in self._panel._attached_files:  # noqa: SLF001
+                    self._panel._attached_files.append(entry)  # noqa: SLF001
+            self._panel._refresh_attachments_bar()  # noqa: SLF001
+            return True
+
     class AssistantPanel(wx.Frame):
         """Main floating panel for the KiCad AI Assistant."""
 
@@ -123,7 +140,7 @@ if _WX_AVAILABLE:
             self._shell_retry_count: int = 0
             # Paths of images the user attached for the next message (cleared
             # after send). Populated via the "Attach image" button or clipboard.
-            self._attached_images: list[str] = []
+            self._attached_files: list[tuple[str, str]] = []  # (path, "image"|"pdf")
 
             # Page-load watchdog: if _on_webview_loaded never fires (WebView2
             # glitch on Windows), reset _page_loading so renders are not
@@ -262,6 +279,19 @@ if _WX_AVAILABLE:
                         self._on_webview_error,
                         self._conv_view,
                     )
+
+                    # Block navigation to any URL — prevents files (PDFs, images,
+                    # etc.) dropped onto the WebView from being opened inside it.
+                    # Only the shell page (loaded via SetPage) should ever display.
+                    def _on_navigating(event):
+                        if event.GetURL() not in ("", "about:blank"):
+                            event.Veto()
+
+                    self.Bind(
+                        _wx_html2.EVT_WEBVIEW_NAVIGATING,
+                        _on_navigating,
+                        self._conv_view,
+                    )
                     # Load the static shell (CSS + JS + empty containers).
                     # After this, all UI updates go through RunScript.
                     self._load_shell()
@@ -311,7 +341,10 @@ if _WX_AVAILABLE:
 
             # ---- Attachments bar (image thumbnails; empty when none attached) ----
             self._attachments_hbox = wx.BoxSizer(wx.HORIZONTAL)
-            vbox.Add(self._attachments_hbox, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 4)
+            self._attachments_sizer_item = vbox.Add(
+                self._attachments_hbox, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 4
+            )
+            self._attachments_sizer_item.Show(False)  # hidden until images attached
 
             # ---- Input row ----
             #  [📎] [____ Ask the AI assistant… ____] [ ●  ]
@@ -403,6 +436,8 @@ if _WX_AVAILABLE:
             self._attach_btn.Bind(wx.EVT_BUTTON, self._on_attach)
             self._input.Bind(wx.EVT_TEXT_ENTER, self._on_send)
             self._input.Bind(wx.EVT_CHAR_HOOK, self._on_input_key)
+            # Enable drag-and-drop of images and PDFs onto the input box.
+            self._input.SetDropTarget(_FileDropTarget(self))
             self.Bind(wx.EVT_MENU, self._on_settings, id=wx.ID_PREFERENCES)
             self.Bind(wx.EVT_MENU, self._on_new_session, id=self._menu_new_session_id)
             self.Bind(wx.EVT_MENU, self._on_load_session, id=self._menu_load_session_id)
@@ -635,9 +670,14 @@ if _WX_AVAILABLE:
                 return
             text = self._input.GetValue().strip()
             images = self._encode_attached_images()
-            if not text and not images:
+            pdfs = [p for p, t in self._attached_files if t == "pdf"]
+            if not text and not images and not pdfs:
                 return
             if images and not self._settings.llm_supports_vision:
+                log.info(
+                    "_on_send: blocked — %d image(s) but vision disabled in settings",
+                    len(images),
+                )
                 wx.MessageBox(
                     "The current model is configured as not supporting vision. "
                     'Enable "Model supports vision" in Settings or remove the attached '
@@ -647,19 +687,30 @@ if _WX_AVAILABLE:
                     self,
                 )
                 return
-            log.info("_on_send: user message (%d chars, %d image(s))", len(text), len(images))
+            log.info(
+                "_on_send: user message (%d chars, %d image(s), %d PDF(s), vision=%s)",
+                len(text),
+                len(images),
+                len(pdfs),
+                self._settings.llm_supports_vision,
+            )
             self._input.Clear()
-            display_text = text or "(image attachment)"
+            display_text = text or "(attachment)"
             if images:
                 display_text += f"\n\n[📎 {len(images)} image(s) attached]"
+            if pdfs:
+                display_text += f"\n\n[📄 {len(pdfs)} PDF(s) attached]"
+            # Placeholder — pdf_texts filled in after background extraction
             self._conv_entries.append(
                 {
                     "type": "user",
                     "text": display_text,
                     "timestamp": datetime.datetime.now().strftime("%H:%M:%S"),
+                    "pdf_texts": [],
                 }
             )
-            self._attached_images.clear()
+            _user_entry = self._conv_entries[-1]
+            self._attached_files.clear()
             self._refresh_attachments_bar()
             self._follow_output_to_bottom = True
             # Create the session file on the very first message so current.json
@@ -698,8 +749,38 @@ if _WX_AVAILABLE:
             def _run():
                 log.info("Background _run: started")
                 try:
+                    # Extract PDF text before sending to LLM
+                    text_with_pdf = text
+                    if pdfs:
+                        self._set_status("⏳ Extracting PDF text…", self._C_WARN)
+                        pdf_texts: list[dict] = []
+                        pdf_blocks: list[str] = []
+                        for pdf_path in pdfs:
+                            extracted = self._extract_pdf_text(pdf_path)
+                            basename = os.path.basename(pdf_path)
+                            if extracted.startswith("[Error]"):
+                                log.error("PDF extraction failed: %s — %s", pdf_path, extracted)
+                                pdf_texts.append(
+                                    {"name": basename, "text": extracted, "error": True}
+                                )
+                                pdf_blocks.append(f"--- PDF: {basename} ---\n{extracted}")
+                            else:
+                                log.info("PDF extracted: %s → %d chars", basename, len(extracted))
+                                pdf_texts.append({"name": basename, "text": extracted})
+                                pdf_blocks.append(
+                                    f"--- PDF: {basename} "
+                                    f"(text extracted with page numbers) ---\n\n{extracted}"
+                                )
+                        self._set_status("Ready", self._C_OK)
+                        # Store extracted texts for UI display
+                        _user_entry["pdf_texts"] = pdf_texts
+                        if pdf_blocks:
+                            pdf_block = "\n\n".join(pdf_blocks)
+                            text_with_pdf = text + ("\n\n" if text else "") + pdf_block
+                        # Re-render so the collapsible PDF text appears
+                        wx.CallAfter(self._render_conversation, True)
                     reply = self._llm_client.run(
-                        text,
+                        text_with_pdf,
                         context_block,
                         on_tool_call=lambda name, args, result: wx.CallAfter(
                             self._on_tool_call, name, args, result
@@ -871,14 +952,13 @@ if _WX_AVAILABLE:
             )
             if dlg.ShowModal() == wx.ID_OK:
                 paths = dlg.GetPaths()
-                images = [p for p in paths if not p.lower().endswith(".pdf")]
-                pdfs = [p for p in paths if p.lower().endswith(".pdf")]
-                for path in images:
-                    if path not in self._attached_images:
-                        self._attached_images.append(path)
+                log.info("_on_attach: %d file(s) selected", len(paths))
+                for path in paths:
+                    ftype = "pdf" if path.lower().endswith(".pdf") else "image"
+                    entry = (path, ftype)
+                    if entry not in self._attached_files:
+                        self._attached_files.append(entry)
                 self._refresh_attachments_bar()
-                for path in pdfs:
-                    self._on_add_pdf(pdf_path=path)
             dlg.Destroy()
 
         # ------------------------------------------------------------------ #
@@ -899,14 +979,16 @@ if _WX_AVAILABLE:
             )
             if dlg.ShowModal() == wx.ID_OK:
                 for path in dlg.GetPaths():
-                    if path not in self._attached_images:
-                        self._attached_images.append(path)
+                    entry = (path, "image")
+                    if entry not in self._attached_files:
+                        self._attached_files.append(entry)
                 self._refresh_attachments_bar()
             dlg.Destroy()
 
         def _on_paste_from_clipboard(self, event=None) -> None:
             """Read a bitmap from the OS clipboard and attach it as an image."""
             if not wx.TheClipboard.Open():
+                log.warning("_on_paste_from_clipboard: could not open clipboard")
                 wx.MessageBox(
                     "Could not open the system clipboard.",
                     "Clipboard",
@@ -920,10 +1002,22 @@ if _WX_AVAILABLE:
                         bmp = bdo.GetBitmap()
                         if bmp.IsOk():
                             path = self._save_clipboard_bitmap(bmp)
-                            if path and path not in self._attached_images:
-                                self._attached_images.append(path)
-                                self._refresh_attachments_bar()
+                            if path:
+                                entry = (path, "image")
+                                if entry not in self._attached_files:
+                                    self._attached_files.append(entry)
+                                    self._refresh_attachments_bar()
+                                log.info(
+                                    "_on_paste_from_clipboard: pasted image %dx%d → %s",
+                                    bmp.GetWidth(),
+                                    bmp.GetHeight(),
+                                    os.path.basename(path),
+                                )
                             return
+                    else:
+                        log.warning("_on_paste_from_clipboard: GetData returned False")
+                else:
+                    log.debug("_on_paste_from_clipboard: clipboard has no bitmap")
                 wx.MessageBox(
                     "No image found in the clipboard.",
                     "Clipboard",
@@ -951,39 +1045,54 @@ if _WX_AVAILABLE:
             return path if img.SaveFile(path, wx.BITMAP_TYPE_PNG) else None
 
         def _remove_attachment(self, index: int) -> None:
-            if 0 <= index < len(self._attached_images):
-                del self._attached_images[index]
+            if 0 <= index < len(self._attached_files):
+                del self._attached_files[index]
             self._refresh_attachments_bar()
 
         def _clear_attachments(self, event=None) -> None:
-            self._attached_images.clear()
+            self._attached_files.clear()
             self._refresh_attachments_bar()
 
         def _refresh_attachments_bar(self) -> None:
-            """Rebuild the thumbnail strip from self._attached_images."""
+            """Rebuild the thumbnail strip from self._attached_files."""
             for item in list(self._attachments_hbox.GetChildren()):
                 win = item.GetWindow()
                 self._attachments_hbox.Detach(win)
                 if win:
                     win.Destroy()
 
-            if self._attached_images:
-                for idx, path in enumerate(self._attached_images):
-                    sb = wx.StaticBitmap(self._ui_panel, bitmap=self._fit_thumbnail(path))
+            # Show/hide the sizer item so the bar collapses when empty
+            self._attachments_sizer_item.Show(bool(self._attached_files))
+            if self._attached_files:
+                img_count = sum(1 for _, t in self._attached_files if t == "image")
+                pdf_count = sum(1 for _, t in self._attached_files if t == "pdf")
+                for idx, (path, ftype) in enumerate(self._attached_files):
+                    if ftype == "image":
+                        bmp = self._fit_thumbnail(path)
+                    else:
+                        bg = self._ui_panel.GetBackgroundColour()
+                        bmp = self._make_pdf_thumbnail(bg=bg)
+                    sb = wx.StaticBitmap(self._ui_panel, bitmap=bmp)
                     sb.SetToolTip(os.path.basename(path))
                     sb.Bind(
                         wx.EVT_LEFT_DOWN,
                         lambda evt, i=idx: self._remove_attachment(i),
                     )
                     self._attachments_hbox.Add(sb, 0, wx.RIGHT, 4)
-                count = wx.StaticText(
-                    self._ui_panel, label=f"{len(self._attached_images)} image(s)"
-                )
+                parts = []
+                if img_count:
+                    parts.append(f"{img_count} image(s)")
+                if pdf_count:
+                    parts.append(f"{pdf_count} PDF(s)")
+                count = wx.StaticText(self._ui_panel, label=" + ".join(parts))
                 self._attachments_hbox.Add(count, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 4)
                 clear_btn = wx.Button(self._ui_panel, label="✕ clear")
                 clear_btn.Bind(wx.EVT_BUTTON, self._clear_attachments)
                 self._attachments_hbox.Add(clear_btn, 0, wx.ALIGN_CENTER_VERTICAL)
-            self.Layout()
+            # Defer layout to next idle so window destruction (Destroy() above)
+            # is fully processed before recalculating sizer geometry.
+            wx.CallAfter(self._ui_panel.Layout)
+            wx.CallAfter(self.SendSizeEvent)
 
         @staticmethod
         def _fit_thumbnail(path: str, max_size: int = 48) -> wx.Bitmap:
@@ -1003,6 +1112,47 @@ if _WX_AVAILABLE:
                 log.warning("Could not load thumbnail %s: %s", path, e)
                 return wx.Bitmap(max_size, max_size)
 
+        @staticmethod
+        def _make_pdf_thumbnail(size: int = 48, bg: wx.Colour | None = None) -> wx.Bitmap:
+            """Draw a simple PDF file icon with 'PDF' label."""
+            bmp, mdc = AssistantPanel._new_icon_bitmap(size, bg)
+            gc = wx.GraphicsContext.Create(mdc)
+            # White page with folded corner
+            page_w = size * 0.55
+            page_h = size * 0.7
+            x0 = (size - page_w) / 2
+            y0 = (size - page_h) / 2
+            fold = page_w * 0.25
+            path = gc.CreatePath()
+            path.MoveToPoint(x0, y0)
+            path.AddLineToPoint(x0 + page_w - fold, y0)
+            path.AddLineToPoint(x0 + page_w, y0 + fold)
+            path.AddLineToPoint(x0 + page_w, y0 + page_h)
+            path.AddLineToPoint(x0, y0 + page_h)
+            path.CloseSubpath()
+            gc.SetBrush(wx.Brush(wx.Colour(255, 255, 255)))
+            gc.SetPen(wx.Pen(wx.Colour(120, 120, 120), 1))
+            gc.DrawPath(path)
+            # Folded corner
+            fold_path = gc.CreatePath()
+            fold_path.MoveToPoint(x0 + page_w - fold, y0)
+            fold_path.AddLineToPoint(x0 + page_w - fold, y0 + fold)
+            fold_path.AddLineToPoint(x0 + page_w, y0 + fold)
+            fold_path.CloseSubpath()
+            gc.SetBrush(wx.Brush(wx.Colour(220, 220, 220)))
+            gc.DrawPath(fold_path)
+            # 'PDF' text
+            font = wx.Font(
+                max(7, int(size * 0.16)),
+                wx.FONTFAMILY_DEFAULT,
+                wx.FONTSTYLE_NORMAL,
+                wx.FONTWEIGHT_BOLD,
+            )
+            gc.SetFont(font, wx.Colour(200, 40, 40))
+            gc.DrawText("PDF", x0 + 2, y0 + page_h * 0.35)
+            del gc, mdc
+            return bmp
+
         def _encode_attached_images(self) -> list[dict]:
             """Resize (≤1024px longest edge) and base64-encode attached images."""
             import base64
@@ -1010,10 +1160,16 @@ if _WX_AVAILABLE:
             import uuid
 
             encoded: list[dict] = []
-            for path in list(self._attached_images):
+            for path, ftype in list(self._attached_files):
+                if ftype != "image":
+                    continue
                 try:
                     img = wx.Image(path, wx.BITMAP_TYPE_ANY)
                     if not img.IsOk():
+                        log.warning(
+                            "_encode_attached_images: %s failed to load (IsOk=False)",
+                            path,
+                        )
                         continue
                     w, h = img.GetWidth(), img.GetHeight()
                     longest = max(w, h)
@@ -1024,10 +1180,22 @@ if _WX_AVAILABLE:
                             int(round(h * scale)),
                             wx.IMAGE_QUALITY_HIGH,
                         )
+                        log.debug(
+                            "_encode_attached_images: %s resized %dx%d → %dx%d",
+                            os.path.basename(path),
+                            w,
+                            h,
+                            img.GetWidth(),
+                            img.GetHeight(),
+                        )
                     tmp = os.path.join(
                         tempfile.gettempdir(), f"kicad_ai_enc_{uuid.uuid4().hex}.png"
                     )
                     if not img.SaveFile(tmp, wx.BITMAP_TYPE_PNG):
+                        log.warning(
+                            "_encode_attached_images: %s SaveFile failed",
+                            path,
+                        )
                         continue
                     with open(tmp, "rb") as f:
                         data = base64.b64encode(f.read()).decode()
@@ -1036,8 +1204,19 @@ if _WX_AVAILABLE:
                     except OSError:
                         pass
                     encoded.append({"media_type": "image/png", "data": data})
+                    log.debug(
+                        "_encode_attached_images: %s encoded (%d bytes base64)",
+                        os.path.basename(path),
+                        len(data),
+                    )
                 except Exception as e:
                     log.warning("Could not encode attachment %s: %s", path, e)
+            img_total = sum(1 for _, t in self._attached_files if t == "image")
+            log.info(
+                "_encode_attached_images: %d/%d image(s) encoded successfully",
+                len(encoded),
+                img_total,
+            )
             return encoded
 
         # ------------------------------------------------------------------ #
@@ -1045,101 +1224,64 @@ if _WX_AVAILABLE:
         # ------------------------------------------------------------------ #
 
         def _on_add_pdf(self, event=None, *, pdf_path: str | None = None) -> None:
-            """Open a PDF, extract text with page numbers, inject into input."""
-            if self._busy:
-                wx.MessageBox(
-                    "Please wait for the current request to finish.",
-                    "Busy",
-                    wx.OK | wx.ICON_INFORMATION,
-                    self,
-                )
-                return
+            """Add a PDF to the attachments bar (text extracted at send time)."""
             if pdf_path is None:
                 wildcard = "PDF documents (*.pdf)|*.pdf|All files (*.*)|*.*"
                 dlg = wx.FileDialog(
                     self,
-                    "Select PDF to extract",
+                    "Select PDF",
                     wildcard=wildcard,
-                    style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+                    style=wx.FD_OPEN | wx.FD_MULTIPLE | wx.FD_FILE_MUST_EXIST,
                 )
                 if dlg.ShowModal() != wx.ID_OK:
                     dlg.Destroy()
                     return
-                pdf_path = dlg.GetPath()
+                for path in dlg.GetPaths():
+                    entry = (path, "pdf")
+                    if entry not in self._attached_files:
+                        self._attached_files.append(entry)
                 dlg.Destroy()
-
-            # Run extraction in a background thread to avoid blocking the UI.
-            self._set_status("⏳ Extracting PDF text…", self._C_WARN)
-
-            def _run() -> None:
-                import subprocess  # nosec B404 -- controlled subprocess, no user input
-
-                # Resolve the plugin venv python (same one the MCP server uses).
-                python = self._server_mgr._resolve_python()  # noqa: SLF001
-                plugin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                cmd = [
-                    python,
-                    "-m",
-                    "kicad_plugin.pdf_extractor",
-                    pdf_path,
-                    "--max-pages",
-                    "50",
-                ]
-                try:
-                    result = subprocess.run(  # nosec B603 -- paths validated
-                        cmd,
-                        capture_output=True,
-                        text=True,
-                        timeout=60,
-                        cwd=plugin_dir,
-                    )
-                except Exception as e:  # noqa: BLE001
-                    wx.CallAfter(self._on_pdf_extracted, None, f"Subprocess failed: {e}", None)
-                    return
-
-                if result.returncode != 0:
-                    err = result.stderr.strip() or "Unknown extraction error"
-                    wx.CallAfter(self._on_pdf_extracted, None, err, None)
-                else:
-                    wx.CallAfter(self._on_pdf_extracted, result.stdout, None, pdf_path)
-
-            threading.Thread(target=_run, daemon=True).start()
-
-        def _on_pdf_extracted(
-            self, text: str | None, error: str | None, pdf_path: str | None
-        ) -> None:
-            """Called on the UI thread after PDF extraction finishes."""
-            self._set_status("Ready", self._C_OK)
-            if error:
-                wx.MessageBox(
-                    f"PDF text extraction failed:\n{error}",
-                    "PDF Error",
-                    wx.OK | wx.ICON_ERROR,
-                    self,
-                )
-                return
-            if not text:
-                wx.MessageBox(
-                    "No extractable text found in this PDF (it may be a "
-                    "scanned/image-only document).",
-                    "PDF Empty",
-                    wx.OK | wx.ICON_INFORMATION,
-                    self,
-                )
-                return
-            # Inject the extracted text into the input box, prefixed with a
-            # header so the LLM knows the source.
-            import os.path
-
-            basename = os.path.basename(pdf_path) if pdf_path else "document.pdf"
-            header = f"--- PDF: {basename} (text extracted with page numbers) ---\n\n"
-            current = self._input.GetValue()
-            if current and not current.endswith("\n"):
-                self._input.SetValue(current + "\n\n" + header + text)
             else:
-                self._input.SetValue(header + text)
-            self._input.SetInsertionPointEnd()
-            self._input.SetFocus()
+                entry = (pdf_path, "pdf")
+                if entry not in self._attached_files:
+                    self._attached_files.append(entry)
+            self._refresh_attachments_bar()
+
+        def _extract_pdf_text(self, pdf_path: str) -> str:
+            """Extract text from a PDF (called from background thread at send time).
+
+            Returns the extracted text or an error message prefixed with [Error].
+            """
+            import subprocess  # nosec B404 -- controlled subprocess, no user input
+
+            python = self._server_mgr._resolve_python()  # noqa: SLF001
+            plugin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            env = self._server_mgr._build_env(port=0)  # noqa: SLF001
+            for k in ("MCP_TRANSPORT", "MCP_PORT", "MCP_HOST"):
+                env.pop(k, None)
+            cmd = [
+                python,
+                "-m",
+                "kicad_plugin.pdf_extractor",
+                pdf_path,
+                "--max-pages",
+                "50",
+            ]
+            try:
+                result = subprocess.run(  # nosec B603 -- paths validated
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    cwd=plugin_dir,
+                    env=env,
+                )
+            except Exception as e:  # noqa: BLE001
+                return f"[Error] Subprocess failed: {e}"
+            if result.returncode != 0:
+                err = result.stderr.strip() or "Unknown extraction error"
+                return f"[Error] {err}"
+            return result.stdout or ""
 
         def _on_reply(self, reply: str, ctx: dict, was_streamed: bool = False) -> None:
             # Stop the flush timer and drain any remaining chunks

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -145,6 +145,7 @@ if _WX_AVAILABLE:
         _C_OK = (0, 140, 0)  # Green   – success notices
         _C_WARN = (190, 100, 0)  # Amber   – warnings
         _C_ERR = (190, 30, 30)  # Red     – errors
+        _C_GREY = (140, 140, 140)  # Grey   – idle status dot
         _BG_CONV = wx.Colour(245, 247, 252)  # Very light blue-grey conversation bg
         _BG_TOOL = wx.Colour(250, 248, 240)  # Warm off-white tool-log bg
 
@@ -313,72 +314,50 @@ if _WX_AVAILABLE:
             vbox.Add(self._attachments_hbox, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 4)
 
             # ---- Input row ----
+            #  [📎] [____ Ask the AI assistant… ____] [ ●  ]
+            #  Attach  Text input (expands)         [➤/⬛]
             hbox = wx.BoxSizer(wx.HORIZONTAL)
 
-            self._add_img_btn = wx.BitmapButton(
-                panel, bitmap=wx.ArtProvider.GetBitmap(wx.ART_FILE_OPEN, wx.ART_BUTTON, (20, 20))
+            # Attach button — single entry point for images & PDFs.
+            self._attach_btn = wx.BitmapButton(
+                panel,
+                bitmap=self._make_attach_bitmap(bg=panel.GetBackgroundColour()),
+                style=wx.BU_EXACTFIT | wx.BORDER_NONE,
             )
-            self._add_img_btn.SetToolTip("Attach image(s)")
-            hbox.Add(self._add_img_btn, 0, wx.RIGHT, 2)
+            self._attach_btn.SetToolTip("Attach image or PDF…")
+            hbox.Add(self._attach_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 4)
 
-            self._paste_img_btn = wx.BitmapButton(
-                panel, bitmap=wx.ArtProvider.GetBitmap(wx.ART_PASTE, wx.ART_BUTTON, (20, 20))
-            )
-            self._paste_img_btn.SetToolTip("Paste image from clipboard (Ctrl+V)")
-            hbox.Add(self._paste_img_btn, 0, wx.RIGHT, 4)
-
-            self._add_pdf_btn = wx.BitmapButton(
-                panel, bitmap=wx.ArtProvider.GetBitmap(wx.ART_FILE_OPEN, wx.ART_BUTTON, (20, 20))
-            )
-            self._add_pdf_btn.SetToolTip("Attach PDF (extract text with page numbers)")
-            hbox.Add(self._add_pdf_btn, 0, wx.RIGHT, 4)
-
+            # Plain native TextCtrl — GTK themes paint the background (light)
+            # and SetBackgroundColour would be ignored, so leave it untouched.
             self._input = wx.TextCtrl(
                 panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE | wx.BORDER_SIMPLE
             )
             self._input.SetHint("Ask the AI assistant…")
             hbox.Add(self._input, 1, wx.EXPAND)
 
-            # Rounded red square stop button — matches TextCtrl height exactly.
-            # GetSizeFromTextSize excludes the BORDER_SIMPLE frame; add it back.
-            text_h = self._input.GetSizeFromTextSize(self._input.GetTextExtent("Ag")).height
-            btn_h = max(text_h + 4, 48)  # at least 48 to fit 40×40 red + padding
-            corner_r = 3  # small corner radius
+            # Right-hand column: status dot on top, Send/Stop toggle below.
+            side_vbox = wx.BoxSizer(wx.VERTICAL)
 
-            stop_bmp = wx.Bitmap(btn_h, btn_h)
-            mdc = wx.MemoryDC(stop_bmp)
-            gc = wx.GraphicsContext.Create(mdc)
-            # Light grey button background
-            gc.SetBrush(wx.Brush(wx.Colour(230, 230, 230)))
-            gc.SetPen(wx.TRANSPARENT_PEN)
-            gc.DrawRectangle(0, 0, btn_h, btn_h)
-            # Flat red 40×40 rounded square, centred
-            red_sz = 40
-            pad = (btn_h - red_sz) // 2
-            path = gc.CreatePath()
-            path.AddRoundedRectangle(pad, pad, red_sz, red_sz, corner_r)
-            gc.SetBrush(wx.Brush(wx.Colour(255, 0, 0)))
-            gc.SetPen(wx.Pen(wx.Colour(180, 0, 0), 1))
-            gc.DrawPath(path)
-            del gc
-            del mdc
-
-            self._stop_btn = wx.BitmapButton(
-                panel, bitmap=stop_bmp, style=wx.BU_EXACTFIT | wx.BORDER_SIMPLE
+            # Status dot — 14 px coloured circle, tooltip carries full text.
+            self._status_dot = wx.StaticBitmap(
+                panel,
+                bitmap=self._make_status_dot_bitmap(self._C_GREY, bg=panel.GetBackgroundColour()),
             )
-            self._stop_btn.SetMinSize(wx.Size(btn_h, btn_h))
-            self._stop_btn.SetToolTip("Stop generation (Escape)")
-            self._stop_btn.Enable(False)
-            hbox.Add(self._stop_btn, 0, wx.EXPAND)
+            self._status_dot.SetToolTip("Starting backend…")
+            side_vbox.Add(self._status_dot, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 2)
+
+            # Send / Stop toggle button — doubles as Stop during generation.
+            self._send_btn = wx.BitmapButton(
+                panel,
+                bitmap=self._make_send_bitmap(bg=panel.GetBackgroundColour()),
+                style=wx.BU_EXACTFIT | wx.BORDER_NONE,
+            )
+            self._send_btn.SetToolTip("Send message (Enter)")
+            side_vbox.Add(self._send_btn, 0, wx.ALIGN_CENTER_HORIZONTAL)
+
+            hbox.Add(side_vbox, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
 
             vbox.Add(hbox, 0, wx.ALL | wx.EXPAND, 4)
-
-            # ---- Status bar (below input) ----
-            status_hbox = wx.BoxSizer(wx.HORIZONTAL)
-            self._status_label = wx.StaticText(panel, label="⏳ Starting backend…")
-            status_hbox.Add(self._status_label, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 6)
-
-            vbox.Add(status_hbox, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 4)
 
             panel.SetSizer(vbox)
 
@@ -420,10 +399,8 @@ if _WX_AVAILABLE:
             self.SetMenuBar(menu_bar)
 
             # ---- Events ----
-            self._stop_btn.Bind(wx.EVT_BUTTON, self._on_stop)
-            self._add_img_btn.Bind(wx.EVT_BUTTON, self._on_add_image)
-            self._paste_img_btn.Bind(wx.EVT_BUTTON, self._on_paste_from_clipboard)
-            self._add_pdf_btn.Bind(wx.EVT_BUTTON, self._on_add_pdf)
+            self._send_btn.Bind(wx.EVT_BUTTON, self._on_send_btn)
+            self._attach_btn.Bind(wx.EVT_BUTTON, self._on_attach)
             self._input.Bind(wx.EVT_TEXT_ENTER, self._on_send)
             self._input.Bind(wx.EVT_CHAR_HOOK, self._on_input_key)
             self.Bind(wx.EVT_MENU, self._on_settings, id=wx.ID_PREFERENCES)
@@ -477,17 +454,16 @@ if _WX_AVAILABLE:
         def _on_server_started(self, ok: bool) -> None:
             try:
                 if ok:
-                    self._status_label.SetLabel("✅ Backend ready")
-                    self._status_label.SetForegroundColour(wx.Colour(*self._C_OK))
+                    self._set_status("✅ Backend ready", self._C_OK)
                     self.GetMenuBar().Enable(self._menu_autoroute_id, True)
                     self._init_llm_client()
                     self._check_kicad_ipc_environment()
                     self._auto_save_pcb_on_open()
                 else:
-                    self._status_label.SetLabel(
-                        "❌ Backend failed to start — use Options → Restart Backend to retry"
+                    self._set_status(
+                        "❌ Backend failed to start — use Server → Restart Backend to retry",
+                        self._C_ERR,
                     )
-                    self._status_label.SetForegroundColour(wx.Colour(*self._C_ERR))
                 self.Layout()
             except Exception as e:
                 import traceback
@@ -695,7 +671,7 @@ if _WX_AVAILABLE:
             self._render_conversation(force_scroll_to_bottom=True)
             self._busy = True
             self._cancel_event = threading.Event()
-            self._stop_btn.Enable(True)
+            self._toggle_send_stop(busy=True)
 
             from ..context_bridge import collect_context, context_to_system_prompt_block
 
@@ -760,6 +736,150 @@ if _WX_AVAILABLE:
                     self._on_paste_from_clipboard()
                     return
             event.Skip()
+
+        # ------------------------------------------------------------------ #
+        # Input-row helpers (bitmaps, status dot, send/stop toggle)
+        # ------------------------------------------------------------------ #
+
+        @staticmethod
+        def _new_icon_bitmap(
+            size: int, bg: wx.Colour | None = None
+        ) -> tuple[wx.Bitmap, wx.MemoryDC]:
+            """Create a canvas for a custom-drawn icon with the given background.
+
+            wx.Bitmap(size, size) starts uninitialised (often black on GTK) and
+            MemoryDC.Clear() does not reliably repaint it, so build the base
+            from a wx.Image filled with the panel background colour instead.
+            """
+            if bg is None:
+                bg = wx.WHITE
+            data = bytes((bg.Red(), bg.Green(), bg.Blue())) * (size * size)
+            img = wx.Image(size, size, data)
+            bmp = wx.Bitmap(img)
+            mdc = wx.MemoryDC()
+            mdc.SelectObject(bmp)
+            return bmp, mdc
+
+        @staticmethod
+        def _make_attach_bitmap(size: int = 28, bg: wx.Colour | None = None) -> wx.Bitmap:
+            """Paperclip-style attach icon drawn with GraphicsContext."""
+            bmp, mdc = AssistantPanel._new_icon_bitmap(size, bg)
+            gc = wx.GraphicsContext.Create(mdc)
+            gc.SetPen(wx.Pen(wx.Colour(90, 90, 90), 2))
+            gc.SetBrush(wx.TRANSPARENT_BRUSH)
+            # Simplified paperclip: two rounded-rectangle arcs
+
+            cx, cy = size / 2, size / 2
+            r_outer = size * 0.32
+            r_inner = size * 0.18
+            rect_w = size * 0.36
+            # Outer rounded rect (vertical)
+            path_o = gc.CreatePath()
+            path_o.AddRoundedRectangle(
+                cx - rect_w / 2, cy - r_outer, rect_w, 2 * r_outer, rect_w / 2
+            )
+            gc.DrawPath(path_o)
+            # Inner rounded rect (vertical, shorter)
+            path_i = gc.CreatePath()
+            path_i.AddRoundedRectangle(
+                cx - rect_w / 2 + 3, cy - r_inner, rect_w - 6, 2 * r_inner, (rect_w - 6) / 2
+            )
+            gc.DrawPath(path_i)
+            del gc, mdc
+            return bmp
+
+        @staticmethod
+        def _make_send_bitmap(size: int = 28, bg: wx.Colour | None = None) -> wx.Bitmap:
+            """Paper-plane send icon drawn with GraphicsContext."""
+            bmp, mdc = AssistantPanel._new_icon_bitmap(size, bg)
+            gc = wx.GraphicsContext.Create(mdc)
+            gc.SetBrush(wx.Brush(wx.Colour(34, 85, 204)))  # _C_USER blue
+            gc.SetPen(wx.Pen(wx.Colour(24, 65, 180), 1))
+            path = gc.CreatePath()
+            path.MoveToPoint(4, 4)
+            path.AddLineToPoint(size - 4, size / 2)
+            path.AddLineToPoint(4, size - 4)
+            path.AddLineToPoint(4, 4)
+            gc.DrawPath(path)
+            del gc, mdc
+            return bmp
+
+        @staticmethod
+        def _make_stop_bitmap(size: int = 28, bg: wx.Colour | None = None) -> wx.Bitmap:
+            """Red rounded-square stop icon drawn with GraphicsContext."""
+            bmp, mdc = AssistantPanel._new_icon_bitmap(size, bg)
+            gc = wx.GraphicsContext.Create(mdc)
+            gc.SetBrush(wx.Brush(wx.Colour(220, 70, 70)))
+            gc.SetPen(wx.Pen(wx.Colour(180, 50, 50), 1))
+            path = gc.CreatePath()
+            margin = 5
+            path.AddRoundedRectangle(margin, margin, size - 2 * margin, size - 2 * margin, 3)
+            gc.DrawPath(path)
+            del gc, mdc
+            return bmp
+
+        @staticmethod
+        def _make_status_dot_bitmap(
+            rgb: tuple, size: int = 14, bg: wx.Colour | None = None
+        ) -> wx.Bitmap:
+            """Coloured circle for the status indicator."""
+            bmp, mdc = AssistantPanel._new_icon_bitmap(size, bg)
+            gc = wx.GraphicsContext.Create(mdc)
+            gc.SetBrush(wx.Brush(wx.Colour(*rgb)))
+            gc.SetPen(wx.Pen(wx.Colour(*rgb), 1))
+            gc.DrawEllipse(1, 1, size - 2, size - 2)
+            del gc, mdc
+            return bmp
+
+        def _set_status(self, text: str, colour: tuple | None = None) -> None:
+            """Update the status dot colour + tooltip text."""
+            self._status_dot.SetToolTip(text)
+            if colour is not None:
+                bg = self._ui_panel.GetBackgroundColour()
+                self._status_dot.SetBitmap(self._make_status_dot_bitmap(colour, bg=bg))
+
+        def _toggle_send_stop(self, busy: bool) -> None:
+            """Switch the send button between Send and Stop modes."""
+            bg = self._ui_panel.GetBackgroundColour()
+            if busy:
+                self._send_btn.SetBitmap(self._make_stop_bitmap(bg=bg))
+                self._send_btn.SetToolTip("Stop generation (Escape)")
+            else:
+                self._send_btn.SetBitmap(self._make_send_bitmap(bg=bg))
+                self._send_btn.SetToolTip("Send message (Enter)")
+
+        def _on_send_btn(self, event) -> None:
+            """Handle send/stop button click depending on current state."""
+            if self._busy:
+                self._on_stop(event)
+            else:
+                self._on_send(event)
+
+        def _on_attach(self, event) -> None:
+            """Unified attach dialog: images or PDF in one file picker."""
+            wildcard = (
+                "Images (*.png;*.jpg;*.jpeg;*.bmp;*.webp;*.gif)"
+                "|*.png;*.jpg;*.jpeg;*.bmp;*.webp;*.gif|"
+                "PDF documents (*.pdf)|*.pdf|"
+                "All files (*.*)|*.*"
+            )
+            dlg = wx.FileDialog(
+                self,
+                "Attach image or PDF…",
+                wildcard=wildcard,
+                style=wx.FD_OPEN | wx.FD_MULTIPLE | wx.FD_FILE_MUST_EXIST,
+            )
+            if dlg.ShowModal() == wx.ID_OK:
+                paths = dlg.GetPaths()
+                images = [p for p in paths if not p.lower().endswith(".pdf")]
+                pdfs = [p for p in paths if p.lower().endswith(".pdf")]
+                for path in images:
+                    if path not in self._attached_images:
+                        self._attached_images.append(path)
+                self._refresh_attachments_bar()
+                for path in pdfs:
+                    self._on_add_pdf(pdf_path=path)
+            dlg.Destroy()
 
         # ------------------------------------------------------------------ #
         # Image attachments
@@ -924,7 +1044,7 @@ if _WX_AVAILABLE:
         # PDF text extraction
         # ------------------------------------------------------------------ #
 
-        def _on_add_pdf(self, event) -> None:
+        def _on_add_pdf(self, event=None, *, pdf_path: str | None = None) -> None:
             """Open a PDF, extract text with page numbers, inject into input."""
             if self._busy:
                 wx.MessageBox(
@@ -934,22 +1054,22 @@ if _WX_AVAILABLE:
                     self,
                 )
                 return
-            wildcard = "PDF documents (*.pdf)|*.pdf|All files (*.*)|*.*"
-            dlg = wx.FileDialog(
-                self,
-                "Select PDF to extract",
-                wildcard=wildcard,
-                style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
-            )
-            if dlg.ShowModal() != wx.ID_OK:
+            if pdf_path is None:
+                wildcard = "PDF documents (*.pdf)|*.pdf|All files (*.*)|*.*"
+                dlg = wx.FileDialog(
+                    self,
+                    "Select PDF to extract",
+                    wildcard=wildcard,
+                    style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+                )
+                if dlg.ShowModal() != wx.ID_OK:
+                    dlg.Destroy()
+                    return
+                pdf_path = dlg.GetPath()
                 dlg.Destroy()
-                return
-            pdf_path = dlg.GetPath()
-            dlg.Destroy()
 
             # Run extraction in a background thread to avoid blocking the UI.
-            self._status_label.SetLabel("⏳ Extracting PDF text…")
-            self._add_pdf_btn.Enable(False)
+            self._set_status("⏳ Extracting PDF text…", self._C_WARN)
 
             def _run() -> None:
                 import subprocess  # nosec B404 -- controlled subprocess, no user input
@@ -989,8 +1109,7 @@ if _WX_AVAILABLE:
             self, text: str | None, error: str | None, pdf_path: str | None
         ) -> None:
             """Called on the UI thread after PDF extraction finishes."""
-            self._add_pdf_btn.Enable(True)
-            self._status_label.SetLabel("Ready")
+            self._set_status("Ready", self._C_OK)
             if error:
                 wx.MessageBox(
                     f"PDF text extraction failed:\n{error}",
@@ -1058,7 +1177,7 @@ if _WX_AVAILABLE:
                         self._render_conversation(force_scroll_to_bottom=True)
             self._busy = False
             self._cancel_event = None
-            self._stop_btn.Enable(False)
+            self._toggle_send_stop(busy=False)
             # Auto-refresh after tool calls
             if self._tool_calls_made:
                 self._auto_refresh(ctx)
@@ -1271,7 +1390,7 @@ if _WX_AVAILABLE:
                     self._render_conversation(force_scroll_to_bottom=True)
             self._busy = False
             self._cancel_event = None
-            self._stop_btn.Enable(False)
+            self._toggle_send_stop(busy=False)
 
         def _on_restart(self, event) -> None:
             if self._busy:
@@ -1281,8 +1400,7 @@ if _WX_AVAILABLE:
                     wx.OK | wx.ICON_INFORMATION,
                 )
                 return
-            self._status_label.SetLabel("⏳ Restarting backend…")
-            self._status_label.SetForegroundColour(wx.NullColour)
+            self._set_status("⏳ Restarting backend…", self._C_WARN)
             self._conv_entries.append(
                 {
                     "type": "status",
@@ -1639,8 +1757,7 @@ if _WX_AVAILABLE:
 
             # ---- 5. Update UI, then start background thread ----
             self.GetMenuBar().Enable(self._menu_autoroute_id, False)
-            self._status_label.SetLabel("⏳ Auto-routing in progress…")
-            self._status_label.SetForegroundColour(wx.Colour(*self._C_WARN))
+            self._set_status("⏳ Auto-routing in progress…", self._C_WARN)
             self.Layout()
 
             self._conv_entries.append(
@@ -1655,7 +1772,7 @@ if _WX_AVAILABLE:
             from ..autorouter import start_freerouting_thread
 
             def _progress(msg: str) -> None:
-                wx.CallAfter(self._status_label.SetLabel, f"⏳ {msg}")
+                wx.CallAfter(self._set_status, f"⏳ {msg}", self._C_WARN)
 
             def _routing_done(success: bool, message: str, stdout: str, stderr: str) -> None:
                 # Marshal back to main thread for pcbnew import + UI update.
@@ -1720,11 +1837,9 @@ if _WX_AVAILABLE:
             # ---- Restore menu item and status bar ----
             self.GetMenuBar().Enable(self._menu_autoroute_id, True)
             if success:
-                self._status_label.SetLabel("✅ Backend ready")
-                self._status_label.SetForegroundColour(wx.Colour(*self._C_OK))
+                self._set_status("✅ Backend ready", self._C_OK)
             else:
-                self._status_label.SetLabel("❌ Auto-routing failed")
-                self._status_label.SetForegroundColour(wx.Colour(*self._C_ERR))
+                self._set_status("❌ Auto-routing failed", self._C_ERR)
             self.Layout()
 
             # FreeRouting SMD padstack note
@@ -1802,10 +1917,10 @@ if _WX_AVAILABLE:
             # Remove current.json so a blank close won't restore the old session.
             self._remove_current_link()
 
-            self._status_label.SetLabel(
-                "✅ New session started" + (" (previous session saved)" if has_content else "")
+            self._set_status(
+                "✅ New session started" + (" (previous session saved)" if has_content else ""),
+                self._C_OK,
             )
-            self._status_label.SetForegroundColour(wx.Colour(*self._C_OK))
             self.Layout()
 
         def _remove_current_link(self) -> None:
@@ -1948,8 +2063,7 @@ if _WX_AVAILABLE:
             self._current_session_file = os.path.basename(chosen)
             self._update_current_link(self._current_session_file)
             self._render_conversation(force_scroll_to_bottom=True)
-            self._status_label.SetLabel("✅ Session restored")
-            self._status_label.SetForegroundColour(wx.Colour(*self._C_OK))
+            self._set_status("✅ Session restored", self._C_OK)
             self.Layout()
 
         def _on_clear(self, event) -> None:

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -843,30 +843,48 @@ if _WX_AVAILABLE:
 
         @staticmethod
         def _make_attach_bitmap(size: int = 28, bg: wx.Colour | None = None) -> wx.Bitmap:
-            """Paperclip-style attach icon drawn with GraphicsContext."""
-            bmp, mdc = AssistantPanel._new_icon_bitmap(size, bg)
-            gc = wx.GraphicsContext.Create(mdc)
-            gc.SetPen(wx.Pen(wx.Colour(90, 90, 90), 2))
-            gc.SetBrush(wx.TRANSPARENT_BRUSH)
-            # Simplified paperclip: two rounded-rectangle arcs
+            """Paperclip icon: 3 semicircles + 4 line segments.
 
-            cx, cy = size / 2, size / 2
-            r_outer = size * 0.32
-            r_inner = size * 0.18
-            rect_w = size * 0.36
-            # Outer rounded rect (vertical)
-            path_o = gc.CreatePath()
-            path_o.AddRoundedRectangle(
-                cx - rect_w / 2, cy - r_outer, rect_w, 2 * r_outer, rect_w / 2
-            )
-            gc.DrawPath(path_o)
-            # Inner rounded rect (vertical, shorter)
-            path_i = gc.CreatePath()
-            path_i.AddRoundedRectangle(
-                cx - rect_w / 2 + 3, cy - r_inner, rect_w - 6, 2 * r_inner, (rect_w - 6) / 2
-            )
-            gc.DrawPath(path_i)
-            del gc, mdc
+            Layout (28×28 grid):
+                8  12  14  16  20
+             4      ╭───────╮          ← arc 2: inverted U (top)
+             8      ●       ●          ← arc 2 endpoints (8,8)(16,8)
+            12      │       │
+            16      │       │
+            20      ●─╮   ╭─●  ●───╯  ╰───●  ← arc 3 endpoints (12,20)(16,20)
+            26      ╰───────────╯        ← arc 1: large U (bottom)
+            """
+            bmp, mdc = AssistantPanel._new_icon_bitmap(size, bg)
+            pen = wx.Pen(wx.Colour(90, 90, 90), 2)
+            mdc.SetPen(pen)
+            mdc.SetBrush(wx.TRANSPARENT_BRUSH)
+
+            # Arc 1: Large bottom U (opening up)
+            # Center (14,20), r=6, bbox (8,14,12,12)
+            mdc.DrawEllipticArc(8, 14, 12, 12, 180, 360)
+
+            # Arc 2: Inverted U (opening down)
+            # Center (12,8), r=4, bbox (8,4,8,8)
+            mdc.DrawEllipticArc(8, 4, 8, 8, 0, 180)
+
+            # Arc 3: Small bottom U (opening up, smaller)
+            # Center (14,20), r=2, bbox (12,18,4,4)
+            mdc.DrawEllipticArc(12, 18, 4, 4, 180, 360)
+
+            # 4 line segments connecting arc endpoints
+            # Left outer:  arc1 left  (8,20) → arc2 left  (8,8)
+            # Right outer: arc1 right (20,20) → arc2 right (16,8)
+            # Left inner:  arc3 left  (12,20) → arc2 left  (8,8)
+            # Right inner: arc3 right (16,20) → arc2 right (16,8)
+            for x1, y1, x2, y2 in [
+                (8, 20, 8, 8),
+                (12, 20, 12, 8),
+                (16, 20, 16, 8),
+                (20, 20, 20, 8),
+            ]:
+                mdc.DrawLine(x1, y1, x2, y2)
+
+            del mdc
             return bmp
 
         @staticmethod

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -41,6 +41,24 @@ if _WX_AVAILABLE:
         pass
 
 
+def _strip_images_from_history(history: list[dict]) -> list[dict]:
+    """Drop image_url blocks (base64 bloat) from history before persisting."""
+    stripped = []
+    for msg in history:
+        content = msg.get("content")
+        if isinstance(content, list):
+            text_blocks = [b for b in content if b.get("type") == "text"]
+            if len(text_blocks) == 1:
+                content = text_blocks[0].get("text", "")
+            elif text_blocks:
+                content = text_blocks
+            else:
+                content = ""
+            msg = {**msg, "content": content}
+        stripped.append(msg)
+    return stripped
+
+
 if _WX_AVAILABLE:
 
     class AssistantPanel(wx.Frame):
@@ -103,6 +121,9 @@ if _WX_AVAILABLE:
             self._stream_wrapper_visible: bool = False
             # Shell load retry counter (prevents infinite retry on WebView2 failure).
             self._shell_retry_count: int = 0
+            # Paths of images the user attached for the next message (cleared
+            # after send). Populated via the "Attach image" button or clipboard.
+            self._attached_images: list[str] = []
 
             # Page-load watchdog: if _on_webview_loaded never fires (WebView2
             # glitch on Windows), reset _page_loading so renders are not
@@ -287,8 +308,24 @@ if _WX_AVAILABLE:
             search_hbox.Add(self._search_close_btn, 0)
             vbox.Add(search_hbox, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 4)
 
+            # ---- Attachments bar (image thumbnails; empty when none attached) ----
+            self._attachments_hbox = wx.BoxSizer(wx.HORIZONTAL)
+            vbox.Add(self._attachments_hbox, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 4)
+
             # ---- Input row ----
             hbox = wx.BoxSizer(wx.HORIZONTAL)
+
+            self._add_img_btn = wx.BitmapButton(
+                panel, bitmap=wx.ArtProvider.GetBitmap(wx.ART_FILE_OPEN, wx.ART_BUTTON, (20, 20))
+            )
+            self._add_img_btn.SetToolTip("Attach image(s)")
+            hbox.Add(self._add_img_btn, 0, wx.RIGHT, 2)
+
+            self._paste_img_btn = wx.BitmapButton(
+                panel, bitmap=wx.ArtProvider.GetBitmap(wx.ART_PASTE, wx.ART_BUTTON, (20, 20))
+            )
+            self._paste_img_btn.SetToolTip("Paste image from clipboard (Ctrl+V)")
+            hbox.Add(self._paste_img_btn, 0, wx.RIGHT, 4)
 
             self._input = wx.TextCtrl(
                 panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE | wx.BORDER_SIMPLE
@@ -378,6 +415,8 @@ if _WX_AVAILABLE:
 
             # ---- Events ----
             self._stop_btn.Bind(wx.EVT_BUTTON, self._on_stop)
+            self._add_img_btn.Bind(wx.EVT_BUTTON, self._on_add_image)
+            self._paste_img_btn.Bind(wx.EVT_BUTTON, self._on_paste_from_clipboard)
             self._input.Bind(wx.EVT_TEXT_ENTER, self._on_send)
             self._input.Bind(wx.EVT_CHAR_HOOK, self._on_input_key)
             self.Bind(wx.EVT_MENU, self._on_settings, id=wx.ID_PREFERENCES)
@@ -612,17 +651,33 @@ if _WX_AVAILABLE:
                 )
                 return
             text = self._input.GetValue().strip()
-            if not text:
+            images = self._encode_attached_images()
+            if not text and not images:
                 return
-            log.info("_on_send: user message (%d chars)", len(text))
+            if images and not self._settings.llm_supports_vision:
+                wx.MessageBox(
+                    "The current model is configured as not supporting vision. "
+                    'Enable "Model supports vision" in Settings or remove the attached '
+                    "image(s) before sending.",
+                    "Vision not enabled",
+                    wx.OK | wx.ICON_WARNING,
+                    self,
+                )
+                return
+            log.info("_on_send: user message (%d chars, %d image(s))", len(text), len(images))
             self._input.Clear()
+            display_text = text or "(image attachment)"
+            if images:
+                display_text += f"\n\n[📎 {len(images)} image(s) attached]"
             self._conv_entries.append(
                 {
                     "type": "user",
-                    "text": text,
+                    "text": display_text,
                     "timestamp": datetime.datetime.now().strftime("%H:%M:%S"),
                 }
             )
+            self._attached_images.clear()
+            self._refresh_attachments_bar()
             self._follow_output_to_bottom = True
             # Create the session file on the very first message so current.json
             # is established before the AI responds.
@@ -667,6 +722,7 @@ if _WX_AVAILABLE:
                             self._on_tool_call, name, args, result
                         ),
                         on_text_delta=_on_delta,
+                        images=images,
                     )
                 except Exception as e:
                     log.exception("LLM request failed")
@@ -690,7 +746,172 @@ if _WX_AVAILABLE:
             if key_code == wx.WXK_RETURN and event.ShiftDown():
                 self._input.WriteText("\n")
                 return  # consume the event — don't fire EVT_TEXT_ENTER
+            if key_code == ord("V") and event.ControlDown():
+                # If the clipboard holds a bitmap, attach it as an image instead
+                # of pasting text; otherwise fall through to normal paste.
+                if self._clipboard_has_bitmap():
+                    self._on_paste_from_clipboard()
+                    return
             event.Skip()
+
+        # ------------------------------------------------------------------ #
+        # Image attachments
+        # ------------------------------------------------------------------ #
+
+        def _on_add_image(self, event) -> None:
+            """Open a file dialog and attach the selected images."""
+            wildcard = (
+                "Images (*.png;*.jpg;*.jpeg;*.bmp;*.webp;*.gif)"
+                "|*.png;*.jpg;*.jpeg;*.bmp;*.webp;*.gif|All files (*.*)|*.*"
+            )
+            dlg = wx.FileDialog(
+                self,
+                "Attach image(s)",
+                wildcard=wildcard,
+                style=wx.FD_OPEN | wx.FD_MULTIPLE | wx.FD_FILE_MUST_EXIST,
+            )
+            if dlg.ShowModal() == wx.ID_OK:
+                for path in dlg.GetPaths():
+                    if path not in self._attached_images:
+                        self._attached_images.append(path)
+                self._refresh_attachments_bar()
+            dlg.Destroy()
+
+        def _on_paste_from_clipboard(self, event=None) -> None:
+            """Read a bitmap from the OS clipboard and attach it as an image."""
+            if not wx.TheClipboard.Open():
+                wx.MessageBox(
+                    "Could not open the system clipboard.",
+                    "Clipboard",
+                    wx.OK | wx.ICON_INFORMATION,
+                )
+                return
+            try:
+                if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_BITMAP)):
+                    bdo = wx.BitmapDataObject()
+                    if wx.TheClipboard.GetData(bdo):
+                        bmp = bdo.GetBitmap()
+                        if bmp.IsOk():
+                            path = self._save_clipboard_bitmap(bmp)
+                            if path and path not in self._attached_images:
+                                self._attached_images.append(path)
+                                self._refresh_attachments_bar()
+                            return
+                wx.MessageBox(
+                    "No image found in the clipboard.",
+                    "Clipboard",
+                    wx.OK | wx.ICON_INFORMATION,
+                )
+            finally:
+                wx.TheClipboard.Close()
+
+        def _clipboard_has_bitmap(self) -> bool:
+            if not wx.TheClipboard.Open():
+                return False
+            try:
+                return wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_BITMAP))
+            finally:
+                wx.TheClipboard.Close()
+
+        @staticmethod
+        def _save_clipboard_bitmap(bmp: wx.Bitmap) -> str | None:
+            """Persist a clipboard bitmap to a temp PNG and return its path."""
+            import tempfile
+            import uuid
+
+            img = bmp.ConvertToImage()
+            path = os.path.join(tempfile.gettempdir(), f"kicad_ai_clip_{uuid.uuid4().hex}.png")
+            return path if img.SaveFile(path, wx.BITMAP_TYPE_PNG) else None
+
+        def _remove_attachment(self, index: int) -> None:
+            if 0 <= index < len(self._attached_images):
+                del self._attached_images[index]
+            self._refresh_attachments_bar()
+
+        def _clear_attachments(self, event=None) -> None:
+            self._attached_images.clear()
+            self._refresh_attachments_bar()
+
+        def _refresh_attachments_bar(self) -> None:
+            """Rebuild the thumbnail strip from self._attached_images."""
+            for item in list(self._attachments_hbox.GetChildren()):
+                win = item.GetWindow()
+                self._attachments_hbox.Detach(win)
+                if win:
+                    win.Destroy()
+
+            if self._attached_images:
+                for idx, path in enumerate(self._attached_images):
+                    sb = wx.StaticBitmap(self._ui_panel, bitmap=self._fit_thumbnail(path))
+                    sb.SetToolTip(os.path.basename(path))
+                    sb.Bind(
+                        wx.EVT_LEFT_DOWN,
+                        lambda evt, i=idx: self._remove_attachment(i),
+                    )
+                    self._attachments_hbox.Add(sb, 0, wx.RIGHT, 4)
+                count = wx.StaticText(
+                    self._ui_panel, label=f"{len(self._attached_images)} image(s)"
+                )
+                self._attachments_hbox.Add(count, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 4)
+                clear_btn = wx.Button(self._ui_panel, label="✕ clear")
+                clear_btn.Bind(wx.EVT_BUTTON, self._clear_attachments)
+                self._attachments_hbox.Add(clear_btn, 0, wx.ALIGN_CENTER_VERTICAL)
+            self.Layout()
+
+        @staticmethod
+        def _fit_thumbnail(path: str, max_size: int = 48) -> wx.Bitmap:
+            """Load an image and scale it to fit within max_size×max_size."""
+            try:
+                img = wx.Image(path, wx.BITMAP_TYPE_ANY)
+                w, h = img.GetWidth(), img.GetHeight()
+                scale = min(max_size / w, max_size / h, 1.0)
+                if scale < 1.0:
+                    img = img.Scale(
+                        max(1, int(round(w * scale))),
+                        max(1, int(round(h * scale))),
+                        wx.IMAGE_QUALITY_HIGH,
+                    )
+                return wx.Bitmap(img)
+            except Exception as e:
+                log.warning("Could not load thumbnail %s: %s", path, e)
+                return wx.Bitmap(max_size, max_size)
+
+        def _encode_attached_images(self) -> list[dict]:
+            """Resize (≤1024px longest edge) and base64-encode attached images."""
+            import base64
+            import tempfile
+            import uuid
+
+            encoded: list[dict] = []
+            for path in list(self._attached_images):
+                try:
+                    img = wx.Image(path, wx.BITMAP_TYPE_ANY)
+                    if not img.IsOk():
+                        continue
+                    w, h = img.GetWidth(), img.GetHeight()
+                    longest = max(w, h)
+                    if longest > 1024:
+                        scale = 1024.0 / longest
+                        img = img.Scale(
+                            int(round(w * scale)),
+                            int(round(h * scale)),
+                            wx.IMAGE_QUALITY_HIGH,
+                        )
+                    tmp = os.path.join(
+                        tempfile.gettempdir(), f"kicad_ai_enc_{uuid.uuid4().hex}.png"
+                    )
+                    if not img.SaveFile(tmp, wx.BITMAP_TYPE_PNG):
+                        continue
+                    with open(tmp, "rb") as f:
+                        data = base64.b64encode(f.read()).decode()
+                    try:
+                        os.remove(tmp)
+                    except OSError:
+                        pass
+                    encoded.append({"media_type": "image/png", "data": data})
+                except Exception as e:
+                    log.warning("Could not encode attachment %s: %s", path, e)
+            return encoded
 
         def _on_reply(self, reply: str, ctx: dict, was_streamed: bool = False) -> None:
             # Stop the flush timer and drain any remaining chunks
@@ -1521,7 +1742,11 @@ if _WX_AVAILABLE:
                 "title": title,
                 "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
                 "conv_entries": self._conv_entries,
-                "llm_history": self._llm_client.get_history() if self._llm_client else [],
+                "llm_history": (
+                    _strip_images_from_history(self._llm_client.get_history())
+                    if self._llm_client
+                    else []
+                ),
             }
             try:
                 fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/kicad_plugin/ui/settings_dialog.py
+++ b/kicad_plugin/ui/settings_dialog.py
@@ -56,6 +56,18 @@ if _WX_AVAILABLE:
             self._model = wx.TextCtrl(self, value=self._settings.llm_model)
             grid.Add(self._model, 1, wx.EXPAND)
 
+            # Supports vision
+            grid.Add(
+                wx.StaticText(self, label="Model supports vision:"), 0, wx.ALIGN_CENTER_VERTICAL
+            )
+            self._supports_vision = wx.CheckBox(self)
+            self._supports_vision.SetValue(self._settings.llm_supports_vision)
+            self._supports_vision.SetToolTip(
+                "Enable when the model accepts image input (e.g. gpt-4o, claude-3.x, llava). "
+                "Disable for text-only models to avoid sending image data they cannot process."
+            )
+            grid.Add(self._supports_vision, 1)
+
             # Custom base URL
             grid.Add(wx.StaticText(self, label="Custom endpoint URL:"), 0, wx.ALIGN_CENTER_VERTICAL)
             self._base_url = wx.TextCtrl(self, value=self._settings.llm_base_url)
@@ -161,6 +173,7 @@ if _WX_AVAILABLE:
             settings.llm_provider = self._PROVIDERS[self._provider.GetSelection()]
             settings.llm_api_key = self._api_key.GetValue().strip()
             settings.llm_model = self._model.GetValue().strip()
+            settings.llm_supports_vision = self._supports_vision.GetValue()
             settings.llm_base_url = self._base_url.GetValue().strip()
             settings.python_executable = self._python.GetValue().strip()
             settings.server_port = self._port.GetValue()

--- a/kicad_plugin/ui/shell.js
+++ b/kicad_plugin/ui/shell.js
@@ -78,13 +78,37 @@ function _autorouteHtml(e) {
         + output + '</pre></div></details>';
 }
 
+function _pdfTextsHtml(pdfTexts) {
+    if (!pdfTexts || pdfTexts.length === 0) return '';
+    var html = '';
+    for (var i = 0; i < pdfTexts.length; i++) {
+        var p = pdfTexts[i];
+        var icon = p.error ? '\u2717' : '\u2713';
+        var iconColor = p.error ? '#c62828' : '#2e7d32';
+        var css = p.error ? 'tool-entry tool-err' : 'tool-entry tool-ok';
+        var uid = 'pdf_' + i + '_' + Math.random().toString(36).slice(2);
+        html += '<details class="tools" id="' + uid + '" style="margin:2px 0">'
+            + '<summary><span style="color:' + iconColor + '">' + icon + '</span> '
+            + '<span style="color:#444;font-weight:600">\uD83D\uDCC4 ' + _escapeHtml(p.name)
+            + '</span></summary>'
+            + '<div class="tool-body ' + css + '" data-details="' + uid + '">'
+            + '<pre style="margin:2px 0;max-height:300px;overflow-y:auto">'
+            + _escapeHtml(p.text || '') + '</pre></div></details>';
+    }
+    return html;
+}
+
 function _renderEntry(e) {
     try {
         var div = document.createElement('div');
         switch (e.type) {
             case 'user':
+                var userBody = _escapeHtml(e.text || '').replace(/\n/g, '<br>');
+                if (e.pdf_texts && e.pdf_texts.length > 0) {
+                    userBody += _pdfTextsHtml(e.pdf_texts);
+                }
                 div.innerHTML = _msgBlock('You', '#1565C0', '#E3F2FD',
-                    _escapeHtml(e.text || '').replace(/\n/g, '<br>'), e.timestamp || '');
+                    userBody, e.timestamp || '');
                 break;
             case 'ai':
                 div.innerHTML = _msgBlock('AI', '#00695C', '#E8F5E9',

--- a/plans/kicad-plugin-enhancement.md
+++ b/plans/kicad-plugin-enhancement.md
@@ -1,0 +1,103 @@
+# kicad_plugin 优化建议
+
+## 状态：规划中
+
+## 目标
+
+为 kicad_plugin（KiCad AI Assistant 插件）增加三项能力，要求同时支持 **Linux / Windows / macOS**：
+
+1. 支持上传图片（用户给 LLM 看图）
+2. 支持获取 schematic 或 PCB 的截图（LLM 主动"看"板子）
+3. 支持解析 PDF 文档
+
+## 现有架构（相关部分）
+
+```
+KiCad GUI (wxPython)
+  └─ kicad_plugin/
+       ├─ ui/panel.py        ← 聊天面板（wx.Frame, TextCtrl 输入）
+       ├─ llm_client.py      ← LLMClient，直连 OpenAI/Anthropic/Ollama，多模态消息在此构建
+       ├─ server_manager.py  ← 启动 kcaa MCP server（独立 venv 子进程）
+       └─ setup_plugin.sh/.bat/.ps1 ← 创建 venv 安装依赖
+```
+
+关键结论：
+- 插件运行在 KiCad 嵌入式 wx 环境，`wx` 可用 → 截图/图片 UI 无需额外依赖。
+- LLM 消息构建集中在 `llm_client.py`（`_build_anthropic_messages` / `_stream_openai` / `_stream_ollama` / `_call_*`），新增多模态字段需按 provider 分别处理。
+- KiCad 嵌入式 Python 装第三方包受限；纯 Python / 有跨平台轮子的库（PyMuPDF、pdfplumber、pypdf）应装进 `setup_plugin*.sh/.bat/.ps1` 创建的 venv，插件侧以子进程调用。
+
+---
+
+## 1. 支持上传图片
+
+### 方案
+- **UI（panel.py）**：输入框旁加"添加图片"按钮（`wx.FileDialog` 过滤 png/jpg），选中后 `wx.Image` 加载并显示缩略图；支持一次携带多张，随下一条消息一起发送。
+- **消息构建（llm_client.py）**，按 provider 区分：
+  - OpenAI：content 变为数组
+    `[{"type":"text","text":...}, {"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}]`
+  - Anthropic：
+    `[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"<base64>"}}]`
+  - Ollama：请求体加 `images: ["<base64>"]`，messages 使用数组格式。
+- **发送前压缩**：最长边缩到 ~1024px，控制体积，避免超 token/超时；统一 `wx.Image.Scale` → `wx.Image.ConvertToBitmap` → 编码。
+- **模型要求**：需 vision 能力（gpt-4o / claude-3.x / llava 等），在设置中提示。
+
+### 跨平台
+- 全链路只用 Python 标准库（base64）+ wx → 天然支持三平台。
+
+---
+
+## 2. 支持获取 schematic / PCB 截图
+
+### 方案 A：wx 屏幕抓取（推荐，主路径）
+- 插件在 KiCad GUI 内运行，用 `wx.ScreenDC` + `wx.MemoryDC` + `wx.Bitmap` 抓取当前编辑器画布区域：
+  ```python
+  dc = wx.ScreenDC()
+  bmp = wx.Bitmap(w, h)
+  mem = wx.MemoryDC(bmp)
+  mem.Blit(0, 0, w, h, dc, x, y)
+  mem.SelectObject(wx.NullBitmap)
+  bmp.ConvertToImage().SaveFile(path, wx.BITMAP_TYPE_PNG)
+  ```
+- 画布窗口句柄：schematic 编辑器 / PCB 编辑器各取对应 wxWindow 的 `GetScreenPosition()+GetSize()`。
+- OpenGL GAL 画布同样可抓到（按屏幕坐标抓取）。
+- 截图保存为临时 PNG → base64 → 按第 1 节多模态格式注入消息，供 LLM 分析。
+
+### 方案 B：KiCad plot 导出（备选/整板渲染）
+- PCB：`pcbnew.PLOT_CONTROLLER` plot 到 SVG/PDF；schematic：eeschema plot 导出。
+- 需要 PNG 时用 Pillow/cairosvg 转换（cairosvg 依赖 native cairo，三平台均有轮子；Pillow 为纯 wheel）。
+- 适合不依赖 GUI 的场景或需要整板/整图导出。
+
+### 建议
+- 方案 A 为主（实时取景、所见即所得），方案 B 提供"整板导出"工具；两者输出统一为 base64 图片。
+
+---
+
+## 3. 支持解析 PDF 文档
+
+### 方案
+- **A. 文本抽取**：`pypdf`（纯 Python）/ `pdfplumber`（表格友好）/ `PyMuPDF`（fitz，速度快）。
+- **B. 页面转图**：`PyMuPDF` 渲染每页为 PNG，按第 1 节多模态格式发送 —— 适合 datasheet 原理图、图表密集文档（纯文本抽取易乱）。
+- **推荐组合**：先抽文本入上下文；当页数少、图/表多或文本乱时自动转图让多模态模型读。
+
+### 运行位置
+- 库安装进 `setup_plugin.sh/.bat/.ps1` 的 venv（`pymupdf`、`pdfplumber`）。
+- 插件侧通过 `server_manager` 类似机制以子进程跑解析脚本，避免污染 KiCad 嵌入式 Python。
+
+### 跨平台
+- `pymupdf` / `pdfplumber` / `pypdf` 均有 Linux / macOS / Windows 支持（PyMuPDF 提供三平台 wheel）。
+
+---
+
+## 实施顺序建议
+
+1. 图片上传（第 1 节）—— 打通多模态消息格式，第 2、3 节复用。
+2. 截图（第 2 节 A 方案）—— 复用图片注入链路。
+3. PDF 解析（第 3 节）—— 依赖 venv 与子进程机制。
+
+## 风险 / 注意事项
+
+- **token 与超时**：图片/多页 PDF 会显著增加输入体积，需限制尺寸与页数（如最多前 N 页）。
+- **Vision 模型支持**：需在设置中提示所选模型必须支持图像输入。
+- **Wayland 抓屏限制**：Linux Wayland 下 `wx.ScreenDC` 可能受限，需验证；备选使用 KiCad plot 导出或 `grim` 等工具。
+- **KiCad 版本差异**：schematic plot / 新版 API 各版本接口不同，做兼容层。
+- **测试**：三平台 CI 需覆盖截图与 PDF 解析（现有 `.github` 有 CI 可扩展）。

--- a/plans/kicad-plugin-enhancement.md
+++ b/plans/kicad-plugin-enhancement.md
@@ -1,14 +1,15 @@
 # kicad_plugin 优化建议
 
-## 状态：规划中
+## 状态：图片上传已完成，PDF 解析待做
 
 ## 目标
 
-为 kicad_plugin（KiCad AI Assistant 插件）增加三项能力，要求同时支持 **Linux / Windows / macOS**：
+为 kicad_plugin（KiCad AI Assistant 插件）增加两项能力，要求同时支持 **Linux / Windows / macOS**：
 
-1. 支持上传图片（用户给 LLM 看图）
-2. 支持获取 schematic 或 PCB 的截图（LLM 主动"看"板子）
-3. 支持解析 PDF 文档
+1. 支持上传/粘贴图片（用户给 LLM 看图，含从剪贴板粘贴截图）
+2. 支持解析 PDF 文档
+
+> 截图能力不做插件内实现：用户自行截图后 **Ctrl+V** 粘贴到聊天框即可，schematic / PCB 截图均走此路径。详见「暂不考虑」章节。
 
 ## 现有架构（相关部分）
 
@@ -28,10 +29,12 @@ KiCad GUI (wxPython)
 
 ---
 
-## 1. 支持上传图片
+## 1. 支持上传 / 粘贴图片
 
 ### 方案
 - **UI（panel.py）**：输入框旁加"添加图片"按钮（`wx.FileDialog` 过滤 png/jpg），选中后 `wx.Image` 加载并显示缩略图；支持一次携带多张，随下一条消息一起发送。
+- **剪贴板粘贴（Ctrl+V）**：输入框内 Ctrl+V 时，若系统剪贴板含位图（`wx.DF_BITMAP`）则粘贴为图片（存临时 PNG 进附件栏），否则退化为普通文本粘贴；另有"粘贴"按钮（`wx.ART_PASTE`）触发同一逻辑。
+- **附件缩略图条**：已选图片显示 48×48 缩略图，点击移除；带数量标签与"✕ clear"一键清空。
 - **消息构建（llm_client.py）**，按 provider 区分：
   - OpenAI：content 变为数组
     `[{"type":"text","text":...}, {"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}]`
@@ -39,6 +42,7 @@ KiCad GUI (wxPython)
     `[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"<base64>"}}]`
   - Ollama：请求体加 `images: ["<base64>"]`，messages 使用数组格式。
 - **发送前压缩**：最长边缩到 ~1024px，控制体积，避免超 token/超时；统一 `wx.Image.Scale` → `wx.Image.ConvertToBitmap` → 编码。
+- **会话保存**：写 session 文件前剥离 `image_url` 块（避免 base64 撑爆文件），加载会话后图片上下文不保留。
 - **模型要求**：需 vision 能力（gpt-4o / claude-3.x / llava 等），在设置中提示。
 
 ### 跨平台
@@ -46,38 +50,20 @@ KiCad GUI (wxPython)
 
 ---
 
-## 2. 支持获取 schematic / PCB 截图
+## 2. 支持解析 PDF 文档
 
-### 方案 A：wx 屏幕抓取（推荐，主路径）
-- 插件在 KiCad GUI 内运行，用 `wx.ScreenDC` + `wx.MemoryDC` + `wx.Bitmap` 抓取当前编辑器画布区域：
-  ```python
-  dc = wx.ScreenDC()
-  bmp = wx.Bitmap(w, h)
-  mem = wx.MemoryDC(bmp)
-  mem.Blit(0, 0, w, h, dc, x, y)
-  mem.SelectObject(wx.NullBitmap)
-  bmp.ConvertToImage().SaveFile(path, wx.BITMAP_TYPE_PNG)
-  ```
-- 画布窗口句柄：schematic 编辑器 / PCB 编辑器各取对应 wxWindow 的 `GetScreenPosition()+GetSize()`。
-- OpenGL GAL 画布同样可抓到（按屏幕坐标抓取）。
-- 截图保存为临时 PNG → base64 → 按第 1 节多模态格式注入消息，供 LLM 分析。
+### 方案 A（主路径）：文本抽取 + 页码标注
+- `pypdf`（纯 Python）/ `pdfplumber`（表格友好）/ `PyMuPDF`（fitz，速度快）。
+- **每段文字前标注页码**（如 `[P3]`），LLM 回答时能引用具体页。
 
-### 方案 B：KiCad plot 导出（备选/整板渲染）
-- PCB：`pcbnew.PLOT_CONTROLLER` plot 到 SVG/PDF；schematic：eeschema plot 导出。
-- 需要 PNG 时用 Pillow/cairosvg 转换（cairosvg 依赖 native cairo，三平台均有轮子；Pillow 为纯 wheel）。
-- 适合不依赖 GUI 的场景或需要整板/整图导出。
+### 方案 B（用户按需补充）：页面转图
+- `PyMuPDF` 渲染用户指定页为 PNG，走第 1 节多模态格式发送 —— 适合 datasheet 原理图、图表密集页。
+- **由用户判断**：看完文本摘要后，如信息不足（图表、原理图），用户主动要求补充指定页截图，而非系统自动转图。
 
-### 建议
-- 方案 A 为主（实时取景、所见即所得），方案 B 提供"整板导出"工具；两者输出统一为 base64 图片。
-
----
-
-## 3. 支持解析 PDF 文档
-
-### 方案
-- **A. 文本抽取**：`pypdf`（纯 Python）/ `pdfplumber`（表格友好）/ `PyMuPDF`（fitz，速度快）。
-- **B. 页面转图**：`PyMuPDF` 渲染每页为 PNG，按第 1 节多模态格式发送 —— 适合 datasheet 原理图、图表密集文档（纯文本抽取易乱）。
-- **推荐组合**：先抽文本入上下文；当页数少、图/表多或文本乱时自动转图让多模态模型读。
+### 推荐组合（简化版，2026-08-04 定稿）
+- **默认流程**：全量抽文本（带页码）入上下文。
+- **补充流程**：用户判断需要看图 → 用户要求渲染指定页（或当前打开的 PDF 页）→ 方案 B 转图发给 LLM。
+- 不引入 LLM 选页/自动转图逻辑，保持实现简单。
 
 ### 运行位置
 - 库安装进 `setup_plugin.sh/.bat/.ps1` 的 venv（`pymupdf`、`pdfplumber`）。
@@ -90,14 +76,127 @@ KiCad GUI (wxPython)
 
 ## 实施顺序建议
 
-1. 图片上传（第 1 节）—— 打通多模态消息格式，第 2、3 节复用。
-2. 截图（第 2 节 A 方案）—— 复用图片注入链路。
-3. PDF 解析（第 3 节）—— 依赖 venv 与子进程机制。
+1. 图片上传/粘贴（第 1 节）—— 打通多模态消息格式，PDF 复用。✅ 已完成
+2. PDF 解析（第 2 节）—— 主路径走方案 A（抽文本带页码）；补充走方案 B（用户指定页转图）。依赖 venv 与子进程机制。
 
 ## 风险 / 注意事项
 
 - **token 与超时**：图片/多页 PDF 会显著增加输入体积，需限制尺寸与页数（如最多前 N 页）。
 - **Vision 模型支持**：需在设置中提示所选模型必须支持图像输入。
-- **Wayland 抓屏限制**：Linux Wayland 下 `wx.ScreenDC` 可能受限，需验证；备选使用 KiCad plot 导出或 `grim` 等工具。
-- **KiCad 版本差异**：schematic plot / 新版 API 各版本接口不同，做兼容层。
-- **测试**：三平台 CI 需覆盖截图与 PDF 解析（现有 `.github` 有 CI 可扩展）。
+- **剪贴板格式**：Ctrl+V 依赖系统剪贴板位图格式（wx.DF_BITMAP），X11/Wayland/Windows/macOS 需验证；剪贴板只有文本时退化为普通粘贴。
+- **测试**：三平台 CI 需覆盖图片粘贴与 PDF 解析（现有 `.github` 有 CI 可扩展）。
+
+---
+
+## 最终方案与目标（2026-08-05 定稿）
+
+### 目标
+为 kicad_plugin（KiCad AI Assistant 插件）增加两项能力，支持 Linux / Windows / macOS：
+1. 用户上传/粘贴图片给 LLM 看（含 Ctrl+V 粘贴系统截图）
+2. 解析 PDF 文档
+
+> 截图不单独做插件内实现：用户自行截图后 Ctrl+V 粘贴到聊天框。
+
+### 最终方案
+
+| 能力 | 方案 | 说明 |
+|---|---|---|
+| 图片上传 | **已实现**（2026-08-04） | 面板加"添加图片/粘贴"按钮，缩略图条，Ctrl+V 智能粘贴（剪贴板有 bitmap 时粘贴为图片，否则粘贴文本）；压缩 ≤1024px → base64；OpenAI/Anthropic/Ollama 三 provider 格式转换；会话保存剥离 base64 |
+| 截图（schematic/PCB） | 不实现插件内抓取 | 用户系统截图 → Ctrl+V 粘贴 → 复用图片链路 |
+| PDF 解析 | **主路径**：全量抽文本（带页码 `[P3]`）入上下文；**补充**：用户判断信息不足时要求渲染指定页转图 | 不做 LLM 选页/自动转图，保持简单 |
+
+### 迭代路径（先落地，看效果再增强）
+1. **PDF v1**：只做"抽文本带页码"（PyMuPDF，venv 子进程）。验证文本抽取对 datasheet 的可用性。
+2. **PDF v2**（视 v1 效果）：用户指定页转图 → 复用图片注入链路。
+3. **PDF v3**（可选）：若文本乱/图表多，再考虑 qwen3.8-max 原生 PDF 理解（方案 C）或 LLM 选页（见「暂不考虑」章节）。
+
+### 已完成的代码改动（ideas 分支）
+- `kicad_plugin/llm_client.py`：`run()` 支持 `images` 参数；OpenAI 数组格式 + Anthropic/Ollama 转换；`_maybe_compact` 兼容数组 content。
+- `kicad_plugin/ui/panel.py`：附件 UI（添加/粘贴/缩略图/清空）；Ctrl+V 智能粘贴；压缩编码；会话保存剥离图片。
+- 44 个 `test_llm_client` 单元测试通过；ruff lint/format 通过。
+
+---
+
+## 暂不考虑（2026-08-05）
+
+以下能力经研究后决定暂不实现，保留研究结论供后续参考。
+
+### N1. 插件内 schematic / PCB 截图
+
+#### 方案 A：wx 屏幕抓取（仅限 PCB editor 实时取景）
+- 插件在 KiCad GUI 内运行，用 `wx.ScreenDC` + `wx.MemoryDC` + `wx.Bitmap` 抓取当前编辑器画布区域：
+  ```python
+  dc = wx.ScreenDC()
+  bmp = wx.Bitmap(w, h)
+  mem = wx.MemoryDC(bmp)
+  mem.Blit(0, 0, w, h, dc, x, y)
+  mem.SelectObject(wx.NullBitmap)
+  bmp.ConvertToImage().SaveFile(path, wx.BITMAP_TYPE_PNG)
+  ```
+- 原理：`wx.ScreenDC` 走 OS 层 API 抓屏幕像素（X11 `XGetImage` / Windows `BitBlt` / macOS `CGWindowListCreateImage`），**抓取与窗口属于哪个进程无关**。
+
+#### ⚠️ 难点（2026-08-04 研究结论）
+- **插件只运行在 PCB editor 进程**：`kicad_plugin/__init__.py` 中 `_ActionPluginBase = pcbnew.ActionPlugin`。
+- **KiCad 的 schematic editor（eeschema）是独立进程**：`wx.GetTopLevelWindows()` 只能枚举**本进程**窗口 → **Python 端从物理上拿不到 schematic editor 的 wx 对象**（不是难，是跨进程不可达）。
+- 要抓 schematic 窗口必须跨进程查窗口坐标：Windows `EnumWindows` / X11 `xwininfo` / macOS `CGWindowListCopyWindowInfo`，三平台实现各异、维护成本高。
+- **结论：方案 A 只对 PCB editor 可行（同进程拿 `GetScreenPosition()`）；schematic 实时截图改走方案 B。**
+- 另：Linux **Wayland** 下 `wx.ScreenDC` 抓屏受限（X11 正常），需验证。
+
+#### 方案 B：kicad-cli 导出
+- 不走 KiCad GUI，用独立进程 `kicad-cli` 导出文件 → **无跨进程问题、无 GUI 依赖**。
+- PCB：`kicad-cli pcb export svg --output out.svg board.kicad_pcb`（KiCad 7+）。
+- Schematic：`kicad-cli sch export svg --output out.svg sheet.kicad_sch`（KiCad 7+，`--recursive` 可导出层级子图）。
+
+#### ✅ 可行性（2026-08-04 研究结论：链路大半已存在）
+- **PCB 链路已实现**：`kcaa/tools/export_tools.py` 的 `generate_thumbnail_with_cli` 已用 `kicad-cli pcb export svg` 生成 PCB 图并返回给 LLM（fastmcp `Image`）。
+- **kicad-cli 查找已封装**：`kcaa/utils/kicad_cli.py`（三平台路径检测 + 缓存 + `KICAD_CLI_PATH` 环境变量）；安全子进程封装在 `kcaa/utils/secure_subprocess.py`。
+- **schematic 子命令已验证**：`kcaa/tools/bom_tools.py` 已用 `kicad-cli sch export bom` → sch 链路可用。
+- 测试夹具齐全：`tests/**/fixtures/` 下有 `.kicad_pcb` / `.kicad_sch`，可在有 KiCad 的环境写集成测试。
+
+#### ⚠️ 难点
+- **kicad-cli 不直接输出 PNG**（`pcb/sch export` 只支持 svg/pdf/dxf 等）。**SVG 不是 vision 模型原生支持的格式**（OpenAI/Anthropic/Ollama 只收 png/jpeg/webp/gif）→ 必须转换：Pillow（纯 wheel）或 cairosvg（native cairo）。
+- **现有 `generate_thumbnail_with_cli` 直接返回 `format="svg"`，LLM 侧可能拒收** → 需补 SVG→PNG 转换步骤。
+- 实时性差：导出的是整板/整图，不是当前视图（"当前视图"仍要靠方案 A，仅 PCB）。
+- 本机（2026-08-04）无 kicad-cli，尚未实测运行；需在有 KiCad 环境验证 `sch export svg` 与转换链路。
+
+#### 暂不考虑原因
+- 方案 A 跨进程不可行（schematic）；方案 B 需额外维护 SVG→PNG 转换，性价比低。
+- **替代路径**：用户用系统截图工具截取 schematic / PCB 画面 → 在插件输入框 **Ctrl+V** 粘贴 → 走第 1 节图片注入链路发给 LLM。该功能已在第 1 节的图片粘贴实现中覆盖。
+
+### N2. PDF 方案 C：百炼 + qwen3.8-max 原生 PDF 理解
+
+- **qwen3.8-max 原生支持 PDF**（2026-08-04 官方文档确认，`https://help.aliyun.com/zh/model-studio/pdf-understanding`），走 OpenAI 兼容接口，content 数组加 `type: "file"` 块：
+  ```json
+  {"type": "file", "file": {"file_url": "https://.../doc.pdf"}}            // URL，二选一
+  // 或 Base64：
+  {"type": "file", "file": {"file_data": "data:application/pdf;base64,xxx", "filename": "report.pdf"}}  // file_data 时 filename 必填
+  ```
+- **限制**：单文件 ≤150MB、≤500 页；首包超时最长 300s（建议流式）；**仅华北 2（北京）地域**；不支持 Responses API。
+- **计费**（两段流水线）：
+  1. 文档解析费：0.02 元/页（平台先做版面分析/OCR，拆成文字 + 图片）；
+  2. 模型调用费：解析出的**文字按文本 token、图片按图片 token** 计入输入，按模型标准输入价计费。
+- **优点**：不用在插件里装 PyMuPDF/pdfplumber 做预处理；文字走文本 token（便宜）、仅图表走图片 token。
+- **缺点**：非通用能力（仅百炼华北2 + qwen3.8-max）；base_url 需带 WorkspaceId（`https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`）。
+
+#### 暂不考虑原因
+- 非通用能力，仅百炼华北2 + qwen3.8-max；先走通用方案 A+B，视效果再考虑。
+
+### N3. PDF 图文拆分的对应关系问题
+
+- 方案 C / 方案 A+B 把文字与图片拆开，**页面内图文相对位置丢失**（模型不知道图片A和文字B在页面上谁在上谁在下）。
+- **保留的**：页序、图注/标题文字（caption 是文字，跟着文字流走）。
+- **影响分场景**：文字为主（报告/论文）影响小；图文强耦合（datasheet 原理图+引脚表+时序图）影响中等 —— 但图片内部信息（引脚名、数值）模型可自读，不依赖坐标对应，且图注可交叉验证。
+- **强版面场景**：用方案 B 整页转图保真，代价是全页按图片 token 计费（更贵）。
+
+#### 暂不考虑原因
+- 先落地方案 A（抽文本带页码），看实际效果再决定是否需要整页转图保真。
+
+### N4. PDF 成本对比与图片 token 算法
+
+| 方案 | 解析成本 | 输入 token 成本 | 通用性 |
+|---|---|---|---|
+| 百炼原生 PDF（方案 C） | 0.02 元/页 | 文字按文本、图表按图片 token | 仅华北2 + qwen3.8-max |
+| 本地转图（方案 B） | 0（本地渲染） | 全页按图片 token（贵） | 任何 vision 模型 |
+| 本地抽文本（方案 A） | 0 | 仅文本 token（最便宜，但丢图表） | 任何模型 |
+- 图片 token 算法（百炼视觉模型）：**每张 ≈ ⌈h×w/1024⌉ + 2**（1024×1024 ≈ 1026 token，线性增长）。
+- 图文混合文档用方案 C 更划算；纯图 PDF 方案 B/C 成本接近。

--- a/plans/kicad-plugin-enhancement.md
+++ b/plans/kicad-plugin-enhancement.md
@@ -1,130 +1,130 @@
-# kicad_plugin 优化建议
+# kicad_plugin Enhancement Plan
 
-## 状态：图片上传已完成，PDF 解析待做
+## Status: Image upload complete, PDF parsing done
 
-## 目标
+## Goals
 
-为 kicad_plugin（KiCad AI Assistant 插件）增加两项能力，要求同时支持 **Linux / Windows / macOS**：
+Add two capabilities to kicad_plugin (KiCad AI Assistant plugin), requiring support for **Linux / Windows / macOS**:
 
-1. 支持上传/粘贴图片（用户给 LLM 看图，含从剪贴板粘贴截图）
-2. 支持解析 PDF 文档
+1. Support uploading/pasting images (user shows images to LLM, including pasting screenshots from clipboard)
+2. Support parsing PDF documents
 
-> 截图能力不做插件内实现：用户自行截图后 **Ctrl+V** 粘贴到聊天框即可，schematic / PCB 截图均走此路径。详见「暂不考虑」章节。
+> Screenshot capture is not implemented inside the plugin: users take screenshots themselves and **Ctrl+V** paste into the chat box. Both schematic and PCB screenshots use this path. See "Not Considered" section for details.
 
-## 现有架构（相关部分）
+## Existing Architecture (Relevant Parts)
 
 ```
 KiCad GUI (wxPython)
   └─ kicad_plugin/
-       ├─ ui/panel.py        ← 聊天面板（wx.Frame, TextCtrl 输入）
-       ├─ llm_client.py      ← LLMClient，直连 OpenAI/Anthropic/Ollama，多模态消息在此构建
-       ├─ server_manager.py  ← 启动 kcaa MCP server（独立 venv 子进程）
-       └─ setup_plugin.sh/.bat/.ps1 ← 创建 venv 安装依赖
+       ├─ ui/panel.py        ← Chat panel (wx.Frame, TextCtrl input)
+       ├─ llm_client.py      ← LLMClient, direct connection to OpenAI/Anthropic/Ollama, multimodal messages built here
+       ├─ server_manager.py  ← Starts kcaa MCP server (separate venv subprocess)
+       └─ setup_plugin.sh/.bat/.ps1 ← Creates venv and installs dependencies
 ```
 
-关键结论：
-- 插件运行在 KiCad 嵌入式 wx 环境，`wx` 可用 → 截图/图片 UI 无需额外依赖。
-- LLM 消息构建集中在 `llm_client.py`（`_build_anthropic_messages` / `_stream_openai` / `_stream_ollama` / `_call_*`），新增多模态字段需按 provider 分别处理。
-- KiCad 嵌入式 Python 装第三方包受限；纯 Python / 有跨平台轮子的库（PyMuPDF、pdfplumber、pypdf）应装进 `setup_plugin*.sh/.bat/.ps1` 创建的 venv，插件侧以子进程调用。
+Key conclusions:
+- The plugin runs in KiCad's embedded wx environment, `wx` is available → screenshot/image UI needs no additional dependencies.
+- LLM message construction is centralized in `llm_client.py` (`_build_anthropic_messages` / `_stream_openai` / `_stream_ollama` / `_call_*`); adding multimodal fields requires per-provider handling.
+- KiCad's embedded Python has limited third-party package installation; pure Python / cross-platform wheel libraries (PyMuPDF, pdfplumber, pypdf) should be installed in the venv created by `setup_plugin*.sh/.bat/.ps1`, and called via subprocess from the plugin side.
 
 ---
 
-## 1. 支持上传 / 粘贴图片
+## 1. Support Uploading / Pasting Images
 
-### 方案
-- **UI（panel.py）**：输入框旁加"添加图片"按钮（`wx.FileDialog` 过滤 png/jpg），选中后 `wx.Image` 加载并显示缩略图；支持一次携带多张，随下一条消息一起发送。
-- **剪贴板粘贴（Ctrl+V）**：输入框内 Ctrl+V 时，若系统剪贴板含位图（`wx.DF_BITMAP`）则粘贴为图片（存临时 PNG 进附件栏），否则退化为普通文本粘贴；另有"粘贴"按钮（`wx.ART_PASTE`）触发同一逻辑。
-- **附件缩略图条**：已选图片显示 48×48 缩略图，点击移除；带数量标签与"✕ clear"一键清空。
-- **消息构建（llm_client.py）**，按 provider 区分：
-  - OpenAI：content 变为数组
+### Approach
+- **UI (panel.py)**: Add an "Add Image" button next to the input box (`wx.FileDialog` filtering png/jpg), after selection load with `wx.Image` and display thumbnail; support multiple images at once, sent together with the next message.
+- **Clipboard Paste (Ctrl+V)**: When Ctrl+V is pressed in the input box, if the system clipboard contains a bitmap (`wx.DF_BITMAP`), paste as image (save to temporary PNG and add to attachment bar), otherwise fall back to normal text paste; also a "Paste" button (`wx.ART_PASTE`) triggers the same logic.
+- **Attachment Thumbnail Bar**: Selected images show as 48×48 thumbnails, click to remove; includes count label and "✕ clear" button to clear all.
+- **Message Construction (llm_client.py)**, per provider:
+  - OpenAI: content becomes an array
     `[{"type":"text","text":...}, {"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}]`
-  - Anthropic：
+  - Anthropic:
     `[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"<base64>"}}]`
-  - Ollama：请求体加 `images: ["<base64>"]`，messages 使用数组格式。
-- **发送前压缩**：最长边缩到 ~1024px，控制体积，避免超 token/超时；统一 `wx.Image.Scale` → `wx.Image.ConvertToBitmap` → 编码。
-- **会话保存**：写 session 文件前剥离 `image_url` 块（避免 base64 撑爆文件），加载会话后图片上下文不保留。
-- **模型要求**：需 vision 能力（gpt-4o / claude-3.x / llava 等），在设置中提示。
+  - Ollama: request body adds `images: ["<base64>"]`, messages use array format.
+- **Pre-send Compression**: Scale longest edge to ~1024px to control size, avoid token/timeout issues; unified `wx.Image.Scale` → `wx.Image.ConvertToBitmap` → encode.
+- **Session Saving**: Strip `image_url` blocks before writing session files (to avoid base64 bloating files); image context is not preserved after loading a session.
+- **Model Requirements**: Requires vision capability (gpt-4o / claude-3.x / llava, etc.), prompted in settings.
 
-### 跨平台
-- 全链路只用 Python 标准库（base64）+ wx → 天然支持三平台。
-
----
-
-## 2. 支持解析 PDF 文档
-
-### 方案 A（主路径）：文本抽取 + 页码标注
-- `pypdf`（纯 Python）/ `pdfplumber`（表格友好）/ `PyMuPDF`（fitz，速度快）。
-- **每段文字前标注页码**（如 `[P3]`），LLM 回答时能引用具体页。
-
-### 方案 B（用户按需补充）：页面转图
-- `PyMuPDF` 渲染用户指定页为 PNG，走第 1 节多模态格式发送 —— 适合 datasheet 原理图、图表密集页。
-- **由用户判断**：看完文本摘要后，如信息不足（图表、原理图），用户主动要求补充指定页截图，而非系统自动转图。
-
-### 推荐组合（简化版，2026-08-04 定稿）
-- **默认流程**：全量抽文本（带页码）入上下文。
-- **补充流程**：用户判断需要看图 → 用户要求渲染指定页（或当前打开的 PDF 页）→ 方案 B 转图发给 LLM。
-- 不引入 LLM 选页/自动转图逻辑，保持实现简单。
-
-### 运行位置
-- 库安装进 `setup_plugin.sh/.bat/.ps1` 的 venv（`pymupdf`、`pdfplumber`）。
-- 插件侧通过 `server_manager` 类似机制以子进程跑解析脚本，避免污染 KiCad 嵌入式 Python。
-
-### 跨平台
-- `pymupdf` / `pdfplumber` / `pypdf` 均有 Linux / macOS / Windows 支持（PyMuPDF 提供三平台 wheel）。
+### Cross-Platform
+- The entire chain uses only Python standard library (base64) + wx → naturally supports all three platforms.
 
 ---
 
-## 实施顺序建议
+## 2. Support Parsing PDF Documents
 
-1. 图片上传/粘贴（第 1 节）—— 打通多模态消息格式，PDF 复用。✅ 已完成
-2. PDF 解析（第 2 节）—— 主路径走方案 A（抽文本带页码）；补充走方案 B（用户指定页转图）。依赖 venv 与子进程机制。
+### Approach A (Main Path): Text Extraction + Page Number Annotation
+- `pypdf` (pure Python) / `pdfplumber` (table-friendly) / `PyMuPDF` (fitz, fast).
+- **Annotate page number before each text segment** (e.g., `[P3]`), so the LLM can reference specific pages when answering.
 
-## 风险 / 注意事项
+### Approach B (User-On-Demand): Page-to-Image Conversion
+- `PyMuPDF` renders user-specified pages as PNG, sent via the multimodal format from Section 1 — suitable for datasheet schematics, chart-dense pages.
+- **User decides**: After reading the text summary, if information is insufficient (charts, schematics), the user actively requests rendering specific pages, rather than the system auto-converting.
 
-- **token 与超时**：图片/多页 PDF 会显著增加输入体积，需限制尺寸与页数（如最多前 N 页）。
-- **Vision 模型支持**：需在设置中提示所选模型必须支持图像输入。
-- **剪贴板格式**：Ctrl+V 依赖系统剪贴板位图格式（wx.DF_BITMAP），X11/Wayland/Windows/macOS 需验证；剪贴板只有文本时退化为普通粘贴。
-- **测试**：三平台 CI 需覆盖图片粘贴与 PDF 解析（现有 `.github` 有 CI 可扩展）。
+### Recommended Combination (Simplified, finalized 2026-08-04)
+- **Default flow**: Extract all text (with page numbers) into context.
+- **Supplementary flow**: User decides they need to see images → user requests rendering specific pages (or currently open PDF page) → Approach B converts to image and sends to LLM.
+- No LLM page selection / auto-conversion logic, keeping implementation simple.
+
+### Execution Location
+- Libraries installed in the venv from `setup_plugin.sh/.bat/.ps1` (`pymupdf`, `pdfplumber`).
+- Plugin side runs the extraction script as a subprocess via a mechanism similar to `server_manager`, to avoid polluting KiCad's embedded Python.
+
+### Cross-Platform
+- `pymupdf` / `pdfplumber` / `pypdf` all support Linux / macOS / Windows (PyMuPDF provides wheels for all three platforms).
 
 ---
 
-## 最终方案与目标（2026-08-05 定稿）
+## Suggested Implementation Order
 
-### 目标
-为 kicad_plugin（KiCad AI Assistant 插件）增加两项能力，支持 Linux / Windows / macOS：
-1. 用户上传/粘贴图片给 LLM 看（含 Ctrl+V 粘贴系统截图）
-2. 解析 PDF 文档
+1. Image upload/paste (Section 1) — Establish multimodal message format, reused by PDF. ✅ Complete
+2. PDF parsing (Section 2) — Main path uses Approach A (extract text with page numbers); supplementary uses Approach B (user-specified page to image). Depends on venv and subprocess mechanism.
 
-> 截图不单独做插件内实现：用户自行截图后 Ctrl+V 粘贴到聊天框。
+## Risks / Notes
 
-### 最终方案
+- **Tokens and Timeout**: Images/multi-page PDFs significantly increase input size; need to limit size and page count (e.g., max first N pages).
+- **Vision Model Support**: Need to prompt in settings that the selected model must support image input.
+- **Clipboard Format**: Ctrl+V depends on system clipboard bitmap format (wx.DF_BITMAP); X11/Wayland/Windows/macOS need verification; when clipboard only has text, falls back to normal paste.
+- **Testing**: Three-platform CI needs to cover image paste and PDF parsing (existing `.github` has CI that can be extended).
 
-| 能力 | 方案 | 说明 |
+---
+
+## Final Plan and Goals (Finalized 2026-08-05)
+
+### Goals
+Add two capabilities to kicad_plugin (KiCad AI Assistant plugin), supporting Linux / Windows / macOS:
+1. Users upload/paste images for LLM to see (including Ctrl+V pasting system screenshots)
+2. Parse PDF documents
+
+> Screenshots are not implemented inside the plugin: users take screenshots themselves and Ctrl+V paste into the chat box.
+
+### Final Plan
+
+| Capability | Approach | Description |
 |---|---|---|
-| 图片上传 | **已实现**（2026-08-04） | 面板加"添加图片/粘贴"按钮，缩略图条，Ctrl+V 智能粘贴（剪贴板有 bitmap 时粘贴为图片，否则粘贴文本）；压缩 ≤1024px → base64；OpenAI/Anthropic/Ollama 三 provider 格式转换；会话保存剥离 base64 |
-| 截图（schematic/PCB） | 不实现插件内抓取 | 用户系统截图 → Ctrl+V 粘贴 → 复用图片链路 |
-| PDF 解析 | **主路径**：全量抽文本（带页码 `[P3]`）入上下文；**补充**：用户判断信息不足时要求渲染指定页转图 | 不做 LLM 选页/自动转图，保持简单 |
+| Image Upload | **Implemented** (2026-08-04) | Panel has "Add Image/Paste" button, thumbnail bar, Ctrl+V smart paste (pastes as image when clipboard has bitmap, otherwise pastes text); compress ≤1024px → base64; OpenAI/Anthropic/Ollama three-provider format conversion; session save strips base64 |
+| Screenshot (schematic/PCB) | Not implemented in plugin | User takes system screenshot → Ctrl+V paste → reuses image pipeline |
+| PDF Parsing | **Main path**: extract all text (with page numbers `[P3]`) into context; **Supplementary**: user requests rendering specific pages to image when text is insufficient | No LLM page selection / auto-conversion, keeping it simple |
 
-### 迭代路径（先落地，看效果再增强）
-1. **PDF v1**：只做"抽文本带页码"（PyMuPDF，venv 子进程）。验证文本抽取对 datasheet 的可用性。
-2. **PDF v2**（视 v1 效果）：用户指定页转图 → 复用图片注入链路。
-3. **PDF v3**（可选）：若文本乱/图表多，再考虑 qwen3.8-max 原生 PDF 理解（方案 C）或 LLM 选页（见「暂不考虑」章节）。
+### Iteration Path (Land first, enhance based on results)
+1. **PDF v1**: Only "extract text with page numbers" (PyMuPDF, venv subprocess). Validate text extraction usability for datasheets.
+2. **PDF v2** (depending on v1 results): User-specified page to image → reuse image injection pipeline.
+3. **PDF v3** (optional): If text is messy/chart-heavy, consider qwen3.8-max native PDF understanding (Approach C) or LLM page selection (see "Not Considered" section).
 
-### 已完成的代码改动（ideas 分支）
-- `kicad_plugin/llm_client.py`：`run()` 支持 `images` 参数；OpenAI 数组格式 + Anthropic/Ollama 转换；`_maybe_compact` 兼容数组 content。
-- `kicad_plugin/ui/panel.py`：附件 UI（添加/粘贴/缩略图/清空）；Ctrl+V 智能粘贴；压缩编码；会话保存剥离图片。
-- 44 个 `test_llm_client` 单元测试通过；ruff lint/format 通过。
+### Completed Code Changes (ideas branch)
+- `kicad_plugin/llm_client.py`: `run()` supports `images` parameter; OpenAI array format + Anthropic/Ollama conversion; `_maybe_compact` compatible with array content.
+- `kicad_plugin/ui/panel.py`: Attachment UI (add/paste/thumbnail/clear); Ctrl+V smart paste; compression encoding; session save strips images.
+- 44 `test_llm_client` unit tests pass; ruff lint/format pass.
 
 ---
 
-## 暂不考虑（2026-08-05）
+## Not Considered (2026-08-05)
 
-以下能力经研究后决定暂不实现，保留研究结论供后续参考。
+The following capabilities were researched but decided not to implement. Research conclusions are retained for future reference.
 
-### N1. 插件内 schematic / PCB 截图
+### N1. In-Plugin Schematic / PCB Screenshot
 
-#### 方案 A：wx 屏幕抓取（仅限 PCB editor 实时取景）
-- 插件在 KiCad GUI 内运行，用 `wx.ScreenDC` + `wx.MemoryDC` + `wx.Bitmap` 抓取当前编辑器画布区域：
+#### Approach A: wx Screen Capture (PCB editor only, real-time)
+- The plugin runs inside the KiCad GUI, use `wx.ScreenDC` + `wx.MemoryDC` + `wx.Bitmap` to capture the current editor canvas area:
   ```python
   dc = wx.ScreenDC()
   bmp = wx.Bitmap(w, h)
@@ -133,70 +133,70 @@ KiCad GUI (wxPython)
   mem.SelectObject(wx.NullBitmap)
   bmp.ConvertToImage().SaveFile(path, wx.BITMAP_TYPE_PNG)
   ```
-- 原理：`wx.ScreenDC` 走 OS 层 API 抓屏幕像素（X11 `XGetImage` / Windows `BitBlt` / macOS `CGWindowListCreateImage`），**抓取与窗口属于哪个进程无关**。
+- Principle: `wx.ScreenDC` uses OS-level API to capture screen pixels (X11 `XGetImage` / Windows `BitBlt` / macOS `CGWindowListCreateImage`), **capture works regardless of which process the window belongs to**.
 
-#### ⚠️ 难点（2026-08-04 研究结论）
-- **插件只运行在 PCB editor 进程**：`kicad_plugin/__init__.py` 中 `_ActionPluginBase = pcbnew.ActionPlugin`。
-- **KiCad 的 schematic editor（eeschema）是独立进程**：`wx.GetTopLevelWindows()` 只能枚举**本进程**窗口 → **Python 端从物理上拿不到 schematic editor 的 wx 对象**（不是难，是跨进程不可达）。
-- 要抓 schematic 窗口必须跨进程查窗口坐标：Windows `EnumWindows` / X11 `xwininfo` / macOS `CGWindowListCopyWindowInfo`，三平台实现各异、维护成本高。
-- **结论：方案 A 只对 PCB editor 可行（同进程拿 `GetScreenPosition()`）；schematic 实时截图改走方案 B。**
-- 另：Linux **Wayland** 下 `wx.ScreenDC` 抓屏受限（X11 正常），需验证。
+#### ⚠️ Challenges (2026-08-04 research conclusion)
+- **Plugin only runs in PCB editor process**: `kicad_plugin/__init__.py` has `_ActionPluginBase = pcbnew.ActionPlugin`.
+- **KiCad's schematic editor (eeschema) is a separate process**: `wx.GetTopLevelWindows()` can only enumerate **current process** windows → **Python side physically cannot access schematic editor's wx objects** (not difficult, just cross-process unreachable).
+- To capture schematic windows, must query window coordinates across processes: Windows `EnumWindows` / X11 `xwininfo` / macOS `CGWindowListCopyWindowInfo`, implementations differ across platforms, high maintenance cost.
+- **Conclusion: Approach A only works for PCB editor (same process, can get `GetScreenPosition()`); schematic real-time screenshot uses Approach B.**
+- Also: Linux **Wayland** has limited `wx.ScreenDC` screen capture (X11 works fine), needs verification.
 
-#### 方案 B：kicad-cli 导出
-- 不走 KiCad GUI，用独立进程 `kicad-cli` 导出文件 → **无跨进程问题、无 GUI 依赖**。
-- PCB：`kicad-cli pcb export svg --output out.svg board.kicad_pcb`（KiCad 7+）。
-- Schematic：`kicad-cli sch export svg --output out.svg sheet.kicad_sch`（KiCad 7+，`--recursive` 可导出层级子图）。
+#### Approach B: kicad-cli Export
+- Instead of going through KiCad GUI, use a separate process `kicad-cli` to export files → **no cross-process issue, no GUI dependency**.
+- PCB: `kicad-cli pcb export svg --output out.svg board.kicad_pcb` (KiCad 7+).
+- Schematic: `kicad-cli sch export svg --output out.svg sheet.kicad_sch` (KiCad 7+, `--recursive` can export hierarchical sub-sheets).
 
-#### ✅ 可行性（2026-08-04 研究结论：链路大半已存在）
-- **PCB 链路已实现**：`kcaa/tools/export_tools.py` 的 `generate_thumbnail_with_cli` 已用 `kicad-cli pcb export svg` 生成 PCB 图并返回给 LLM（fastmcp `Image`）。
-- **kicad-cli 查找已封装**：`kcaa/utils/kicad_cli.py`（三平台路径检测 + 缓存 + `KICAD_CLI_PATH` 环境变量）；安全子进程封装在 `kcaa/utils/secure_subprocess.py`。
-- **schematic 子命令已验证**：`kcaa/tools/bom_tools.py` 已用 `kicad-cli sch export bom` → sch 链路可用。
-- 测试夹具齐全：`tests/**/fixtures/` 下有 `.kicad_pcb` / `.kicad_sch`，可在有 KiCad 的环境写集成测试。
+#### ✅ Feasibility (2026-08-04 research conclusion: most of the pipeline already exists)
+- **PCB pipeline implemented**: `kcaa/tools/export_tools.py`'s `generate_thumbnail_with_cli` already uses `kicad-cli pcb export svg` to generate PCB image and return to LLM (fastmcp `Image`).
+- **kicad-cli lookup encapsulated**: `kcaa/utils/kicad_cli.py` (three-platform path detection + caching + `KICAD_CLI_PATH` environment variable); secure subprocess wrapper in `kcaa/utils/secure_subprocess.py`.
+- **Schematic subcommand verified**: `kcaa/tools/bom_tools.py` already uses `kicad-cli sch export bom` → sch pipeline works.
+- Test fixtures available: `tests/**/fixtures/` has `.kicad_pcb` / `.kicad_sch`, can write integration tests in environments with KiCad.
 
-#### ⚠️ 难点
-- **kicad-cli 不直接输出 PNG**（`pcb/sch export` 只支持 svg/pdf/dxf 等）。**SVG 不是 vision 模型原生支持的格式**（OpenAI/Anthropic/Ollama 只收 png/jpeg/webp/gif）→ 必须转换：Pillow（纯 wheel）或 cairosvg（native cairo）。
-- **现有 `generate_thumbnail_with_cli` 直接返回 `format="svg"`，LLM 侧可能拒收** → 需补 SVG→PNG 转换步骤。
-- 实时性差：导出的是整板/整图，不是当前视图（"当前视图"仍要靠方案 A，仅 PCB）。
-- 本机（2026-08-04）无 kicad-cli，尚未实测运行；需在有 KiCad 环境验证 `sch export svg` 与转换链路。
+#### ⚠️ Challenges
+- **kicad-cli does not directly output PNG** (`pcb/sch export` only supports svg/pdf/dxf, etc.). **SVG is not a format natively supported by vision models** (OpenAI/Anthropic/Ollama only accept png/jpeg/webp/gif) → must convert: Pillow (pure wheel) or cairosvg (native cairo).
+- **Existing `generate_thumbnail_with_cli` directly returns `format="svg"`, LLM side may reject** → need to add SVG→PNG conversion step.
+- Poor real-time: exports the entire board/sheet, not the current view ("current view" still requires Approach A, PCB only).
+- Local machine (2026-08-04) has no kicad-cli, not yet tested; need to verify `sch export svg` and conversion pipeline in an environment with KiCad.
 
-#### 暂不考虑原因
-- 方案 A 跨进程不可行（schematic）；方案 B 需额外维护 SVG→PNG 转换，性价比低。
-- **替代路径**：用户用系统截图工具截取 schematic / PCB 画面 → 在插件输入框 **Ctrl+V** 粘贴 → 走第 1 节图片注入链路发给 LLM。该功能已在第 1 节的图片粘贴实现中覆盖。
+#### Reason for Not Considering
+- Approach A is cross-process infeasible (schematic); Approach B requires additional SVG→PNG conversion maintenance, low cost-effectiveness.
+- **Alternative path**: User uses system screenshot tool to capture schematic / PCB screen → **Ctrl+V** paste in plugin input box → goes through Section 1 image injection pipeline to send to LLM. This functionality is already covered by the image paste implementation in Section 1.
 
-### N2. PDF 方案 C：百炼 + qwen3.8-max 原生 PDF 理解
+### N2. PDF Approach C: Bailian + qwen3.8-max Native PDF Understanding
 
-- **qwen3.8-max 原生支持 PDF**（2026-08-04 官方文档确认，`https://help.aliyun.com/zh/model-studio/pdf-understanding`），走 OpenAI 兼容接口，content 数组加 `type: "file"` 块：
+- **qwen3.8-max natively supports PDF** (2026-08-04 official documentation confirmed, `https://help.aliyun.com/zh/model-studio/pdf-understanding`), uses OpenAI-compatible interface, content array adds `type: "file"` block:
   ```json
-  {"type": "file", "file": {"file_url": "https://.../doc.pdf"}}            // URL，二选一
-  // 或 Base64：
-  {"type": "file", "file": {"file_data": "data:application/pdf;base64,xxx", "filename": "report.pdf"}}  // file_data 时 filename 必填
+  {"type": "file", "file": {"file_url": "https://.../doc.pdf"}}            // URL, either/or
+  // Or Base64:
+  {"type": "file", "file": {"file_data": "data:application/pdf;base64,xxx", "filename": "report.pdf"}}  // filename required when using file_data
   ```
-- **限制**：单文件 ≤150MB、≤500 页；首包超时最长 300s（建议流式）；**仅华北 2（北京）地域**；不支持 Responses API。
-- **计费**（两段流水线）：
-  1. 文档解析费：0.02 元/页（平台先做版面分析/OCR，拆成文字 + 图片）；
-  2. 模型调用费：解析出的**文字按文本 token、图片按图片 token** 计入输入，按模型标准输入价计费。
-- **优点**：不用在插件里装 PyMuPDF/pdfplumber 做预处理；文字走文本 token（便宜）、仅图表走图片 token。
-- **缺点**：非通用能力（仅百炼华北2 + qwen3.8-max）；base_url 需带 WorkspaceId（`https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`）。
+- **Limitations**: Single file ≤150MB, ≤500 pages; first packet timeout up to 300s (streaming recommended); **only North China 2 (Beijing) region**; does not support Responses API.
+- **Billing** (two-stage pipeline):
+  1. Document parsing fee: ¥0.02/page (platform first does layout analysis/OCR, splits into text + images);
+  2. Model call fee: parsed **text charged as text tokens, images as image tokens** for input, billed at model's standard input price.
+- **Pros**: No need to install PyMuPDF/pdfplumber in the plugin for preprocessing; text goes through text tokens (cheaper), only charts go through image tokens.
+- **Cons**: Not a universal capability (only Bailian North China 2 + qwen3.8-max); base_url needs WorkspaceId (`https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`).
 
-#### 暂不考虑原因
-- 非通用能力，仅百炼华北2 + qwen3.8-max；先走通用方案 A+B，视效果再考虑。
+#### Reason for Not Considering
+- Not a universal capability, only Bailian North China 2 + qwen3.8-max; first use universal Approach A+B, consider based on results.
 
-### N3. PDF 图文拆分的对应关系问题
+### N3. PDF Image-Text Split Correspondence Issue
 
-- 方案 C / 方案 A+B 把文字与图片拆开，**页面内图文相对位置丢失**（模型不知道图片A和文字B在页面上谁在上谁在下）。
-- **保留的**：页序、图注/标题文字（caption 是文字，跟着文字流走）。
-- **影响分场景**：文字为主（报告/论文）影响小；图文强耦合（datasheet 原理图+引脚表+时序图）影响中等 —— 但图片内部信息（引脚名、数值）模型可自读，不依赖坐标对应，且图注可交叉验证。
-- **强版面场景**：用方案 B 整页转图保真，代价是全页按图片 token 计费（更贵）。
+- Approach C / Approach A+B split text and images, **intra-page image-text relative position is lost** (the model doesn't know whether image A or text B is above/below on the page).
+- **Preserved**: page order, caption/title text (captions are text, follow the text flow).
+- **Impact by scenario**: Text-heavy (reports/papers) minimal impact; strong image-text coupling (datasheet schematics + pin tables + timing diagrams) moderate impact — but image internal information (pin names, values) can be read by the model itself, doesn't depend on coordinate correspondence, and captions can cross-validate.
+- **Strong layout scenarios**: Use Approach B full-page-to-image for fidelity, at the cost of full-page image token billing (more expensive).
 
-#### 暂不考虑原因
-- 先落地方案 A（抽文本带页码），看实际效果再决定是否需要整页转图保真。
+#### Reason for Not Considering
+- First implement Approach A (extract text with page numbers), see actual results before deciding whether full-page-to-image fidelity is needed.
 
-### N4. PDF 成本对比与图片 token 算法
+### N4. PDF Cost Comparison and Image Token Calculation
 
-| 方案 | 解析成本 | 输入 token 成本 | 通用性 |
+| Approach | Parsing Cost | Input Token Cost | Universality |
 |---|---|---|---|
-| 百炼原生 PDF（方案 C） | 0.02 元/页 | 文字按文本、图表按图片 token | 仅华北2 + qwen3.8-max |
-| 本地转图（方案 B） | 0（本地渲染） | 全页按图片 token（贵） | 任何 vision 模型 |
-| 本地抽文本（方案 A） | 0 | 仅文本 token（最便宜，但丢图表） | 任何模型 |
-- 图片 token 算法（百炼视觉模型）：**每张 ≈ ⌈h×w/1024⌉ + 2**（1024×1024 ≈ 1026 token，线性增长）。
-- 图文混合文档用方案 C 更划算；纯图 PDF 方案 B/C 成本接近。
+| Bailian native PDF (Approach C) | ¥0.02/page | Text as text tokens, charts as image tokens | Only North China 2 + qwen3.8-max |
+| Local image conversion (Approach B) | 0 (local rendering) | Full page as image tokens (expensive) | Any vision model |
+| Local text extraction (Approach A) | 0 | Text tokens only (cheapest, but loses charts) | Any model |
+- Image token calculation (Bailian vision model): **per image ≈ ⌈h×w/1024⌉ + 2** (1024×1024 ≈ 1026 tokens, linear growth).
+- Mixed image-text documents are more cost-effective with Approach C; pure-image PDFs have similar cost for Approach B/C.


### PR DESCRIPTION
## Summary

This PR adds multimodal support (image upload + PDF text extraction) to the KiCad AI Assistant plugin, along with UI improvements and vision pipeline logging.

### Commits

1. **docs: add kicad-plugin-enhancement plan for multimodal support**
2. **potential ideas** — brainstorm notes
3. **feat(plugin): add image upload/paste and vision model toggle**
   - Image attachment via file dialog and Ctrl+V clipboard paste
   - `llm_supports_vision` setting in Settings dialog
   - Base64 encoding with ≤1024px resize in `_encode_attached_images`
   - Multimodal content building in `llm_client.py` (`_build_user_content`, `_anthropic_content`, `_ollama_messages`)
4. **feat(plugin): add PDF text extraction with page numbers (v1)**
   - `pdf_extractor.py` — subprocess-based extraction with PyMuPDF, page-number prefixes
   - Clean env allowlist to avoid KiCad AppImage `PYTHONHOME`/`PYTHONPATH` breaking the venv
5. **refactor(plugin): streamline chat input row UI**
   - Merged attach/send/stop buttons, send/stop toggle
   - Status dot indicator (colour-coded)
   - Icon backgrounds fixed on GTK (wx.Image pixel fill)
6. **feat(plugin): unified file attachments, drag-drop, PDF collapsible display, vision pipeline logging**
   - Unified `_attached_files` list (images + PDFs) with thumbnail/icon display
   - Drag-and-drop support for images and PDFs onto the input box
   - WebView navigation block (prevents dropped files from opening)
   - PDF text extracted at send time in background thread, stored as collapsible `<details>` block
   - Attachment bar layout fix: `Show/Hide` sizer item, deferred `Layout()` via `wx.CallAfter`
   - Logging across vision pipeline (attach, encode, send, content build, provider conversions)

## Files changed
| File | Description |
|------|-------------|
| `kicad_plugin/ui/panel.py` | Main UI: attachments, drag-drop, send flow, PDF extraction, layout, icons |
| `kicad_plugin/ui/shell.js` | `_pdfTextsHtml` — collapsible PDF text display in chat |
| `kicad_plugin/ui/settings_dialog.py` | Vision model toggle checkbox |
| `kicad_plugin/llm_client.py` | Multimodal content building, Ollama image support, vision pipeline logging |
| `kicad_plugin/pdf_extractor.py` | PDF text extraction subprocess (PyMuPDF, page numbers) |
| `kicad_plugin/settings.py` | `llm_supports_vision` setting |
| `kicad_plugin/setup_plugin.sh` / `.ps1` | PyMuPDF dependency in venv setup |
| `plans/kicad-plugin-enhancement.md` | Design plan document |

## Test plan
- [x] Attach image via 📎 button → thumbnail appears in bar
- [x] Attach PDF via 📎 button → PDF icon appears in bar
- [x] Drag image onto input box → thumbnail appears
- [x] Drag PDF onto input box → PDF icon appears
- [x] Drag file onto chat area → file is NOT opened (navigation blocked)
- [x] Ctrl+V paste image from clipboard → thumbnail appears
- [x] Send message with image+PDF → PDF text extracted in background, collapsible block appears in chat
- [x] Expand/collapse PDF text block in chat history
- [x] Click clear button → attachment bar collapses
- [x] Send message → attachment bar collapses after send
- [x] Toggle "Model supports vision" in Settings → blocked when off + images attached
- [x] Check logs for vision pipeline trace (`_on_attach`, `_encode_attached_images`, `_on_send`, `_build_user_content`, `_call_llm`)
- [ ] Ollama provider: verify image attachments are sent via `images` field