### PR TITLE
ci: skip PyPI publish when version unchanged; add PR requirements to docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,38 @@ permissions:
   contents: read
 
 jobs:
+  # Skip the build/publish when pyproject.toml version already exists on PyPI
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check version against PyPI
+      id: check
+      env:
+        PYPI_PACKAGE: kcaa
+      run: |
+        VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "([^"]+)"/\1/')
+        if [ -z "$VERSION" ]; then
+          echo "::error::Could not read version from pyproject.toml"
+          exit 1
+        fi
+        PYPI_VERSION=$(curl -fsSL "https://pypi.org/pypi/${PYPI_PACKAGE}/json" | python3 -c 'import json, sys; print(json.load(sys.stdin)["info"]["version"])' 2>/dev/null || echo "")
+        echo "Local version:  ${VERSION}"
+        echo "Published version: ${PYPI_VERSION:-<none>}"
+        if [ -n "$PYPI_VERSION" ] && [ "$VERSION" = "$PYPI_VERSION" ]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          echo "Version unchanged on PyPI, skipping publish."
+        else
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi
+
   build:
     runs-on: ubuntu-latest
+    needs: check-version
+    if: needs.check-version.outputs.skip != 'true'
     steps:
     - uses: actions/checkout@v4
 
@@ -37,6 +67,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
+    if: needs.check-version.outputs.skip != 'true'
     environment: pypi
     steps:
     - name: Download artifacts

--- a/README.md
+++ b/README.md
@@ -413,6 +413,12 @@ kcaa/
 3. Add your changes with tests
 4. Submit a pull request **against the `develop` branch**
 
+> **PR requirements:**
+> - One pull request should contain **only one** fix, enhancement, or
+>   feature. If you have multiple independent changes, please submit them
+>   as separate pull requests.
+> - Include tests for your changes.
+
 > **Branch policy:**
 > - The `develop` branch is where new features are stabilized — please
 >   submit your changes there first so they can be tested and reviewed.

--- a/README_CN.md
+++ b/README_CN.md
@@ -412,6 +412,10 @@ kcaa/
 3. 提交包含测试的修改
 4. 发起 Pull Request **指向 `develop` 分支**
 
+> **PR 要求：**
+> - 一个 Pull Request 只能包含**一个**修复（fix）、增强（enhancement）或功能（feature）。如果有多个独立的修改，请分别提交为多个 Pull Request。
+> - 修改需要包含测试。
+
 > **分支说明：**
 > - `develop` 分支用于稳定新特性——请先把修改通过 PR 提交到这里，经过测试和评审后再合入。
 > - `main` 分支用于发布版本，在测试通过后，从 `develop` 合并到 `main` 完成发布。


### PR DESCRIPTION
## Summary

- **`.github/workflows/publish.yml`**: only run the build/publish pipeline when the `pyproject.toml` version differs from the latest version already published on PyPI.
  - The workflow still triggers on `release: [published]` and `workflow_dispatch`.
  - A new `check-version` job compares the local version with PyPI (`pypi.org/pypi/kcaa/json`) and sets a `skip` output. `build` and `publish` now gate on it, so a release of the same version or a manual dispatch without a version bump does nothing.
- **`README.md` / `README_CN.md`**: add a PR requirements note stating that one PR should contain only one fix, enhancement, or feature, and that changes should include tests.

## Motivation

Previously every published release re-published the same version, wasting CI time and risking "file already exists" errors. Now the pipeline self-skips when nothing changed.

## Test plan

No Python code touched — docs + workflow YAML only. Pre-commit hooks ran clean (no Python files staged).