### PR TITLE
fix(plugin): make context management prefix-cache friendly

### DIFF
--- a/kicad_plugin/context_bridge.py
+++ b/kicad_plugin/context_bridge.py
@@ -29,14 +29,12 @@ def collect_context() -> dict[str, Any]:
         active_project     Absolute path to .kicad_pro, or None
         active_schematic   Absolute path to .kicad_sch (root), or None
         active_pcb         Absolute path to .kicad_pcb, or None
-        selected_refs      List of component reference strings currently selected
         active_sheet       Sheet path in hierarchical schematics, or None
     """
     ctx: dict[str, Any] = {
         "active_project": None,
         "active_schematic": None,
         "active_pcb": None,
-        "selected_refs": [],
         "active_sheet": None,
     }
 
@@ -46,7 +44,7 @@ def collect_context() -> dict[str, Any]:
         return ctx
 
     # ------------------------------------------------------------------ #
-    # PCB file path + selection (single GetBoard() call)
+    # PCB file path (single GetBoard() call)
     # ------------------------------------------------------------------ #
     try:
         board = pcbnew.GetBoard()
@@ -64,16 +62,6 @@ def collect_context() -> dict[str, Any]:
                 sch_path = os.path.join(proj_dir, proj_name + ".kicad_sch")
                 if os.path.exists(sch_path):
                     ctx["active_schematic"] = os.path.abspath(sch_path)
-
-            # Collect selected footprint references
-            selection = []
-            for fp in board.GetFootprints():
-                try:
-                    if fp.IsSelected():
-                        selection.append(fp.GetReference())
-                except Exception as e:
-                    log.debug("Could not get footprint reference: %s", e)
-            ctx["selected_refs"] = selection
     except Exception as e:
         log.debug("Could not collect PCB context: %s", e)
 
@@ -101,12 +89,6 @@ def context_to_system_prompt_block(ctx: dict[str, Any]) -> str:
         lines.append(f"Active PCB: {ctx['active_pcb']}")
     else:
         lines.append("Active PCB: (none)")
-
-    refs = ctx.get("selected_refs", [])
-    if refs:
-        lines.append(f"Selected components: {', '.join(refs)}")
-    else:
-        lines.append("Selected components: (none)")
 
     if ctx.get("active_sheet"):
         lines.append(f"Active sheet path: {ctx['active_sheet']}")

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -1066,23 +1066,36 @@ class LLMClient:
             )
 
     def _maybe_compact(self, system_prompt: str) -> None:
-        """Dedup tool calls then, if the token budget is exceeded, compact history.
+        """Manage history purely by token budget.
 
-        This is the sole history-management entry point; called once per user turn
-        before the LLM is invoked.
+        Under budget, history is left byte-identical (append-only growth), so
+        provider automatic prefix caches stay valid across turns.  All history
+        mutation — dedup of superseded tool turns, stale-query annotations, and
+        compaction — happens only once the budget is exceeded.
+
+        The one exception is ``_prune_rollback_history``: restoring an earlier
+        file version invalidates prior tool turns, so those are removed every
+        turn for correctness regardless of budget (rare, restore-only).
         """
         self._prune_rollback_history()
-        self._annotate_stale_queries()
-        self._dedup_tool_calls()
 
+        # ---- Budget check --------------------------------------------------
         system_tokens = len(system_prompt) // 4
         history_tokens = self._estimate_tokens(self._history)
         used = system_tokens + history_tokens
         budget = self._context_tokens * self._compact_threshold
 
         if used <= budget:
-            return  # well within limits, nothing to do
+            return  # well within limits — history stays append-only for cache
 
+        # ---- Over budget: cheapest saving first — drop superseded turns ----
+        self._dedup_tool_calls()
+        history_tokens = self._estimate_tokens(self._history)
+        used = system_tokens + history_tokens
+        if used <= budget:
+            return  # dedup alone brought us back within budget
+
+        # ---- Still over budget: compact, then annotate preserved turns -----
         # Estimate the cost of the recent turns we will always keep
         i = len(self._history) - 1
         turns_found = 0
@@ -1107,6 +1120,10 @@ class LLMClient:
 
         self._compact_history(system_prompt, target_summary_chars)
         self._validate_history()  # compaction rebuilds history; verify integrity
+
+        # Annotate stale query results among the preserved turns only — the
+        # compacted prefix is summarized, so nothing earlier needs marking.
+        self._annotate_stale_queries()
 
     @staticmethod
     def _tool_result_succeeded(result: Any) -> bool:

--- a/tests/unit/plugin/test_context_bridge.py
+++ b/tests/unit/plugin/test_context_bridge.py
@@ -15,7 +15,6 @@ class TestCollectContextNoPcbnew:
         assert ctx["active_project"] is None
         assert ctx["active_schematic"] is None
         assert ctx["active_pcb"] is None
-        assert ctx["selected_refs"] == []
         assert ctx["active_sheet"] is None
 
     def test_returns_dict(self):
@@ -27,11 +26,10 @@ class TestCollectContextNoPcbnew:
 class TestCollectContextWithPcbnew:
     """Tests for the pcbnew-available code path."""
 
-    def _make_mock_pcbnew(self, pcb_path=None, footprints=None):
+    def _make_mock_pcbnew(self, pcb_path=None):
         mock_pcbnew = MagicMock()
         mock_board = MagicMock()
         mock_board.GetFileName.return_value = pcb_path or ""
-        mock_board.GetFootprints.return_value = footprints or []
         mock_pcbnew.GetBoard.return_value = mock_board
         mock_pcbnew.GetCurrentFrame.return_value = None
         return mock_pcbnew
@@ -86,30 +84,6 @@ class TestCollectContextWithPcbnew:
 
         assert isinstance(ctx, dict)
 
-    def test_selected_refs_populated(self, tmp_path):
-        pcb = str(tmp_path / "test.kicad_pcb")
-        open(pcb, "w").close()
-
-        fp1 = MagicMock()
-        fp1.IsSelected.return_value = True
-        fp1.GetReference.return_value = "R1"
-
-        fp2 = MagicMock()
-        fp2.IsSelected.return_value = False
-
-        fp3 = MagicMock()
-        fp3.IsSelected.return_value = True
-        fp3.GetReference.return_value = "U1"
-
-        mock_pcbnew = self._make_mock_pcbnew(pcb_path=pcb, footprints=[fp1, fp2, fp3])
-
-        with patch("kicad_plugin.context_bridge._try_import_pcbnew", return_value=mock_pcbnew):
-            ctx = collect_context()
-
-        assert "R1" in ctx["selected_refs"]
-        assert "U1" in ctx["selected_refs"]
-        assert len(ctx["selected_refs"]) == 2
-
 
 class TestContextToSystemPromptBlock:
     def test_includes_active_project(self):
@@ -117,7 +91,6 @@ class TestContextToSystemPromptBlock:
             "active_project": "/proj/test.kicad_pro",
             "active_schematic": "/proj/test.kicad_sch",
             "active_pcb": None,
-            "selected_refs": ["R1", "C3"],
             "active_sheet": None,
         }
         block = context_to_system_prompt_block(ctx)
@@ -128,30 +101,16 @@ class TestContextToSystemPromptBlock:
             "active_project": None,
             "active_schematic": "/proj/test.kicad_sch",
             "active_pcb": None,
-            "selected_refs": [],
             "active_sheet": None,
         }
         block = context_to_system_prompt_block(ctx)
         assert "/proj/test.kicad_sch" in block
-
-    def test_includes_selected_refs(self):
-        ctx = {
-            "active_project": None,
-            "active_schematic": "/proj/test.kicad_sch",
-            "active_pcb": None,
-            "selected_refs": ["U1", "U2"],
-            "active_sheet": None,
-        }
-        block = context_to_system_prompt_block(ctx)
-        assert "U1" in block
-        assert "U2" in block
 
     def test_no_project_shows_none(self):
         ctx = {
             "active_project": None,
             "active_schematic": None,
             "active_pcb": None,
-            "selected_refs": [],
             "active_sheet": None,
         }
         block = context_to_system_prompt_block(ctx)
@@ -162,7 +121,6 @@ class TestContextToSystemPromptBlock:
             "active_project": None,
             "active_schematic": "/proj/board.kicad_sch",
             "active_pcb": None,
-            "selected_refs": [],
             "active_sheet": None,
         }
         block = context_to_system_prompt_block(ctx)
@@ -174,7 +132,6 @@ class TestContextToSystemPromptBlock:
             "active_project": None,
             "active_schematic": None,
             "active_pcb": None,
-            "selected_refs": [],
             "active_sheet": None,
         }
         block = context_to_system_prompt_block(ctx)
@@ -185,7 +142,6 @@ class TestContextToSystemPromptBlock:
             "active_project": None,
             "active_schematic": None,
             "active_pcb": None,
-            "selected_refs": [],
             "active_sheet": None,
         }
         assert isinstance(context_to_system_prompt_block(ctx), str)
@@ -196,7 +152,6 @@ class TestContextToSystemPromptBlock:
             "active_project": None,
             "active_schematic": None,
             "active_pcb": pcb,
-            "selected_refs": [],
             "active_sheet": None,
         }
         block = context_to_system_prompt_block(ctx)
@@ -208,7 +163,6 @@ class TestContextToSystemPromptBlock:
             "active_project": None,
             "active_schematic": "/proj/board.kicad_sch",
             "active_pcb": None,
-            "selected_refs": [],
             "active_sheet": None,
         }
         block = context_to_system_prompt_block(ctx)

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -286,15 +286,100 @@ class TestMaybeCompact:
         called_args = mock_compact.call_args.args
         assert called_args[1] >= 200  # at least the minimum floor
 
-    def test_dedup_always_called(self):
-        client = _make_client()
+    def test_history_unmodified_under_budget(self):
+        """Under budget: history is append-only — no dedup, no annotation, no compaction."""
+        client = _make_client(context_tokens=128_000, compact_threshold=0.70)
         client._history = [_user("hi"), _assistant("hello")]
         with (
             patch.object(client, "_dedup_tool_calls") as mock_dedup,
-            patch.object(client, "_compact_history"),
+            patch.object(client, "_annotate_stale_queries") as mock_annotate,
+            patch.object(client, "_compact_history") as mock_compact,
+        ):
+            client._maybe_compact("short system prompt")
+        mock_dedup.assert_not_called()
+        mock_annotate.assert_not_called()
+        mock_compact.assert_not_called()
+
+    def test_dedup_called_over_budget(self):
+        """Dedup runs only once the budget is exceeded."""
+        client = _make_client(
+            context_tokens=100, compact_threshold=0.70, compact_target=0.40, keep_recent_turns=2
+        )
+        big_content = "x" * 400  # ~100 tokens each
+        client._history = [
+            _user(big_content),
+            _assistant(big_content),
+            _user(big_content),
+            _assistant(big_content),
+            _user(big_content),
+            _assistant(big_content),
+        ]
+        with (
+            patch.object(client, "_dedup_tool_calls") as mock_dedup,
+            patch.object(client, "_compact_history", return_value=True),
+            patch.object(client, "_annotate_stale_queries"),
         ):
             client._maybe_compact("system")
         mock_dedup.assert_called_once()
+
+    def test_dedup_can_avoid_compaction(self):
+        """Dedup alone can bring history back under budget — compact is skipped."""
+        client = _make_client(
+            context_tokens=200, compact_threshold=0.70, compact_target=0.40, keep_recent_turns=2
+        )
+        # ~270 estimated tokens: over the 140 budget. tc1's big tool result is a
+        # superseded duplicate of tc2, so dedup drops that whole turn.
+        client._history = [
+            _user("q1"),
+            _assistant(
+                "t1",
+                tool_calls=[
+                    {"id": "tc1", "function": {"name": "extract_netlist", "arguments": "{}"}}
+                ],
+            ),
+            _tool("tc1", "x" * 400),
+            _user("q2"),
+            _assistant(
+                "t2",
+                tool_calls=[
+                    {"id": "tc2", "function": {"name": "extract_netlist", "arguments": "{}"}}
+                ],
+            ),
+            _tool("tc2", "y" * 200),
+        ]
+        with (
+            patch.object(client, "_compact_history") as mock_compact,
+            patch.object(client, "_annotate_stale_queries") as mock_annotate,
+        ):
+            client._maybe_compact("system")
+        # tc1's turn was pruned, leaving ~120 tokens — back under budget
+        assert not any(m.get("tool_call_id") == "tc1" for m in client._history)
+        mock_compact.assert_not_called()
+        mock_annotate.assert_not_called()
+
+    def test_annotate_runs_after_compaction(self):
+        """Stale annotation runs after compaction, on the preserved turns only."""
+        client = _make_client(
+            context_tokens=100, compact_threshold=0.70, compact_target=0.40, keep_recent_turns=2
+        )
+        big_content = "x" * 400
+        client._history = [
+            _user(big_content),
+            _assistant(big_content),
+            _user(big_content),
+            _assistant(big_content),
+            _user(big_content),
+            _assistant(big_content),
+        ]
+        call_order: list[str] = []
+        with (
+            patch.object(client, "_compact_history", return_value=True) as mock_compact,
+            patch.object(client, "_annotate_stale_queries") as mock_annotate,
+        ):
+            mock_compact.side_effect = lambda *a, **k: call_order.append("compact")
+            mock_annotate.side_effect = lambda: call_order.append("annotate")
+            client._maybe_compact("system")
+        assert call_order == ["compact", "annotate"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #70

## Summary

Context management currently destroys LLM prefix caches on nearly every turn:

- **Dynamic system prompt**: `selected_refs` (live PCB editor selection) was rendered into the system prompt on every user turn. The system prompt is the first request element, so any selection change invalidates the entire cached prefix.
- **Per-turn history mutation**: `_dedup_tool_calls` and `_annotate_stale_queries` ran unconditionally in `_maybe_compact`, deleting superseded tool turns and rewriting earlier tool results in place — resets the cache from the mutation point forward, repeatedly.

Tool calls/results are deterministic server content and ideal cache material; the design invalidated it.

## Changes

- **`kicad_plugin/context_bridge.py`**: remove `selected_refs` from `collect_context()` and `context_to_system_prompt_block()`. System prompt is now static path fields only.
- **`kicad_plugin/llm_client.py`**: rework `_maybe_compact()` to be budget-gated:
  - Under budget: history stays byte-identical (append-only growth) → provider prefix caches stay valid across turns.
  - Over budget: `_dedup_tool_calls` → re-estimate → only if still over: `_compact_history` → `_validate_history` → `_annotate_stale_queries`.
  - `_prune_rollback_history` remains per-turn (correctness: `restore_file_version` invalidation; rare).

## Tests

- `tests/unit/plugin/test_context_bridge.py`: removed selected_refs collection/rendering tests.
- `tests/unit/plugin/test_llm_client.py`: `TestMaybeCompact` now asserts history is unmodified under budget, dedup runs over budget, dedup alone can avoid compaction, and annotation runs after compaction.
- 62 passed (affected files); 101 passed (plugin suite excluding environment-dependent `test_settings` KiCad-version detection); ruff check/format + bandit clean.