### PR TITLE
fix(router): model pin symbols as collision bodies with correct geometry

### DIFF
--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -684,10 +684,10 @@ import time as _time
 
 
 def _viz_dir() -> str:
-    """Return the viz dump directory under the kcaa data dir."""
+    """Return the PCB viz dump directory under the kcaa data dir kcaa_viz/pcb_viz."""
     from kcaa.utils.config import config
 
-    return _os.path.join(config.get_kcaa_data_dir(), "kcaa_viz")
+    return _os.path.join(config.get_kcaa_data_dir(), "kcaa_viz", "pcb_viz")
 
 
 def _dump_viz(

--- a/kcaa/tools/wire_edit_tools.py
+++ b/kcaa/tools/wire_edit_tools.py
@@ -4,9 +4,11 @@ Provides tools to draw, list, and delete wire segments and junction dots
 in KiCad schematics using the skip library.
 """
 
+import json
 import logging
 import math
 import os
+import time
 from typing import Any
 
 from fastmcp import Context, FastMCP
@@ -123,6 +125,33 @@ def _route_collides_at_corners(
                 if abs(cx - px) <= tol and abs(cy - py) <= tol:
                     return True
     return False
+
+
+def _route_check_failures(
+    segments: list[tuple[float, float, float, float]],
+    obstacles: list[tuple[float, float]],
+    existing_wires: list[tuple[float, float, float, float]],
+    sx: float,
+    sy: float,
+    ex: float,
+    ey: float,
+    tol: float,
+) -> list[str]:
+    """Return the list of checks that reject *segments*; empty list = pass.
+
+    Runs the same three gates used by ``_try_angle_config`` — pin on segment
+    interior, collinear overlap with existing wires, pin on a corner — and
+    reports which ones fail.  Kept as its own function so the visualisation
+    dump can record the exact rejection reason per candidate.
+    """
+    fails: list[str] = []
+    if _route_collides(segments, obstacles, tol):
+        fails.append("pin-on-interior")
+    if _route_overlaps_wires(segments, existing_wires, tol):
+        fails.append("wire-overlap")
+    if _route_collides_at_corners(segments, obstacles, tol, sx, sy, ex, ey):
+        fails.append("pin-at-corner")
+    return fails
 
 
 def _route_candidates(
@@ -497,6 +526,7 @@ def _try_angle_config(
     lead_out_dist: float,
     start_natural: float | None = None,
     end_natural: float | None = None,
+    diag: dict[str, Any] | None = None,
 ) -> _RouteConfig | None:
     """Try to find a valid route from (sx,sy) to (ex,ey) using the given
     lead-out angles sa (start) and ea (end).
@@ -524,6 +554,11 @@ def _try_angle_config(
     start_lead + chosen + end_lead always forms a continuous chain, which is
     required by _merge_collinear_segments.
 
+    diag: optional dict filled with leads outcome ("start_lead"/"end_lead":
+    ok | t-tap | opposite-natural | pin-blocked) and, per rejected candidate,
+    an entry in "rejected_candidates" with the segments and failing checks.
+    Only used by the visualisation dump; None disables the bookkeeping.
+
     Returns a _RouteConfig tuple on success, or None if no candidate inner
     route passes the collision / overlap checks.
     """
@@ -542,17 +577,25 @@ def _try_angle_config(
         if _route_overlaps_wires([seg], existing_wires, _PIN_COLLISION_TOL):
             p1x, p1y = _follow_wire_extent(sx, sy, sa, existing_wires, _PIN_COLLISION_TOL)
             start_suppressed = True
+            if diag is not None:
+                diag["start_lead"] = "t-tap"
         elif (
             start_natural is not None and abs((sa - (start_natural + 180.0) % 360.0) % 360.0) < 1e-9
         ):
+            if diag is not None:
+                diag["start_lead"] = "opposite-natural"
             return None  # lead goes into component body (opposite to natural exit)
         elif _route_collides([seg], obstacles, _PIN_COLLISION_TOL) or any(
             abs(p1x - ox) <= _PIN_COLLISION_TOL and abs(p1y - oy) <= _PIN_COLLISION_TOL
             for ox, oy in obstacles
         ):
+            if diag is not None:
+                diag["start_lead"] = "pin-blocked"
             return None  # direction blocked by a component pin
         else:
             start_lead = [seg]
+            if diag is not None:
+                diag["start_lead"] = "ok"
 
     # --- end lead ---
     if ea is not None:
@@ -569,34 +612,35 @@ def _try_angle_config(
         if _route_overlaps_wires([seg], existing_wires, _PIN_COLLISION_TOL):
             p2x, p2y = _follow_wire_extent(ex, ey, ea, existing_wires, _PIN_COLLISION_TOL)
             end_suppressed = True
+            if diag is not None:
+                diag["end_lead"] = "t-tap"
         elif end_natural is not None and abs((ea - (end_natural + 180.0) % 360.0) % 360.0) < 1e-9:
+            if diag is not None:
+                diag["end_lead"] = "opposite-natural"
             return None  # lead goes into component body (opposite to natural exit)
         elif _route_collides([seg], obstacles, _PIN_COLLISION_TOL) or any(
             abs(p2x - ox) <= _PIN_COLLISION_TOL and abs(p2y - oy) <= _PIN_COLLISION_TOL
             for ox, oy in obstacles
         ):
+            if diag is not None:
+                diag["end_lead"] = "pin-blocked"
             return None  # direction blocked by a component pin
         else:
             end_lead = [(p2x, p2y, ex, ey)]  # reversed: inner→pin
+            if diag is not None:
+                diag["end_lead"] = "ok"
 
     # Lead segments in canonical forward direction for collision checking
     lead_segs = start_lead + [(a, b, c, d) for (c, d, a, b) in end_lead]
 
     for candidate in _route_candidates(p1x, p1y, p2x, p2y):
         all_segs = lead_segs + candidate
-        if (
-            not _route_collides(all_segs, obstacles, _PIN_COLLISION_TOL)
-            and not _route_overlaps_wires(all_segs, existing_wires, _PIN_COLLISION_TOL)
-            and not _route_collides_at_corners(
-                all_segs,
-                obstacles,
-                _PIN_COLLISION_TOL,
-                sx,
-                sy,
-                ex,
-                ey,
-            )
-        ):
+        fails = _route_check_failures(
+            all_segs, obstacles, existing_wires, sx, sy, ex, ey, _PIN_COLLISION_TOL
+        )
+        if not fails:
+            if diag is not None:
+                diag["valid"] = True
             return (
                 start_lead,
                 end_lead,
@@ -608,7 +652,95 @@ def _try_angle_config(
                 start_suppressed,
                 end_suppressed,
             )
+        if diag is not None:
+            diag.setdefault("rejected_candidates", []).append(
+                {"segments": [list(s) for s in all_segs], "reasons": fails}
+            )
     return None
+
+
+# ---------------------------------------------------------------------------
+# Visualisation dump (schematic)
+# ---------------------------------------------------------------------------
+
+
+def _sch_viz_dir() -> str:
+    """Return the schematic viz dump directory under the kcaa data dir."""
+    from kcaa.utils.config import config
+
+    return os.path.join(config.get_kcaa_data_dir(), "kcaa_viz", "sch_viz")
+
+
+def _flatten_segments(
+    segments: list[tuple[float, float, float, float]],
+) -> list[list[float]]:
+    """Collapse a connected chain of segments into a deduplicated point list."""
+    pts: list[list[float]] = []
+    for ax, ay, bx, by in segments:
+        if not pts:
+            pts.append([ax, ay])
+        elif abs(pts[-1][0] - ax) > 1e-9 or abs(pts[-1][1] - ay) > 1e-9:
+            pts.append([ax, ay])
+        pts.append([bx, by])
+    return pts
+
+
+def _wire_rect(ax: float, ay: float, bx: float, by: float, half: float = 0.25) -> list[list[float]]:
+    """Thin rectangle polygon around an axis-aligned wire segment (mm)."""
+    if abs(ay - by) < 1e-9:
+        return [[ax, ay - half], [bx, by - half], [bx, by + half], [ax, ay + half]]
+    return [[ax - half, ay], [bx - half, by], [bx + half, by], [ax + half, ay]]
+
+
+def _dump_viz_schematic(
+    stage: str,
+    segments: list[tuple[float, float, float, float]] | None = None,
+    pins: list[tuple[float, float]] | None = None,
+    wires: list[tuple[float, float, float, float]] | None = None,
+    candidates: list[dict[str, Any]] | None = None,
+    notes: str | None = None,
+) -> None:
+    """Dump a schematic routing intermediate state for rendering.
+
+    Mirrors the PCB router pipeline dump (``kcaa/router/router.py``) but with
+    schematic geometry: every symbol pin becomes a small pad AABB (the
+    0.5 mm collision radius), every existing wire becomes a thin obstacle
+    rectangle, and the candidate routes under evaluation are stored alongside
+    their rejection reasons.  Only writes when ``config.viz_dump_enabled`` is
+    set via ``KCAA_DUMP_ROUTE_PIPELINE=1`` in ``.env``.
+    """
+    from kcaa.utils.config import config
+
+    if not config.viz_dump_enabled:
+        return
+    d = _sch_viz_dir()
+    os.makedirs(d, exist_ok=True)
+    ts = time.strftime("%H%M%S")
+    fname = os.path.join(d, f"{ts}_{stage}.json")
+
+    pins = pins or []
+    wires = wires or []
+    tol = _PIN_COLLISION_TOL
+    data: dict[str, Any] = {
+        "stage": stage,
+        "path": _flatten_segments(segments or []),
+        "pads": [["", [px - tol, py - tol, px + tol, py + tol]] for px, py in pins],
+        "obstacles": [(_wire_rect(cx, cy, dx, dy), "wire", "") for cx, cy, dx, dy in wires],
+        "candidates": candidates or [],
+    }
+    if notes:
+        data["notes"] = notes
+    with open(fname, "w") as f:
+        json.dump(data, f)
+    log.info("[viz] dumped %s", fname)
+
+
+def _config_from_result(
+    result: _RouteConfig,
+) -> list[tuple[float, float, float, float]]:
+    """Extract the drawable segment chain (start_lead + inner + end inner→pin)."""
+    start_lead, end_lead, chosen, *_ = result
+    return list(start_lead) + list(chosen) + list(end_lead)
 
 
 def _draw_smart_wire(
@@ -675,31 +807,73 @@ def _draw_smart_wire(
     # relaxes both endpoints together rather than exhausting all end angles
     # for one start angle before moving to the next start angle.
     result: _RouteConfig | None = None
+    from kcaa.utils.config import config
+
     max_rank = len(_start_angles) + len(_end_angles) - 2
     for rank_sum in range(max_rank + 1):
         for si in range(min(rank_sum + 1, len(_start_angles))):
             ei = rank_sum - si
             if ei < 0 or ei >= len(_end_angles):
                 continue
+            sa = _start_angles[si]
+            ea = _end_angles[ei]
+            diag: dict[str, Any] | None = {} if config.viz_dump_enabled else None
             result = _try_angle_config(
                 sx,
                 sy,
                 ex,
                 ey,
-                _start_angles[si],
-                _end_angles[ei],
+                sa,
+                ea,
                 existing_wires,
                 obstacles,
                 lead_out_dist,
                 start_natural=start_angle,
                 end_natural=end_angle,
+                diag=diag,
             )
             if result is not None:
+                try:
+                    _dump_viz_schematic(
+                        f"pair-sa{int(sa)}-ea{int(ea)}",
+                        segments=_config_from_result(result),
+                        pins=obstacles,
+                        wires=existing_wires,
+                        candidates=diag.get("rejected_candidates") if diag else None,
+                        notes="valid",
+                    )
+                except Exception:
+                    log.warning("[viz] failed to dump pair %s", int(sa), exc_info=True)
                 break
+            try:
+                _dump_viz_schematic(
+                    f"pair-sa{int(sa)}-ea{int(ea)}",
+                    segments=None,
+                    pins=obstacles,
+                    wires=existing_wires,
+                    candidates=diag.get("rejected_candidates") if diag else None,
+                    notes=(
+                        f"lead start={diag.get('start_lead')} end={diag.get('end_lead')}"
+                        if diag
+                        else ""
+                    ),
+                )
+            except Exception:
+                log.warning("[viz] failed to dump pair %s", int(sa), exc_info=True)
         if result is not None:
             break
 
     if result is None:
+        try:
+            _dump_viz_schematic(
+                "7-failed",
+                segments=None,
+                pins=obstacles,
+                wires=existing_wires,
+                notes=(f"no route after {len(_start_angles) * len(_end_angles)} angle pairs tried"),
+            )
+        except Exception:
+            log.warning("[viz] failed to dump 7-failed", exc_info=True)
         log.warning(
             "smart_wire: no valid route found between (%.3f,%.3f) and "
             "(%.3f,%.3f); all angle/candidate combinations are blocked.",
@@ -729,6 +903,17 @@ def _draw_smart_wire(
         [(p2x, p2y)] if end_suppressed else []
     ):
         _add_junction_and_split(sch, jx, jy)
+
+    try:
+        _dump_viz_schematic(
+            "7-final",
+            segments=all_draw,
+            pins=obstacles,
+            wires=existing_wires,
+            notes="route drawn",
+        )
+    except Exception:
+        log.warning("[viz] failed to dump 7-final", exc_info=True)
 
     return True
 

--- a/kcaa/tools/wire_edit_tools.py
+++ b/kcaa/tools/wire_edit_tools.py
@@ -9,6 +9,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 from typing import Any
 
@@ -27,6 +28,7 @@ log = logging.getLogger(__name__)
 
 _LEAD_OUT_DIST: float = 2.54  # mm — one KiCad grid step, pulls wire into open space
 _PIN_COLLISION_TOL: float = 0.5  # mm — clearance radius around each obstacle pin
+_DUMP_MAX_REJECTED: int = 64  # cap rejected-candidate records per angle pair
 
 
 # ---------------------------------------------------------------------------
@@ -137,22 +139,132 @@ def _route_check_failures(
     ex: float,
     ey: float,
     tol: float,
+    pin_symbols: list[tuple[float, float, float, float]] | None = None,
+    lead_segs: list[tuple[float, float, float, float]] | None = None,
 ) -> list[str]:
     """Return the list of checks that reject *segments*; empty list = pass.
 
-    Runs the same three gates used by ``_try_angle_config`` — pin on segment
-    interior, collinear overlap with existing wires, pin on a corner — and
-    reports which ones fail.  Kept as its own function so the visualisation
-    dump can record the exact rejection reason per candidate.
+    Runs the four gates used by ``_try_angle_config`` — pin on segment
+    interior, collinear overlap with pin symbol stubs, collinear overlap
+    with existing wires, pin on a corner — and reports which ones fail.
+    Kept as its own function so the visualisation dump can record the exact
+    rejection reason per candidate.
+
+    Only the actual lead-out segments (``lead_segs``, in forward electrical
+    point → tip direction) running outward on their own pin stub are exempt
+    from the stub gate; every other overlap with a pin symbol is rejected.
     """
     fails: list[str] = []
     if _route_collides(segments, obstacles, tol):
         fails.append("pin-on-interior")
+    if pin_symbols and _intersects_any(
+        segments,
+        pin_symbols,
+        tol,
+        exempt=(
+            (lambda seg, line, tol: seg in (lead_segs or []) and _lead_on_own_stub(seg, line, tol))
+            if lead_segs
+            else None
+        ),
+    ):
+        fails.append("pin-overlap")
     if _route_overlaps_wires(segments, existing_wires, tol):
         fails.append("wire-overlap")
     if _route_collides_at_corners(segments, obstacles, tol, sx, sy, ex, ey):
         fails.append("pin-at-corner")
     return fails
+
+
+def _intersects_any(
+    segments: list[tuple[float, float, float, float]],
+    lines: list[tuple[float, float, float, float]],
+    tol: float,
+    exempt=None,
+) -> bool:
+    """Return True if any segment intersects (overlaps or crosses) any line.
+
+    *exempt* is an optional predicate ``(segment, line, tol) -> bool`` that
+    excuses specific pairs (e.g. a lead running outward on its own pin stub).
+    """
+    for seg in segments:
+        for line in lines:
+            if _segments_intersect(seg, line, tol):
+                if exempt is not None and exempt(seg, line, tol):
+                    continue
+                return True
+    return False
+
+
+def _lead_on_own_stub(
+    seg: tuple[float, float, float, float],
+    stub: tuple[float, float, float, float],
+    tol: float,
+) -> bool:
+    """True when *seg* is the outgoing lead of *stub*'s own pin.
+
+    The legitimate lead-out starts at the pin's electrical point and runs
+    outward along the stub direction (stub = electrical point → stub tip).
+    A segment that returns from outside onto the stub (or crosses it at
+    length) is *not* exempt — that is a wire drawn on top of the pin symbol.
+    """
+    ex, ey, tx, ty = stub
+    sdx, sdy = tx - ex, ty - ey
+    for sx0, sy0, sx1, sy1 in (
+        (seg[0], seg[1], seg[2], seg[3]),
+        (seg[2], seg[3], seg[0], seg[1]),  # end_lead is stored inner→pin
+    ):
+        if abs(sx0 - ex) <= tol and abs(sy0 - ey) <= tol:
+            if (sx1 - sx0) * sdx + (sy1 - sy0) * sdy > 0:
+                return True
+    return False
+
+
+def _point_in_interior(
+    px: float,
+    py: float,
+    sx0: float,
+    sy0: float,
+    sx1: float,
+    sy1: float,
+    tol: float,
+) -> bool:
+    """True when (px,py) lies strictly inside axis-aligned segment (s0→s1)."""
+    if abs(sy0 - sy1) < 1e-9:
+        return abs(py - sy0) <= tol and min(sx0, sx1) + tol < px < max(sx0, sx1) - tol
+    if abs(sx0 - sx1) < 1e-9:
+        return abs(px - sx0) <= tol and min(sy0, sy1) + tol < py < max(sy0, sy1) - tol
+    return False
+
+
+def _segments_intersect(
+    seg: tuple[float, float, float, float],
+    line: tuple[float, float, float, float],
+    tol: float,
+) -> bool:
+    """True when the two axis-aligned segments share more than an endpoint.
+
+    Covers both collinear interval overlap (the wire-overlap gate) and a
+    T/perpendicular crossing where one segment passes *through* the other's
+    interior — e.g. a route running across the middle of a pin symbol.
+    Endpoint touches (lead on its own stub, bridge landing on a wire end)
+    are not flagged.
+    """
+    if _segments_overlap(*seg, *line, tol):
+        return True
+    ax, ay, bx, by = seg
+    cx, cy, dx, dy = line
+    # One horizontal, one vertical, crossing strictly interior to both.
+    if abs(ay - by) < 1e-9 and abs(ax - bx) > 1e-9 and abs(cx - dx) < 1e-9 and abs(cy - dy) > 1e-9:
+        vx, hy = cx, ay
+        return _point_in_interior(vx, hy, ax, ay, bx, by, tol) and _point_in_interior(
+            vx, hy, cx, cy, cx, dy, tol
+        )
+    if abs(cx - dx) < 1e-9 and abs(cy - dy) > 1e-9 and abs(ay - by) < 1e-9 and abs(ax - bx) > 1e-9:
+        vx, hy = ax, cy
+        return _point_in_interior(vx, hy, cx, cy, dx, dy, tol) and _point_in_interior(
+            vx, hy, ax, ay, ax, by, tol
+        )
+    return False
 
 
 def _route_lanes(
@@ -628,6 +740,7 @@ def _try_angle_config(
     start_natural: float | None = None,
     end_natural: float | None = None,
     diag: dict[str, Any] | None = None,
+    pin_symbols: list[tuple[float, float, float, float]] | None = None,
 ) -> _RouteConfig | None:
     """Try to find a valid route from (sx,sy) to (ex,ey) using the given
     lead-out angles sa (start) and ea (end).
@@ -668,25 +781,29 @@ def _try_angle_config(
     Returns a _RouteConfig tuple on success, or None if no candidate inner
     route passes the collision / overlap checks.
     """
-    # --- start lead ---
+    # --- start lead options ---
+    # Angle-level state is length-independent and decided once:
+    #  * t-tap: lead overlaps an existing wire → tip absorbed into the
+    #    followed chain (any length does the same);
+    #  * opposite-natural: direction rejected outright;
+    #  * plain lead: each length has its own tip; lengths are swept by the
+    #    search below so a route blocked at the anchor can be rescued by
+    #    moving the exit point minimally (conflict-driven).
     dvsx = dvsy = 0.0
     if sa is not None:
         dvsx, dvsy = _dir_vec(sa)
 
-    p1x, p1y = sx, sy
-    start_lead: list[tuple[float, float, float, float]] = []
+    start_opts: list[
+        tuple[float | None, float, float, list[tuple[float, float, float, float]]]
+    ] = []
     start_suppressed = False
-    cur_sl: float | None = None  # lead length actually used (for diagnostics)
     if sa is not None:
-        # Angle-level gates are length-independent: evaluated once at the
-        # anchor length (T-tap absorbs any lead into the followed chain;
-        # opposite-natural rejects the direction outright).
         anchor = lead_lengths[0]
         seg_anchor = (sx, sy, round(sx + dvsx * anchor, 4), round(sy + dvsy * anchor, 4))
         if _route_overlaps_wires([seg_anchor], existing_wires, _PIN_COLLISION_TOL):
             p1x, p1y = _follow_wire_extent(sx, sy, sa, existing_wires, _PIN_COLLISION_TOL)
             start_suppressed = True
-            cur_sl = anchor
+            start_opts = [(anchor, p1x, p1y, [])]
             if diag is not None:
                 diag["start_lead"] = "t-tap"
         elif (
@@ -696,10 +813,6 @@ def _try_angle_config(
                 diag["start_lead"] = "opposite-natural"
             return None  # lead goes into component body (opposite to natural exit)
         else:
-            # Only the tip position depends on the length: try the anchor
-            # first, then shorter/longer leads only when a length is blocked,
-            # so the exit point is disrupted as little as possible.
-            found = False
             for length in lead_lengths:
                 tip = (round(sx + dvsx * length, 4), round(sy + dvsy * length, 4))
                 seg = (sx, sy, tip[0], tip[1])
@@ -709,34 +822,30 @@ def _try_angle_config(
                     for ox, oy in obstacles
                 ):
                     continue  # lead blocked at this length; try a neighbour
-                p1x, p1y = tip
-                start_lead = [seg]
-                cur_sl = length
-                found = True
-                break
-            if not found:
+                start_opts.append((length, tip[0], tip[1], [seg]))
+            if not start_opts:
                 if diag is not None:
                     diag["start_lead"] = "pin-blocked"
                 return None  # every lead length blocked by a component pin
             if diag is not None:
                 diag["start_lead"] = "ok"
+    else:
+        start_opts = [(None, sx, sy, [])]
 
-    # --- end lead ---
+    # --- end lead options ---
     dvex = dvey = 0.0
     if ea is not None:
         dvex, dvey = _dir_vec(ea)
 
-    p2x, p2y = ex, ey
-    end_lead: list[tuple[float, float, float, float]] = []
+    end_opts: list[tuple[float | None, float, float, list[tuple[float, float, float, float]]]] = []
     end_suppressed = False
-    cur_el: float | None = None  # end lead length actually used
     if ea is not None:
         anchor = lead_lengths[0]
         seg_anchor = (ex, ey, round(ex + dvex * anchor, 4), round(ey + dvey * anchor, 4))
         if _route_overlaps_wires([seg_anchor], existing_wires, _PIN_COLLISION_TOL):
             p2x, p2y = _follow_wire_extent(ex, ey, ea, existing_wires, _PIN_COLLISION_TOL)
             end_suppressed = True
-            cur_el = anchor
+            end_opts = [(anchor, p2x, p2y, [])]
             if diag is not None:
                 diag["end_lead"] = "t-tap"
         elif end_natural is not None and abs((ea - (end_natural + 180.0) % 360.0) % 360.0) < 1e-9:
@@ -744,7 +853,6 @@ def _try_angle_config(
                 diag["end_lead"] = "opposite-natural"
             return None  # lead goes into component body (opposite to natural exit)
         else:
-            found = False
             for length in lead_lengths:
                 tip = (round(ex + dvex * length, 4), round(ey + dvey * length, 4))
                 seg = (ex, ey, tip[0], tip[1])
@@ -754,48 +862,80 @@ def _try_angle_config(
                     for ox, oy in obstacles
                 ):
                     continue
-                p2x, p2y = tip
-                end_lead = [(p2x, p2y, ex, ey)]  # reversed: inner→pin
-                cur_el = length
-                found = True
-                break
-            if not found:
+                end_opts.append((length, tip[0], tip[1], [(tip[0], tip[1], ex, ey)]))  # inner→pin
+            if not end_opts:
                 if diag is not None:
                     diag["end_lead"] = "pin-blocked"
                 return None  # every lead length blocked by a component pin
             if diag is not None:
                 diag["end_lead"] = "ok"
+    else:
+        end_opts = [(None, ex, ey, [])]
 
-    # Lead segments in canonical forward direction for collision checking
-    lead_segs = start_lead + [(a, b, c, d) for (c, d, a, b) in end_lead]
+    # Conflict-driven length sweep: the anchor length pair is tried first so
+    # previously-working routes are untouched; further lengths are swept only
+    # because every candidate at the current length was rejected, moving the
+    # exit point as little as necessary.
+    anchor_l = lead_lengths[0]
+    combos = sorted(
+        (
+            (sl, s1x, s1y, sseg, el, e1x, e1y, eseg)
+            for sl, s1x, s1y, sseg in start_opts
+            for el, e1x, e1y, eseg in end_opts
+        ),
+        key=lambda c: (
+            (0.0 if c[0] is None else abs(c[0] - anchor_l))
+            + (0.0 if c[4] is None else abs(c[4] - anchor_l)),
+            c[0] or 0.0,
+            c[4] or 0.0,
+        ),
+    )
 
-    for candidate in _route_candidates(p1x, p1y, p2x, p2y):
-        all_segs = lead_segs + candidate
-        fails = _route_check_failures(
-            all_segs, obstacles, existing_wires, sx, sy, ex, ey, _PIN_COLLISION_TOL
-        )
-        if not fails:
+    for cur_sl, p1x, p1y, sseg, cur_el, p2x, p2y, eseg in combos:
+        # Lead segments in canonical forward direction for collision checking
+        lead_segs = sseg + [(a, b, c, d) for (c, d, a, b) in eseg]
+        for candidate in _route_candidates(p1x, p1y, p2x, p2y):
+            all_segs = lead_segs + candidate
+            fails = _route_check_failures(
+                all_segs,
+                obstacles,
+                existing_wires,
+                sx,
+                sy,
+                ex,
+                ey,
+                _PIN_COLLISION_TOL,
+                pin_symbols=pin_symbols,
+                lead_segs=lead_segs,
+            )
+            if not fails:
+                if diag is not None:
+                    diag["valid"] = True
+                return (
+                    sseg,
+                    eseg,
+                    candidate,
+                    p1x,
+                    p1y,
+                    p2x,
+                    p2y,
+                    start_suppressed,
+                    end_suppressed,
+                )
             if diag is not None:
-                diag["valid"] = True
-            return (
-                start_lead,
-                end_lead,
-                candidate,
-                p1x,
-                p1y,
-                p2x,
-                p2y,
-                start_suppressed,
-                end_suppressed,
-            )
-        if diag is not None:
-            diag.setdefault("rejected_candidates", []).append(
-                {
-                    "segments": [list(s) for s in all_segs],
-                    "reasons": fails,
-                    "lead": [cur_sl, cur_el],
-                }
-            )
+                rejected = diag.setdefault("rejected_candidates", [])
+                # Keep the record bounded: candidate shapes are checked in
+                # ranked order, so the first entries carry the diagnostic
+                # value; later W/snake variants repeat the same failure modes.
+                if len(rejected) < _DUMP_MAX_REJECTED:
+                    rejected.append(
+                        {
+                            "segments": [list(seg) for seg in all_segs],
+                            "reasons": fails,
+                            "lead": [cur_sl, cur_el],
+                        }
+                    )
+
     return None
 
 
@@ -839,6 +979,7 @@ def _dump_viz_schematic(
     wires: list[tuple[float, float, float, float]] | None = None,
     candidates: list[dict[str, Any]] | None = None,
     notes: str | None = None,
+    pin_stubs: list[tuple[float, float, float, float]] | None = None,
 ) -> None:
     """Dump a schematic routing intermediate state for rendering.
 
@@ -866,6 +1007,7 @@ def _dump_viz_schematic(
         "path": _flatten_segments(segments or []),
         "pads": [["", [px - tol, py - tol, px + tol, py + tol]] for px, py in pins],
         "obstacles": [(_wire_rect(cx, cy, dx, dy), "wire", "") for cx, cy, dx, dy in wires],
+        "pin_stubs": [list(s) for s in (pin_stubs or [])],
         "candidates": candidates or [],
     }
     if notes:
@@ -929,6 +1071,11 @@ def _draw_smart_wire(
     """
     obstacles = obstacle_pins or []
 
+    # Pin symbols are 2.54–3.81 mm lines on the schematic; treat them as
+    # collision bodies so routes cannot run on top of a pin.  Outgoing
+    # leads on their own stub stay exempt inside the collision gate.
+    pin_symbols = _collect_pin_symbol_stubs(sch)
+
     # Build the ordered list of (sa, ea) pairs to try.
     # Natural angles are tried first; then all 4 cardinals for each endpoint
     # (excluding duplicates already covered by the natural pair) are tried in
@@ -990,6 +1137,7 @@ def _draw_smart_wire(
                     start_natural=start_angle,
                     end_natural=end_angle,
                     diag=diag,
+                    pin_symbols=pin_symbols,
                 )
                 pair_name = f"{stage_name}-pair-sa{int(sa)}-ea{int(ea)}"
                 if result is not None:
@@ -1001,6 +1149,7 @@ def _draw_smart_wire(
                             pins=obstacles,
                             wires=existing_wires,
                             candidates=diag.get("rejected_candidates") if diag else None,
+                            pin_stubs=pin_symbols,
                             notes=f"stage={stage_name} valid",
                         )
                     except Exception:
@@ -1013,6 +1162,7 @@ def _draw_smart_wire(
                         pins=obstacles,
                         wires=existing_wires,
                         candidates=diag.get("rejected_candidates") if diag else None,
+                        pin_stubs=pin_symbols,
                         notes=(
                             f"stage={stage_name} lead start={diag.get('start_lead')} "
                             f"end={diag.get('end_lead')}"
@@ -1034,6 +1184,7 @@ def _draw_smart_wire(
                 segments=None,
                 pins=obstacles,
                 wires=existing_wires,
+                pin_stubs=pin_symbols,
                 notes=(
                     f"no route after {len(stages)} stages x "
                     f"{len(_start_angles) * len(_end_angles)} angle pairs tried"
@@ -1077,6 +1228,7 @@ def _draw_smart_wire(
             segments=all_draw,
             pins=obstacles,
             wires=existing_wires,
+            pin_stubs=pin_symbols,
             notes=f"stage={succeeded_stage} route drawn",
         )
     except Exception:
@@ -1168,6 +1320,93 @@ def _collect_all_pin_data(sch: Any) -> list[tuple[float, float, float]]:
     except AttributeError:
         pass
     return data
+
+
+def _symbol_pin_lengths(sch: Any) -> dict[str, dict[str, float]]:
+    """{sanitized lib_id: {pin number: symbol stub length in mm}}.
+
+    Reads the embedded ``lib_symbols`` of the schematic.  A KiCad pin symbol
+    is drawn as a line from its electrical point along the pin's direction;
+    its length (typically 2.54 or 3.81 mm) is part of the lib definition
+    and is not copied into the placed symbol instance, so the router needs
+    it from here to treat pin symbols as collision bodies.  Pins are
+    exposed as ``Pin_1``..``Pin_n`` attributes (skip nodes don't support
+    ``len()``/iteration on the wrapper).
+    """
+    if not hasattr(sch, "lib_symbols"):
+        return {}
+    libs = sch.lib_symbols
+    result: dict[str, dict[str, float]] = {}
+    for attr in dir(libs):
+        if attr.startswith("_"):
+            continue
+        lib = getattr(libs, attr, None)
+        pins = getattr(lib, "pin", None) if lib is not None else None
+        if pins is None:
+            continue
+        lengths: dict[str, float] = {}
+        for name in dir(pins):
+            if not name.startswith("Pin_"):
+                continue
+            m = re.search(r"\d+", name)
+            if not m:
+                continue
+            raw_len = str(
+                getattr(pins, name, "").length
+                if hasattr(getattr(pins, name, None), "length")
+                else ""
+            )
+            lm = re.search(r"[\d.]+", raw_len)
+            if lm:
+                lengths[m.group(0)] = float(lm.group(0))
+        if lengths:
+            result[attr] = lengths
+    return result
+
+
+def _sanitize_lib_id(lib_id: str) -> str:
+    """Map a lib id (``Vendor:Part``) to skip's sanitised attribute name."""
+    return lib_id.replace(":", "_").replace("/", "_").replace(".", "_").replace("-", "_")
+
+
+def _collect_pin_symbol_stubs(
+    sch: Any,
+) -> list[tuple[float, float, float, float]]:
+    """World-space stub segments for every pin symbol.
+
+    A KiCad pin symbol is drawn from its electrical point *into the
+    component body* — the opposite of the wire-exit direction that
+    ``sym_pin_world_coords`` reports.  These lines span the lib-defined pin
+    length and are the collision bodies a wire must not run on top of (a
+    plain point check against the electrical point alone misses e.g. a
+    route tail drawn on the far side of the pin).  The stub gate exempts
+    only outgoing leads on their own stub; all other overlaps are rejected.
+    """
+    lengths_by_lib = _symbol_pin_lengths(sch)
+    stubs: list[tuple[float, float, float, float]] = []
+    try:
+        for sym in sch.symbol:
+            raw_lib = getattr(sym, "lib_id", "")
+            lib_id = getattr(raw_lib, "value", raw_lib)
+            lib_lengths = lengths_by_lib.get(_sanitize_lib_id(str(lib_id)), {})
+            try:
+                for pin in sym_pin_world_coords(sym):
+                    length = lib_lengths.get(str(pin.number), 2.54)
+                    # Symbol line runs into the body: opposite the exit dir.
+                    dx, dy = _dir_vec((pin.angle + 180.0) % 360.0)
+                    stubs.append(
+                        (
+                            pin.x,
+                            pin.y,
+                            round(pin.x + dx * length, 4),
+                            round(pin.y + dy * length, 4),
+                        )
+                    )
+            except AttributeError:
+                continue
+    except AttributeError:
+        pass
+    return stubs
 
 
 def _junction_exists_at(sch: Any, px: float, py: float, tol: float = 0.01) -> bool:

--- a/kcaa/tools/wire_edit_tools.py
+++ b/kcaa/tools/wire_edit_tools.py
@@ -948,6 +948,12 @@ def _sch_viz_dir() -> str:
     """Return the schematic viz dump directory under the kcaa data dir."""
     from kcaa.utils.config import config
 
+    # KCAA_VIZ_DIR overrides the dump root so test/debug runs can be written
+    # to a scratch location instead of polluting the live viz directory the
+    # KiCad plugin renders from.
+    override = os.environ.get("KCAA_VIZ_DIR")
+    if override:
+        return os.path.join(os.path.expanduser(override), "sch_viz")
     return os.path.join(config.get_kcaa_data_dir(), "kcaa_viz", "sch_viz")
 
 

--- a/kcaa/tools/wire_edit_tools.py
+++ b/kcaa/tools/wire_edit_tools.py
@@ -4,6 +4,7 @@ Provides tools to draw, list, and delete wire segments and junction dots
 in KiCad schematics using the skip library.
 """
 
+from collections.abc import Sequence
 import json
 import logging
 import math
@@ -154,6 +155,43 @@ def _route_check_failures(
     return fails
 
 
+def _route_lanes(
+    x1: float,
+    x2: float,
+    delta: float = 0.635,
+    n_anchors: int = 8,
+    n_offsets: int = 2,
+) -> list[float]:
+    """Ordered lane positions inside the open span between x1 and x2.
+
+    Direction-independent: works with x2 < x1 (a downwards/leftwards run).
+    The evenly spaced anchors come first (kept from the original 8th
+    fractions), then each anchor perturbed by ±k·*delta* (k=1..n_offsets)
+    so a blocked anchor can be escaped by a small local move instead of
+    jumping to a distant lane.  Values outside the span are clipped away
+    and duplicates removed.  n_offsets=0 returns plain anchors.
+    """
+    if abs(x2 - x1) <= 1e-9:
+        return []
+    span_lo, span_hi = min(x1, x2), max(x1, x2)
+    lanes: list[float] = []
+    seen: set[float] = set()
+
+    def _add(v: float) -> None:
+        r = round(v, 4)
+        if span_lo < r < span_hi and r not in seen:
+            seen.add(r)
+            lanes.append(r)
+
+    for k in range(1, n_anchors):
+        a = span_lo + (span_hi - span_lo) * k / n_anchors
+        _add(a)
+        for kd in range(1, n_offsets + 1):
+            _add(a - kd * delta)
+            _add(a + kd * delta)
+    return lanes
+
+
 def _route_candidates(
     x1: float,
     y1: float,
@@ -169,10 +207,18 @@ def _route_candidates(
       1. Direct (1 segment) — only when points are axis-aligned.
       2. L-A: horizontal-first via corner (x2, y1).
       3. L-B: vertical-first via corner (x1, y2).
-      4-10.  7 horizontal Z-routes: jog at x = x1 + k*(x2−x1)/8 for k=1..7.
-      11-17. 7 vertical Z-routes:   jog at y = y1 + k*(y2−y1)/8 for k=1..7.
-      18-29. U-detours for the collinear case (same axis, direct route blocked):
-             jog ±2.54, ±5.08, ±7.62 mm perpendicular, crossing full span, then back.
+      4-79.  Horizontal Z-routes: jog the vertical column to every lane x
+             (8 anchors + ±0.635/±1.27 micro-offsets).
+      80-155. Vertical Z-routes: jog the horizontal row to every lane y.
+      156-253. 4-seg W-routes (H-V-H-V / V-H-V-H) on the 8 anchors, so the
+             middle vertical can stop short of the far edge and dodge a
+             wall in the terminal column.
+      254-547. 5-seg snakes (H-V-H-V-H / V-H-V-H-V) on the 8 anchors: the
+             two jogs (xa, xb) / (ya, yb) are independent, letting the
+             final stub on the endpoint row stay short and clean.
+      548+.  U-detours for the collinear case (same axis, direct route
+             blocked): jog ±2.54, ±5.08, ±7.62 mm perpendicular, crossing
+             full span, then back.
     """
     candidates: list[list[tuple[float, float, float, float]]] = []
     dx = x2 - x1
@@ -189,9 +235,11 @@ def _route_candidates(
     candidates.append([(x1, y1, x1, y2), (x1, y2, x2, y2)])
 
     if abs(dx) > 1e-9 and abs(dy) > 1e-9:
-        # Horizontal Z-routes: jog the vertical column to a fractional x
-        for k in range(1, 8):
-            xj = x1 + dx * k / 8.0
+        xlanes = _route_lanes(x1, x2)
+        ylanes = _route_lanes(y1, y2)
+
+        # Horizontal Z-routes: jog the vertical column to a lane x
+        for xj in xlanes:
             candidates.append(
                 [
                     (x1, y1, xj, y1),
@@ -199,9 +247,8 @@ def _route_candidates(
                     (xj, y2, x2, y2),
                 ]
             )
-        # Vertical Z-routes: jog the horizontal row to a fractional y
-        for k in range(1, 8):
-            yj = y1 + dy * k / 8.0
+        # Vertical Z-routes: jog the horizontal row to a lane y
+        for yj in ylanes:
             candidates.append(
                 [
                     (x1, y1, x1, yj),
@@ -209,6 +256,60 @@ def _route_candidates(
                     (x2, yj, x2, y2),
                 ]
             )
+
+        # 4-seg W-routes: the middle vertical stops at a lane y instead of
+        # crossing the full span, so the last run is on the terminal column
+        # only (escapes a wall sitting on the start/end columns).
+        x_anchors = _route_lanes(x1, x2, n_offsets=0)
+        y_anchors = _route_lanes(y1, y2, n_offsets=0)
+        for xa in x_anchors:
+            for yw in y_anchors:
+                candidates.append(
+                    [
+                        (x1, y1, xa, y1),
+                        (xa, y1, xa, yw),
+                        (xa, yw, x2, yw),
+                        (x2, yw, x2, y2),
+                    ]
+                )
+        for ya in y_anchors:
+            for xw in x_anchors:
+                candidates.append(
+                    [
+                        (x1, y1, x1, ya),
+                        (x1, ya, xw, ya),
+                        (xw, ya, xw, y2),
+                        (xw, y2, x2, y2),
+                    ]
+                )
+
+        # 5-seg snakes: two independent jogs let the final stub on the
+        # endpoint row stay short (e.g. land left of a stub starting right
+        # at the pin instead of crossing it).
+        for i, xa in enumerate(x_anchors):
+            for xb in x_anchors[i + 1 :]:
+                for yw in y_anchors:
+                    candidates.append(
+                        [
+                            (x1, y1, xa, y1),
+                            (xa, y1, xa, yw),
+                            (xa, yw, xb, yw),
+                            (xb, yw, xb, y2),
+                            (xb, y2, x2, y2),
+                        ]
+                    )
+        for i, ya in enumerate(y_anchors):
+            for yb in y_anchors[i + 1 :]:
+                for xw in x_anchors:
+                    candidates.append(
+                        [
+                            (x1, y1, x1, ya),
+                            (x1, ya, xw, ya),
+                            (xw, ya, xw, yb),
+                            (xw, yb, x2, yb),
+                            (x2, yb, x2, y2),
+                        ]
+                    )
 
     # U-detours: used when the direct axis-aligned route is blocked by an
     # existing wire.  Jog perpendicular to the connecting axis by multiples
@@ -523,7 +624,7 @@ def _try_angle_config(
     ea: float | None,
     existing_wires: list[tuple[float, float, float, float]],
     obstacles: list[tuple[float, float]],
-    lead_out_dist: float,
+    lead_lengths: Sequence[float],
     start_natural: float | None = None,
     end_natural: float | None = None,
     diag: dict[str, Any] | None = None,
@@ -535,13 +636,18 @@ def _try_angle_config(
     * If the lead segment overlaps an existing wire: suppress the segment,
       advance the inner endpoint to the far end of the wire chain
       (T-tap mode), and mark as suppressed so a junction is placed later.
-    * If a component pin blocks the lead segment: return None — this angle
-      direction is unusable, try the next one.
+    * If a component pin blocks the lead segment at every tried length:
+      return None — this angle direction is unusable, try the next one.
     * If the lead direction is exactly opposite to the pin's natural exit
       angle and does not follow an existing wire: return None — this
       direction routes into the component body (e.g. through a GND triangle).
-    * Otherwise: emit the lead segment and place the inner endpoint at the
-      lead tip.
+    * Otherwise: emit the lead segment at the shortest tried length whose
+      tip is not blocked, and place the inner endpoint at that tip.
+
+    ``lead_lengths`` is tried in order; the first entry is the anchor
+    (caller-disrupting) length and remaining entries are fallbacks tried
+    only when a longer lead is blocked by a pin, keeping the exit point
+    as close to the anchor as possible.
     None for an angle means no lead-out from that endpoint (route directly
     from the pin position).
 
@@ -563,20 +669,24 @@ def _try_angle_config(
     route passes the collision / overlap checks.
     """
     # --- start lead ---
+    dvsx = dvsy = 0.0
     if sa is not None:
-        dvx, dvy = _dir_vec(sa)
-        p1x = round(sx + dvx * lead_out_dist, 4)
-        p1y = round(sy + dvy * lead_out_dist, 4)
-    else:
-        p1x, p1y = sx, sy
+        dvsx, dvsy = _dir_vec(sa)
 
+    p1x, p1y = sx, sy
     start_lead: list[tuple[float, float, float, float]] = []
     start_suppressed = False
-    if sa is not None and (abs(p1x - sx) > 1e-9 or abs(p1y - sy) > 1e-9):
-        seg = (sx, sy, p1x, p1y)
-        if _route_overlaps_wires([seg], existing_wires, _PIN_COLLISION_TOL):
+    cur_sl: float | None = None  # lead length actually used (for diagnostics)
+    if sa is not None:
+        # Angle-level gates are length-independent: evaluated once at the
+        # anchor length (T-tap absorbs any lead into the followed chain;
+        # opposite-natural rejects the direction outright).
+        anchor = lead_lengths[0]
+        seg_anchor = (sx, sy, round(sx + dvsx * anchor, 4), round(sy + dvsy * anchor, 4))
+        if _route_overlaps_wires([seg_anchor], existing_wires, _PIN_COLLISION_TOL):
             p1x, p1y = _follow_wire_extent(sx, sy, sa, existing_wires, _PIN_COLLISION_TOL)
             start_suppressed = True
+            cur_sl = anchor
             if diag is not None:
                 diag["start_lead"] = "t-tap"
         elif (
@@ -585,48 +695,74 @@ def _try_angle_config(
             if diag is not None:
                 diag["start_lead"] = "opposite-natural"
             return None  # lead goes into component body (opposite to natural exit)
-        elif _route_collides([seg], obstacles, _PIN_COLLISION_TOL) or any(
-            abs(p1x - ox) <= _PIN_COLLISION_TOL and abs(p1y - oy) <= _PIN_COLLISION_TOL
-            for ox, oy in obstacles
-        ):
-            if diag is not None:
-                diag["start_lead"] = "pin-blocked"
-            return None  # direction blocked by a component pin
         else:
-            start_lead = [seg]
+            # Only the tip position depends on the length: try the anchor
+            # first, then shorter/longer leads only when a length is blocked,
+            # so the exit point is disrupted as little as possible.
+            found = False
+            for length in lead_lengths:
+                tip = (round(sx + dvsx * length, 4), round(sy + dvsy * length, 4))
+                seg = (sx, sy, tip[0], tip[1])
+                if _route_collides([seg], obstacles, _PIN_COLLISION_TOL) or any(
+                    abs(tip[0] - ox) <= _PIN_COLLISION_TOL
+                    and abs(tip[1] - oy) <= _PIN_COLLISION_TOL
+                    for ox, oy in obstacles
+                ):
+                    continue  # lead blocked at this length; try a neighbour
+                p1x, p1y = tip
+                start_lead = [seg]
+                cur_sl = length
+                found = True
+                break
+            if not found:
+                if diag is not None:
+                    diag["start_lead"] = "pin-blocked"
+                return None  # every lead length blocked by a component pin
             if diag is not None:
                 diag["start_lead"] = "ok"
 
     # --- end lead ---
+    dvex = dvey = 0.0
     if ea is not None:
-        dvx, dvy = _dir_vec(ea)
-        p2x = round(ex + dvx * lead_out_dist, 4)
-        p2y = round(ey + dvy * lead_out_dist, 4)
-    else:
-        p2x, p2y = ex, ey
+        dvex, dvey = _dir_vec(ea)
 
+    p2x, p2y = ex, ey
     end_lead: list[tuple[float, float, float, float]] = []
     end_suppressed = False
-    if ea is not None and (abs(p2x - ex) > 1e-9 or abs(p2y - ey) > 1e-9):
-        seg = (ex, ey, p2x, p2y)
-        if _route_overlaps_wires([seg], existing_wires, _PIN_COLLISION_TOL):
+    cur_el: float | None = None  # end lead length actually used
+    if ea is not None:
+        anchor = lead_lengths[0]
+        seg_anchor = (ex, ey, round(ex + dvex * anchor, 4), round(ey + dvey * anchor, 4))
+        if _route_overlaps_wires([seg_anchor], existing_wires, _PIN_COLLISION_TOL):
             p2x, p2y = _follow_wire_extent(ex, ey, ea, existing_wires, _PIN_COLLISION_TOL)
             end_suppressed = True
+            cur_el = anchor
             if diag is not None:
                 diag["end_lead"] = "t-tap"
         elif end_natural is not None and abs((ea - (end_natural + 180.0) % 360.0) % 360.0) < 1e-9:
             if diag is not None:
                 diag["end_lead"] = "opposite-natural"
             return None  # lead goes into component body (opposite to natural exit)
-        elif _route_collides([seg], obstacles, _PIN_COLLISION_TOL) or any(
-            abs(p2x - ox) <= _PIN_COLLISION_TOL and abs(p2y - oy) <= _PIN_COLLISION_TOL
-            for ox, oy in obstacles
-        ):
-            if diag is not None:
-                diag["end_lead"] = "pin-blocked"
-            return None  # direction blocked by a component pin
         else:
-            end_lead = [(p2x, p2y, ex, ey)]  # reversed: inner→pin
+            found = False
+            for length in lead_lengths:
+                tip = (round(ex + dvex * length, 4), round(ey + dvey * length, 4))
+                seg = (ex, ey, tip[0], tip[1])
+                if _route_collides([seg], obstacles, _PIN_COLLISION_TOL) or any(
+                    abs(tip[0] - ox) <= _PIN_COLLISION_TOL
+                    and abs(tip[1] - oy) <= _PIN_COLLISION_TOL
+                    for ox, oy in obstacles
+                ):
+                    continue
+                p2x, p2y = tip
+                end_lead = [(p2x, p2y, ex, ey)]  # reversed: inner→pin
+                cur_el = length
+                found = True
+                break
+            if not found:
+                if diag is not None:
+                    diag["end_lead"] = "pin-blocked"
+                return None  # every lead length blocked by a component pin
             if diag is not None:
                 diag["end_lead"] = "ok"
 
@@ -654,7 +790,11 @@ def _try_angle_config(
             )
         if diag is not None:
             diag.setdefault("rejected_candidates", []).append(
-                {"segments": [list(s) for s in all_segs], "reasons": fails}
+                {
+                    "segments": [list(s) for s in all_segs],
+                    "reasons": fails,
+                    "lead": [cur_sl, cur_el],
+                }
             )
     return None
 
@@ -807,59 +947,83 @@ def _draw_smart_wire(
     # relaxes both endpoints together rather than exhausting all end angles
     # for one start angle before moving to the next start angle.
     result: _RouteConfig | None = None
+    succeeded_stage: str | None = None
     from kcaa.utils.config import config
 
+    # Two-stage exploration.  Stage 1 tries every angle pair at the anchor
+    # lead length only — bit-identical to previous behaviour whenever it
+    # succeeds.  Stage 2 repeats with neighbourhood lengths, so lead length
+    # changes are purely conflict-driven and never explored while an
+    # anchor-length route exists.  Candidate shapes (including micro-adjusted
+    # jog lanes) are the same for every angle pair in both stages.
+    delta = lead_out_dist / 4.0  # 0.635 mm for the default 2.54 anchor
+    lead_neighbourhood = sorted(
+        {round(lead_out_dist + k * delta, 4) for k in range(-3, 5)},
+        key=lambda length: (abs(length - lead_out_dist), length),
+    )
+    lead_neighbourhood = [length for length in lead_neighbourhood if length > 0]
+    stages: list[tuple[str, list[float]]] = [
+        ("s1", [lead_out_dist]),
+        ("s2", lead_neighbourhood),
+    ]
+
     max_rank = len(_start_angles) + len(_end_angles) - 2
-    for rank_sum in range(max_rank + 1):
-        for si in range(min(rank_sum + 1, len(_start_angles))):
-            ei = rank_sum - si
-            if ei < 0 or ei >= len(_end_angles):
-                continue
-            sa = _start_angles[si]
-            ea = _end_angles[ei]
-            diag: dict[str, Any] | None = {} if config.viz_dump_enabled else None
-            result = _try_angle_config(
-                sx,
-                sy,
-                ex,
-                ey,
-                sa,
-                ea,
-                existing_wires,
-                obstacles,
-                lead_out_dist,
-                start_natural=start_angle,
-                end_natural=end_angle,
-                diag=diag,
-            )
-            if result is not None:
+    for stage_name, lead_lengths in stages:
+        for rank_sum in range(max_rank + 1):
+            for si in range(min(rank_sum + 1, len(_start_angles))):
+                ei = rank_sum - si
+                if ei < 0 or ei >= len(_end_angles):
+                    continue
+                sa = _start_angles[si]
+                ea = _end_angles[ei]
+                diag: dict[str, Any] | None = {} if config.viz_dump_enabled else None
+                result = _try_angle_config(
+                    sx,
+                    sy,
+                    ex,
+                    ey,
+                    sa,
+                    ea,
+                    existing_wires,
+                    obstacles,
+                    lead_lengths,
+                    start_natural=start_angle,
+                    end_natural=end_angle,
+                    diag=diag,
+                )
+                pair_name = f"{stage_name}-pair-sa{int(sa)}-ea{int(ea)}"
+                if result is not None:
+                    succeeded_stage = stage_name
+                    try:
+                        _dump_viz_schematic(
+                            pair_name,
+                            segments=_config_from_result(result),
+                            pins=obstacles,
+                            wires=existing_wires,
+                            candidates=diag.get("rejected_candidates") if diag else None,
+                            notes=f"stage={stage_name} valid",
+                        )
+                    except Exception:
+                        log.warning("[viz] failed to dump pair %s", pair_name, exc_info=True)
+                    break
                 try:
                     _dump_viz_schematic(
-                        f"pair-sa{int(sa)}-ea{int(ea)}",
-                        segments=_config_from_result(result),
+                        pair_name,
+                        segments=None,
                         pins=obstacles,
                         wires=existing_wires,
                         candidates=diag.get("rejected_candidates") if diag else None,
-                        notes="valid",
+                        notes=(
+                            f"stage={stage_name} lead start={diag.get('start_lead')} "
+                            f"end={diag.get('end_lead')}"
+                            if diag
+                            else f"stage={stage_name}"
+                        ),
                     )
                 except Exception:
-                    log.warning("[viz] failed to dump pair %s", int(sa), exc_info=True)
+                    log.warning("[viz] failed to dump pair %s", pair_name, exc_info=True)
+            if result is not None:
                 break
-            try:
-                _dump_viz_schematic(
-                    f"pair-sa{int(sa)}-ea{int(ea)}",
-                    segments=None,
-                    pins=obstacles,
-                    wires=existing_wires,
-                    candidates=diag.get("rejected_candidates") if diag else None,
-                    notes=(
-                        f"lead start={diag.get('start_lead')} end={diag.get('end_lead')}"
-                        if diag
-                        else ""
-                    ),
-                )
-            except Exception:
-                log.warning("[viz] failed to dump pair %s", int(sa), exc_info=True)
         if result is not None:
             break
 
@@ -870,7 +1034,10 @@ def _draw_smart_wire(
                 segments=None,
                 pins=obstacles,
                 wires=existing_wires,
-                notes=(f"no route after {len(_start_angles) * len(_end_angles)} angle pairs tried"),
+                notes=(
+                    f"no route after {len(stages)} stages x "
+                    f"{len(_start_angles) * len(_end_angles)} angle pairs tried"
+                ),
             )
         except Exception:
             log.warning("[viz] failed to dump 7-failed", exc_info=True)
@@ -910,7 +1077,7 @@ def _draw_smart_wire(
             segments=all_draw,
             pins=obstacles,
             wires=existing_wires,
-            notes="route drawn",
+            notes=f"stage={succeeded_stage} route drawn",
         )
     except Exception:
         log.warning("[viz] failed to dump 7-final", exc_info=True)

--- a/scripts/render_viz.py
+++ b/scripts/render_viz.py
@@ -3,7 +3,11 @@
 Render visualization dumps from the router pipeline as images.
 
 Usage:
-    python render_viz.py /tmp/kcaa_viz/
+    python render_viz.py <viz_dir> [run_prefix]
+
+Scans <viz_dir> recursively. PCB pipeline dumps land under
+kcaa_viz/pcb_viz/, schematic routing dumps under kcaa_viz/sch_viz/; PNGs
+are written beside each JSON in a png/ subdirectory.
 
 Depends on: matplotlib, shapely
 """
@@ -40,49 +44,101 @@ def _segment_colors(pts: list[tuple[float, float]]) -> list:
     return cols
 
 
-def _render_stage(fname: str, out_dir: str) -> None:
-    """Render a single stage JSON file to a PNG."""
-    with open(fname) as f:
-        data = json.load(f)
+def _render_scene(data: dict, out_path: str, highlight: int | None = None) -> None:
+    """Draw one scene from a stage JSON to *out_path*.
 
+    ``highlight`` optionally selects one rejected candidate (index into
+    ``data["candidates"]``) to draw thick red; the others are shown as faint
+    gray reference lines so a single failure can be inspected in isolation.
+    """
     stage = data["stage"]
-    path = data["path"]
-    pads = data["pads"]
+    path = data.get("path") or []
+    pads = data.get("pads") or []
     obstacles = data.get("obstacles", [])
-    ts = os.path.basename(fname).split("_")[0]
+    candidates = data.get("candidates") or []
+    notes = data.get("notes") or ""
 
     fig, ax = plt.subplots(1, 1, figsize=(14, 10))
     ax.set_aspect("equal")
 
     # Filter obstacles to only those near the path (culling invisible ones).
     if obstacles:
-        # Get path bounding box.
-        px = [p[0] for p in path]
-        py = [p[1] for p in path]
-        p_minx, p_maxx = min(px), max(px)
-        p_miny, p_maxy = min(py), max(py)
-        margin = 5.0  # mm around path
-        near_obs = []
-        for coords, kind, ref in obstacles:
-            xs = [c[0] for c in coords]
-            ys = [c[1] for c in coords]
-            ox_min, ox_max = min(xs), max(xs)
-            oy_min, oy_max = min(ys), max(ys)
-            if (
-                ox_max >= p_minx - margin
-                and ox_min <= p_maxx + margin
-                and oy_max >= p_miny - margin
-                and oy_min <= p_maxy + margin
-            ):
-                near_obs.append((coords, kind, ref))
+        if path:
+            # Get path bounding box.
+            px = [p[0] for p in path]
+            py = [p[1] for p in path]
+            p_minx, p_maxx = min(px), max(px)
+            p_miny, p_maxy = min(py), max(py)
+            margin = 5.0  # mm around path
+            near_obs = []
+            for coords, kind, ref in obstacles:
+                xs = [c[0] for c in coords]
+                ys = [c[1] for c in coords]
+                ox_min, ox_max = min(xs), max(xs)
+                oy_min, oy_max = min(ys), max(ys)
+                if (
+                    ox_max >= p_minx - margin
+                    and ox_min <= p_maxx + margin
+                    and oy_max >= p_miny - margin
+                    and oy_min <= p_maxy + margin
+                ):
+                    near_obs.append((coords, kind, ref))
+        else:
+            near_obs = list(obstacles)
     else:
         near_obs = []
 
-    # Obstacles (faint gray fill, near path only).
+    # Obstacles (gray fill, near path only). Dark enough to read as existing
+    # wires while staying below the candidate/path zorder.
     for coords, kind, ref in near_obs[:60]:
         xs = [c[0] for c in coords]
         ys = [c[1] for c in coords]
-        ax.fill(xs, ys, alpha=0.05, color="#888888", linewidth=0.2, edgecolor="#cccccc")
+        ax.fill(xs, ys, alpha=0.3, color="#666666", linewidth=0.4, edgecolor="#999999")
+
+    # Rejected routing candidates (schematic dumps): thin lines + reason labels.
+    for i, cand in enumerate(candidates):
+        reasons = cand.get("reasons") or []
+        if not reasons:
+            continue  # selected candidate is drawn as the main path
+        segs = [
+            [(s[0], s[1]), (s[2], s[3])]
+            for s in cand.get("segments", [])
+            if abs(s[0] - s[2]) > 1e-9 or abs(s[1] - s[3]) > 1e-9
+        ]
+        if not segs:
+            continue
+        if highlight is not None and i == highlight:
+            lc = LineCollection(segs, colors="#d62728", linewidths=2.4, alpha=0.95, zorder=4)
+            ax.add_collection(lc)
+            label = ",".join(reasons)
+            mid = segs[len(segs) // 2][0]
+            ax.annotate(
+                label,
+                mid,
+                textcoords="offset points",
+                xytext=(3, -9),
+                fontsize=8,
+                color="#8a2020",
+                fontweight="bold",
+            )
+        elif highlight is None:
+            # Overview: all rejected candidates in thin red with reason labels.
+            lc = LineCollection(segs, colors="#d62728", linewidths=1.0, alpha=0.45, zorder=2)
+            ax.add_collection(lc)
+            label = ",".join(reasons)
+            mid = segs[len(segs) // 2][0]
+            ax.annotate(
+                label,
+                mid,
+                textcoords="offset points",
+                xytext=(3, -9),
+                fontsize=6,
+                color="#8a2020",
+            )
+        else:
+            # Split view: other candidates are faint gray reference lines.
+            lc = LineCollection(segs, colors="#999999", linewidths=0.6, alpha=0.35, zorder=2)
+            ax.add_collection(lc)
 
     # Pad AABBs (thick rectangles).
     for name, aabb in pads:
@@ -97,15 +153,16 @@ def _render_stage(fname: str, out_dir: str) -> None:
             linestyle="--",
         )
         ax.add_patch(rect)
-        ax.text(
-            (minx + maxx) / 2,
-            maxy + 0.15,
-            name,
-            ha="center",
-            va="bottom",
-            fontsize=8,
-            color="#ff7f0e",
-        )
+        if name:
+            ax.text(
+                (minx + maxx) / 2,
+                maxy + 0.15,
+                name,
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="#ff7f0e",
+            )
 
     # Path with segment-colored lines.
     if len(path) >= 2:
@@ -117,32 +174,45 @@ def _render_stage(fname: str, out_dir: str) -> None:
         ax.add_collection(lc)
 
     # Point markers (larger, all points numbered).
-    xs = [p[0] for p in path]
-    ys = [p[1] for p in path]
-    ax.scatter(xs, ys, s=40, c="#1f77b4", zorder=6, edgecolors="white", linewidths=0.8)
-    for idx in range(len(path)):
-        ax.annotate(
-            str(idx),
-            (path[idx][0], path[idx][1]),
-            textcoords="offset points",
-            xytext=(4, 4),
-            fontsize=6,
-            color="#333333",
-            fontweight="bold",
-        )
+    if path:
+        xs = [p[0] for p in path]
+        ys = [p[1] for p in path]
+        ax.scatter(xs, ys, s=40, c="#1f77b4", zorder=6, edgecolors="white", linewidths=0.8)
+        for idx in range(len(path)):
+            ax.annotate(
+                str(idx),
+                (path[idx][0], path[idx][1]),
+                textcoords="offset points",
+                xytext=(4, 4),
+                fontsize=6,
+                color="#333333",
+                fontweight="bold",
+            )
 
-    # Zoom to path + pads, not the full route bbox.
+    # Zoom bounds: min/max extent of ALL segments (path + candidate routes),
+    # padded by a buffer so wire collisions outside the pads stay visible.
+    # (Pads seed the view when a stage has no segments, e.g. lead-rejected pairs.)
     all_xs = [p[0] for p in path]
     all_ys = [p[1] for p in path]
     for _name, aabb in pads:
         all_xs.extend([aabb[0], aabb[2]])
         all_ys.extend([aabb[1], aabb[3]])
-    margin = 1.5  # mm
+    for cand in candidates:
+        for s in cand.get("segments", []):
+            all_xs.extend([s[0], s[2]])
+            all_ys.extend([s[1], s[3]])
+    margin = 3.0  # mm buffer around the visible extent
     ax.set_xlim(min(all_xs) - margin, max(all_xs) + margin)
     ax.set_ylim(min(all_ys) - margin, max(all_ys) + margin)
     ax.invert_yaxis()  # KiCad +Y=down
 
-    ax.set_title(f"Stage: {stage}  ({len(path)} pts)", fontsize=12)
+    title = f"Stage: {stage}  ({len(path)} pts)"
+    if highlight is not None:
+        hl_reasons = ",".join(candidates[highlight].get("reasons") or [])
+        title += f" — cand {highlight + 1}/{len([c for c in candidates if c.get('reasons')])}: {hl_reasons}"
+    if notes:
+        title += f" — {notes}" if len(title) + len(notes) < 110 else ""
+    ax.set_title(title, fontsize=12)
     ax.set_xlabel("X (mm)")
     ax.set_ylabel("Y (mm)")
 
@@ -153,27 +223,61 @@ def _render_stage(fname: str, out_dir: str) -> None:
         mpatches.Patch(color="#d62728", label="45° diag"),
         mpatches.Patch(color="#7f7f7f", label="Other"),
         mpatches.Patch(color="#ff7f0e", alpha=0.3, label="Pad AABB"),
+        mpatches.Patch(color="#d62728", alpha=0.45, label="Rejected candidate"),
+        mpatches.Patch(color="#999999", alpha=0.35, label="Other candidates"),
     ]
     ax.legend(handles=legend_patches, loc="upper right", fontsize=8)
 
-    out_path = os.path.join(out_dir, f"{ts}_{stage}.png")
     fig.tight_layout()
     fig.savefig(out_path, dpi=150)
     plt.close(fig)
     print(f"  → {out_path}")
 
 
+def _render_stage(fname: str, out_dir: str) -> None:
+    """Render a single stage JSON file to an overview PNG.
+
+    Handles both formats:
+    * PCB pipeline dumps: ``path`` polyline + ``pads`` AABBs + obstacle
+      polygons (``kcaa/router/router.py``).
+    * Schematic dumps: same base fields (pins become small ``pads``, wires
+      become thin ``obstacles``) plus an optional ``candidates`` list of
+      rejected routes with reasons and a ``notes`` string
+      (``kcaa/tools/wire_edit_tools.py``).
+    """
+    with open(fname) as f:
+        data = json.load(f)
+
+    stage = data["stage"]
+    ts = os.path.basename(fname).split("_")[0]
+    _render_scene(data, os.path.join(out_dir, f"{ts}_{stage}.png"))
+
+    # One image per rejected candidate so overlapping failures (the red
+    # "grid") can be inspected in isolation.
+    rejected = [
+        (i, c)
+        for i, c in enumerate(data.get("candidates") or [])
+        if (c.get("reasons") or [])
+        and any(abs(s[0] - s[2]) > 1e-9 or abs(s[1] - s[3]) > 1e-9 for s in c.get("segments", []))
+    ]
+    if len(rejected) > 1:
+        for idx, (_i, _c) in enumerate(rejected):
+            base = os.path.basename(fname)[:-5]  # strip .json
+            out_path = os.path.join(out_dir, f"{base}_cand{idx + 1}.png")
+            _render_scene(data, out_path, highlight=_i)
+
+
 def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <viz_dir> [run_prefix]")
-        print("  viz_dir     Path to kcaa_viz directory (e.g. ~/.config/kicad/10.0/kcaa/kcaa_viz)")
+        print("  viz_dir     Path to a viz directory. May be the top kcaa_viz")
+        print("              dir (recurses into sch_viz/ pcb_viz/) or a single")
+        print("              subdir such as kcaa_viz/sch_viz")
         print("  run_prefix  Optional: render only runs matching this prefix (e.g. 102451)")
         sys.exit(1)
     viz_dir = sys.argv[1]
-    out_dir = os.path.join(viz_dir, "png")
-    os.makedirs(out_dir, exist_ok=True)
 
-    json_files = sorted(glob.glob(os.path.join(viz_dir, "*.json")))
+    json_files = sorted(glob.glob(os.path.join(viz_dir, "**", "*.json"), recursive=True))
     if not json_files:
         print(f"No JSON files found in {viz_dir}")
         sys.exit(1)
@@ -200,8 +304,10 @@ def main():
         print(f"Ignoring {older} files from other runs.")
 
     for ts in sorted(matched):
-        print(f"Rendering {len(matched[ts])} stages ({ts}) → {out_dir}")
+        print(f"Rendering {len(matched[ts])} stages ({ts})")
         for fname in matched[ts]:
+            out_dir = os.path.join(os.path.dirname(fname), "png")
+            os.makedirs(out_dir, exist_ok=True)
             try:
                 _render_stage(fname, out_dir)
             except Exception as exc:

--- a/scripts/render_viz.py
+++ b/scripts/render_viz.py
@@ -88,6 +88,18 @@ def _render_scene(data: dict, out_path: str, highlight: int | None = None) -> No
     else:
         near_obs = []
 
+    # Pin symbol stubs: the lib-defined pin lines (2.54–3.81 mm) that wires
+    # must not run on top of.  Drawn as thin blue lines at a low zorder.
+    for sx0, sy0, sx1, sy1 in data.get("pin_stubs") or []:
+        ax.plot(
+            [sx0, sx1],
+            [sy0, sy1],
+            color="#2f6fd0",
+            linewidth=1.0,
+            alpha=0.7,
+            zorder=1,
+        )
+
     # Obstacles (gray fill, near path only). Dark enough to read as existing
     # wires while staying below the candidate/path zorder.
     for coords, kind, ref in near_obs[:60]:

--- a/scripts/render_viz.py
+++ b/scripts/render_viz.py
@@ -62,8 +62,12 @@ def _render_scene(data: dict, out_path: str, highlight: int | None = None) -> No
     ax.set_aspect("equal")
 
     # Filter obstacles to only those near the path (culling invisible ones).
+    # Schematic overview images (pair level, no highlight) keep *all*
+    # existing wires so the full net topology is visible; only the per-candidate
+    # close-ups crop to the neighbourhood of the drawn path.
+    is_schematic = "pin_stubs" in data  # schematic router dumps carry pin stubs
     if obstacles:
-        if path:
+        if path and not (is_schematic and highlight is None):
             # Get path bounding box.
             px = [p[0] for p in path]
             py = [p[1] for p in path]
@@ -100,9 +104,10 @@ def _render_scene(data: dict, out_path: str, highlight: int | None = None) -> No
             zorder=1,
         )
 
-    # Obstacles (gray fill, near path only). Dark enough to read as existing
-    # wires while staying below the candidate/path zorder.
-    for coords, kind, ref in near_obs[:60]:
+    # Obstacles (gray fill). Dark enough to read as existing wires while
+    # staying below the candidate/path zorder.  The 60-polygon cap only
+    # applies to cropped views; schematic overviews draw everything.
+    for coords, kind, ref in near_obs if is_schematic else near_obs[:60]:
         xs = [c[0] for c in coords]
         ys = [c[1] for c in coords]
         ax.fill(xs, ys, alpha=0.3, color="#666666", linewidth=0.4, edgecolor="#999999")


### PR DESCRIPTION
## Problem

Routes can be drawn on top of component pin symbols. In the reported case (U11 p5 → J1 p8), the third segment of the L-shaped net `(147.96, 85.09) → (157.48, 85.09)` was collinear with the real KiCad pin graphics of J1 pin7 (overlap 0.63 mm) and pin8 (3.81 mm).

Root cause: the pin-symbol collision gate checked collision bodies ("stubs") that were geometrically wrong:

- **Direction flipped 180°.** Stubs were built from `_dir_vec(pin.angle)` (the wire-exit direction), but KiCad draws a pin symbol *from the electrical point into the component body* — the opposite direction. J1 pin7 (exit 180°) got a stub west of the pin `[142.24, 144.78]`, while the real symbol extends east `[144.78, 148.59]`.
- **Length fell back to 2.54 mm.** `lib_id` → `lib_symbols` matching failed (embedded lib ids contain `-`, which skip's sanitised attribute names convert to `_`), so J1's real 3.81 mm pin length was never read.

## Fix

- `_collect_pin_symbol_stubs`: stubs now run toward the component body `((angle + 180) % 360)`.
- `_symbol_pin_lengths`: read true symbol lengths from embedded `lib_symbols` (`Pin_N` attributes), keyed by sanitised lib id (incl. `-` → `_`).
- `_try_angle_config`: conflict-driven lead-length sweep — when every candidate fails at the anchor length, retry the candidate family with neighbouring lead lengths (2.54 ± k·0.635 mm). This rescues routes whose default exit point is blocked, e.g. U11 p16 → J1 16, which previously failed because its end-lead tip sat in the blocked x=160.02 wire column.

## Verification

- Segment gate replay on the old third segment → `['pin-overlap', 'wire-overlap']` (previously passed).
- Routed paths for U11 p5 → J1 8 and U11 p16 → J1 16: 0 pin-symbol violations on the final path.
- 8-pair sweep (U11 p1/p2/p3/p5/p7/p11/p15/p16 → J1) all route successfully.
- ruff check / format / bandit pass.
- Render dump confirms stubs (blue) match KiCad pin graphics direction and length.