### PR TITLE
fix(plugin): harden OpenAI-compatible HTTPS handling

### DIFF
--- a/kicad_plugin/README.md
+++ b/kicad_plugin/README.md
@@ -67,7 +67,7 @@ cd "$env:APPDATA\kicad\10.0\scripting\plugins\kicad_ai_plugin"
 2. In the PCB editor or schematic editor, go to **Tools → External Plugins → Refresh Plugins**
 3. The **KiCad AI Assistant** plugin will appear in the plugin list
 4. Click it to open the chat panel
-5. Enter your LLM API key in **Options → Settings**
+5. Enter your LLM API key in **Options → Settings** if your endpoint requires one
 
 ## Configuration
 
@@ -79,9 +79,9 @@ Settings are stored in the KiCad user config directory:
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `llm_provider` | `openai`, `anthropic`, or `ollama` | `openai` |
-| `llm_api_key` | Your LLM API key | (empty) |
+| `llm_api_key` | API key; optional for compatible endpoints without authentication | (empty) |
 | `llm_model` | Model name | `gpt-4o` |
-| `llm_base_url` | Ollama endpoint URL (e.g. http://localhost:11434) | (uses provider default) |
+| `llm_base_url` | Custom OpenAI, Anthropic, or Ollama-compatible endpoint URL | (uses provider default) |
 | `server_port` | Fixed port for MCP server (0 = auto) | `0` |
 | `show_tool_log` | Show tool-call log by default | `true` |
 

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -211,6 +211,59 @@ _in_process_ssl: bool | None = None
 _current_reasoning: list[str] = []
 
 
+def _is_certificate_verification_error(error: BaseException) -> bool:
+    """Return whether *error* was caused by an untrusted certificate chain."""
+    reason = getattr(error, "reason", error)
+    try:
+        import ssl
+
+        if isinstance(reason, ssl.SSLCertVerificationError):
+            return True
+    except ImportError:
+        pass
+    return "certificate verify failed" in str(reason).lower()
+
+
+def _needs_https_fallback(error: BaseException) -> bool:
+    """Return whether HTTPS should be retried with the plugin venv Python."""
+    reason = getattr(error, "reason", error)
+    return _NO_HTTPS_MARKER in str(reason) or _is_certificate_verification_error(error)
+
+
+def _plugin_ssl_context():
+    """Build an SSL context from the certifi bundle installed in the plugin venv."""
+    try:
+        import ssl
+
+        venv_dir = Path(__file__).resolve().parent / ".venv"
+        candidates = [venv_dir / "Lib" / "site-packages" / "certifi" / "cacert.pem"]
+        candidates.extend(venv_dir.glob("lib/python*/site-packages/certifi/cacert.pem"))
+        for ca_bundle in candidates:
+            if ca_bundle.is_file():
+                return ssl.create_default_context(cafile=str(ca_bundle))
+    except (ImportError, OSError):
+        pass
+    return None
+
+
+def _urlopen_with_plugin_ca_retry(request, timeout: float):
+    """Open a URL, retrying certificate failures with the plugin's CA bundle."""
+    import urllib.error
+    import urllib.request
+
+    try:
+        return urllib.request.urlopen(request, timeout=timeout)  # nosec B310 -- user-configured LLM endpoint
+    except urllib.error.URLError as error:
+        if not _is_certificate_verification_error(error):
+            raise
+        context = _plugin_ssl_context()
+        if context is None:
+            raise
+        return urllib.request.urlopen(  # nosec B310 -- user-configured LLM endpoint
+            request, timeout=timeout, context=context
+        )
+
+
 def _resolve_plugin_python() -> str | None:
     """Return the path to the plugin venv's Python, or None if absent."""
     plugin_dir = os.path.dirname(os.path.abspath(__file__))
@@ -472,14 +525,14 @@ def _https_post_json(
     if _in_process_ssl is not False:
         req = urllib.request.Request(url, data=body, headers=headers, method="POST")
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310 -- MCP client, localhost only
+            with _urlopen_with_plugin_ca_retry(req, timeout=timeout) as resp:
                 _in_process_ssl = True
                 return resp.status, resp.read().decode("utf-8", "replace")
         except urllib.error.HTTPError as e:
             _in_process_ssl = True
             return e.code, e.read().decode("utf-8", "replace")
         except urllib.error.URLError as e:
-            if _NO_HTTPS_MARKER not in str(e.reason):
+            if not _needs_https_fallback(e):
                 raise RuntimeError(f"HTTPS request failed: {e}") from e
             _in_process_ssl = False
             # Fall through to subprocess fallback below.
@@ -1912,15 +1965,12 @@ class LLMClient:
                 "stream": True,
             }
         ).encode()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self._settings.llm_api_key}",
-        }
+        headers = self._openai_headers()
 
         if _in_process_ssl is not False:
             req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
             try:
-                with urllib.request.urlopen(req, timeout=300) as resp:  # nosec B310 -- MCP client, localhost only
+                with _urlopen_with_plugin_ca_retry(req, timeout=300) as resp:
                     _in_process_ssl = True
                     text_parts = []
                     tool_calls_by_index: dict[int, dict] = {}
@@ -1985,7 +2035,7 @@ class LLMClient:
                     return {"finish_reason": finish_reason, "message": message}
 
             except urllib.error.URLError as e:
-                if _NO_HTTPS_MARKER not in str(e.reason):
+                if not _needs_https_fallback(e):
                     return {"error": f"HTTPS request failed: {e}"}
                 _in_process_ssl = False
                 # Fall through to subprocess streaming below.
@@ -2161,7 +2211,7 @@ class LLMClient:
         if _in_process_ssl is not False:
             req = urllib.request.Request(url, data=encoded, headers=headers, method="POST")
             try:
-                with urllib.request.urlopen(req, timeout=300) as resp:  # nosec B310 -- MCP client, localhost only
+                with _urlopen_with_plugin_ca_retry(req, timeout=300) as resp:
                     _in_process_ssl = True
                     text_blocks: dict[int, str] = {}
                     tool_blocks: dict[int, dict] = {}
@@ -2255,7 +2305,7 @@ class LLMClient:
                     return {"finish_reason": finish, "message": message_out}
 
             except urllib.error.URLError as e:
-                if _NO_HTTPS_MARKER not in str(e.reason):
+                if not _needs_https_fallback(e):
                     return {"error": f"HTTPS request failed: {e}"}
                 _in_process_ssl = False
                 # Fall through to subprocess streaming below.
@@ -2266,6 +2316,13 @@ class LLMClient:
         return _subprocess_sse_stream(
             url, headers, encoded, timeout=300, fmt="anthropic", on_text_delta=on_text_delta
         )
+
+    def _openai_headers(self) -> dict[str, str]:
+        """Build headers for OpenAI-compatible endpoints with optional auth."""
+        headers = {"Content-Type": "application/json"}
+        if self._settings.llm_api_key:
+            headers["Authorization"] = f"Bearer {self._settings.llm_api_key}"
+        return headers
 
     def _call_openai(self, system: str, tools: list[dict]) -> dict[str, Any]:
         base = (self._settings.llm_base_url or "https://api.openai.com").rstrip("/")
@@ -2287,10 +2344,7 @@ class LLMClient:
         if self._max_tokens > 0:
             payload_dict["max_tokens"] = self._max_tokens
         payload = json.dumps(payload_dict).encode()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self._settings.llm_api_key}",
-        }
+        headers = self._openai_headers()
         try:
             status, text = _https_post_json(url, headers, payload, timeout=300)
         except RuntimeError as e:

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -3,13 +3,16 @@
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
+import ssl
 import sys
 import threading
 import types
 from unittest.mock import MagicMock, patch
+import urllib.error
 
 import pytest
 
+from kicad_plugin import llm_client
 from kicad_plugin.llm_client import LLMClient, _subprocess_sse_stream
 from kicad_plugin.tool_registry import TOOL_POLICIES
 
@@ -927,6 +930,116 @@ class TestToolPolicyRegistry:
 
 
 # ---------------------------------------------------------------------------
+# OpenAI-compatible endpoint and HTTPS fallback tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAICompatibleRequests:
+    def test_custom_base_url_remains_available_on_openai_provider(self):
+        client = _make_client()
+        client._settings.llm_base_url = "https://gateway.example/v1"
+        response = json.dumps(
+            {"choices": [{"finish_reason": "stop", "message": {"content": "ok"}}]}
+        )
+
+        with patch(
+            "kicad_plugin.llm_client._https_post_json", return_value=(200, response)
+        ) as post:
+            client._call_openai("system", [])
+
+        assert post.call_args.args[0] == "https://gateway.example/v1/chat/completions"
+
+    def test_custom_base_url_remains_available_on_anthropic_provider(self):
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        client._settings.llm_base_url = "https://gateway.example/anthropic"
+        response = json.dumps(
+            {"content": [{"type": "text", "text": "ok"}], "stop_reason": "end_turn"}
+        )
+
+        with patch(
+            "kicad_plugin.llm_client._https_post_json", return_value=(200, response)
+        ) as post:
+            client._call_anthropic("system", [])
+
+        assert post.call_args.args[0] == "https://gateway.example/anthropic/v1/messages"
+
+    def test_api_key_adds_bearer_authorization(self):
+        client = _make_client()
+
+        assert client._openai_headers() == {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer sk-test",
+        }
+
+    def test_empty_api_key_omits_authorization(self):
+        client = _make_client()
+        client._settings.llm_api_key = ""
+
+        assert client._openai_headers() == {"Content-Type": "application/json"}
+
+
+class TestHttpsFallback:
+    def test_certificate_error_retries_with_plugin_ca_bundle(self):
+        certificate_error = ssl.SSLCertVerificationError(
+            1, "unable to get local issuer certificate"
+        )
+        response = MagicMock(status=200)
+        response.read.return_value = b"ok"
+        response.__enter__.return_value = response
+        plugin_context = object()
+
+        with (
+            patch.object(llm_client, "_in_process_ssl", None),
+            patch(
+                "urllib.request.urlopen",
+                side_effect=[urllib.error.URLError(certificate_error), response],
+            ) as urlopen,
+            patch.object(llm_client, "_plugin_ssl_context", return_value=plugin_context),
+        ):
+            result = llm_client._https_post_json(
+                "https://gateway.example/v1/chat/completions",
+                {"Content-Type": "application/json"},
+                b"{}",
+                timeout=30,
+            )
+
+        assert result == (200, "ok")
+        assert urlopen.call_count == 2
+        assert urlopen.call_args_list[1].kwargs["context"] is plugin_context
+
+    def test_certificate_error_without_ca_bundle_uses_plugin_venv(self):
+        certificate_error = ssl.SSLCertVerificationError(
+            1, "unable to get local issuer certificate"
+        )
+        process = types.SimpleNamespace(
+            returncode=0,
+            stdout=b'{"status": 200, "body": "ok"}',
+            stderr=b"",
+        )
+
+        with (
+            patch.object(llm_client, "_in_process_ssl", None),
+            patch(
+                "urllib.request.urlopen",
+                side_effect=urllib.error.URLError(certificate_error),
+            ),
+            patch.object(llm_client, "_plugin_ssl_context", return_value=None),
+            patch.object(llm_client, "_resolve_plugin_python", return_value="/tmp/python"),
+            patch.object(llm_client.subprocess, "run", return_value=process) as run,
+        ):
+            result = llm_client._https_post_json(
+                "https://gateway.example/v1/chat/completions",
+                {"Content-Type": "application/json"},
+                b"{}",
+                timeout=30,
+            )
+
+        assert result == (200, "ok")
+        run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # Streaming tests
 # ---------------------------------------------------------------------------
 
@@ -1039,9 +1152,14 @@ class TestStreaming:
         assert args == {"path": "sch.kicad_sch"}
         assert result["finish_reason"] == "tool_calls"
 
-    def test_stream_openai_ssl_fallback_streams_via_subprocess(self):
-        import urllib.error
-
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "unknown url type: https",
+            ssl.SSLCertVerificationError(1, "unable to get local issuer certificate"),
+        ],
+    )
+    def test_stream_openai_ssl_fallback_streams_via_subprocess(self, reason):
         client = _make_client()
         chunks = []
 
@@ -1053,9 +1171,10 @@ class TestStreaming:
         with (
             patch(
                 "urllib.request.urlopen",
-                side_effect=urllib.error.URLError("unknown url type: https"),
+                side_effect=urllib.error.URLError(reason),
             ),
             patch("kicad_plugin.llm_client._in_process_ssl", None),
+            patch("kicad_plugin.llm_client._plugin_ssl_context", return_value=None),
             patch(
                 "kicad_plugin.llm_client._subprocess_sse_stream",
                 return_value=subprocess_result,


### PR DESCRIPTION
## Description

Improve the reliability of the existing OpenAI-compatible endpoint support without adding a separate provider.

- Preserve custom base URLs for the existing OpenAI and Anthropic providers
- Omit the OpenAI-compatible `Authorization` header when the API key is empty
- Retry certificate-verification failures with the certifi CA bundle from the plugin virtualenv
- Fall back to the plugin virtualenv Python when embedded Python cannot validate HTTPS certificates
- Preserve progressive streaming when the HTTPS subprocess fallback is used
- Clarify compatible endpoint and optional authentication behavior in the plugin documentation

## Maintainer feedback addressed

- Retargeted the PR from `main` to `develop`
- Removed the redundant `custom` provider introduced by the previous revision
- Kept the existing OpenAI/Anthropic custom endpoint behavior unchanged
- Rebuilt the change on the latest upstream `develop` branch

## Testing

- `1398 passed, 18 skipped`
- Plugin unit tests: `169 passed`
- Ruff lint and format checks passed
- Bandit security scan passed

## Type of change

- [x] Bug fix
- [x] Documentation update
- [x] Tests