### PR TITLE
fix(plugin): allow data: URL navigation in WebView2 shell load

### DIFF
--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -283,8 +283,16 @@ if _WX_AVAILABLE:
                     # Block navigation to any URL — prevents files (PDFs, images,
                     # etc.) dropped onto the WebView from being opened inside it.
                     # Only the shell page (loaded via SetPage) should ever display.
+                    #
+                    # NOTE (Windows): wx.html2.WebView.SetPage() triggers a
+                    # EVT_WEBVIEW_NAVIGATING with a `data:text/html;base64,...`
+                    # URL on WebView2.  Vetoing it would silently break the
+                    # shell load (EVT_WEBVIEW_LOADED never fires, JS never
+                    # executes).  Allow all `data:` URLs so SetPage works,
+                    # while still blocking external navigation.
                     def _on_navigating(event):
-                        if event.GetURL() not in ("", "about:blank"):
+                        url = event.GetURL()
+                        if url not in ("", "about:blank") and not url.startswith("data:"):
                             event.Veto()
 
                     self.Bind(


### PR DESCRIPTION
## Problem

Fixes #61

On Windows, `wx.html2.WebView.SetPage()` triggers `EVT_WEBVIEW_NAVIGATING` with a `data:text/html;base64,...` URL. The previous `_on_navigating` handler vetoed any URL other than `""` / `about:blank`, which blocked this internal navigation. As a result:

- `EVT_WEBVIEW_LOADED` never fired
- The shell HTML (and its JS) never loaded
- The chat panel stayed blank with "Shell loaded but JS not working" / WebView shell load timeout errors

Meanwhile, the veto was originally added to prevent **drag-dropped files** (PDFs, images, etc.) from being opened inside the WebView.

## Fix

Allow `data:` URLs through the navigation veto while still blocking external navigation (dropped files, links):

```python
def _on_navigating(event):
    url = event.GetURL()
    if url not in ("", "about:blank") and not url.startswith("data:"):
        event.Veto()
```

`SetPage()` is the only way the shell is ever loaded, so `data:` URLs can only come from internal calls — no external content is whitelisted by this change.

## Test

- Windows WebView2: chat panel shell loads, JS executes, no load timeout
- Drag-drop of files onto the WebView still vetoed