### PR TITLE
chore: sync develop into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,26 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    name: Detect Changed Paths
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      pyproject: ${{ steps.filter.outputs.pyproject }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - 'kcaa/**'
+            - 'kicad_plugin/**'
+            - 'tests/**'
+            - 'uv.lock'
+          pyproject:
+            - 'pyproject.toml'
+
   lint:
     runs-on: ubuntu-latest
     name: Lint and Format
@@ -34,6 +54,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Test Python 3.13
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     env:
       KICAD_VERSION: "10"
 
@@ -73,6 +95,8 @@ jobs:
   security:
     runs-on: ubuntu-latest
     name: Security Scan
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
 
     steps:
     - uses: actions/checkout@v4
@@ -96,6 +120,8 @@ jobs:
   test-windows:
     runs-on: windows-latest
     name: Test Windows (integration)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     env:
       KICAD_MCP_PROFILE: "plugin"
       KICAD_VERSION: "10"
@@ -130,7 +156,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Package
-    needs: [lint, test]
+    needs: [lint, test, changes]
+    # Run when code OR pyproject.toml (e.g. version bump) changed; do not run
+    # when a prerequisite failed, but do run when test was skipped
+    # (pyproject-only PRs still validate packaging metadata).
+    if: (needs.changes.outputs.code == 'true' || needs.changes.outputs.pyproject == 'true') && needs.lint.result != 'failure' && needs.test.result != 'failure'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcaa"
-version = "0.1.9"
+version = "0.2.0"
 description = "Model Context Protocol (MCP) server for KiCad electronic design automation (EDA) files"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "kcaa"
-version = "0.1.9"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

Sync `develop` into `main` — 1 commit:

- **#73** — `chore(version)`: bump version to `0.2.0` + CI paths-filter (skip test/security jobs when no code changes; `pyproject.toml`-only PRs still run lint + build).

## Notes

- Develop is ahead of main by exactly this merge (previous sync #72 already landed).
- New CI logic validated on #73: `Detect Changed Paths` job runs, full suite executed on the code-change path.