### PR TITLE
feat(plugin): stream LLM responses via subprocess relay and unify timeouts

### DIFF
--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -247,6 +247,211 @@ sys.stdout.write(json.dumps(result))
 sys.stdout.flush()
 """
 
+# Environment allowlist for plugin-venv subprocesses. KiCad's AppImage sets
+# PYTHONHOME/PYTHONPATH/LD_LIBRARY_PATH for its own embedded interpreter;
+# inheriting them would break the venv Python.
+_SUBPROCESS_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "XDG_RUNTIME_DIR",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Build a clean environment for plugin-venv subprocesses."""
+    return {k: os.environ[k] for k in _SUBPROCESS_ENV_ALLOWLIST if k in os.environ}
+
+
+# Subprocess SSE relay: read raw body bytes from stdin, perform the POST,
+# stream-parse the SSE response, and relay parsed deltas back over stdout.
+# Used when in-process SSL is unavailable so streaming still works with the
+# same per-read socket timeout as the in-process path.
+# Protocol (one JSON payload per line, whitespace-separated kind prefix):
+#   SSE-DATA  {"content": "..."}  text delta -> on_text_delta
+#   SSE-DONE  {"finish_reason": ..., "message": {...}}
+#   SSE-ERROR {"kind": "exception", "error": "..."} |
+#             {"status": <http_code>, "body": "..."} |
+#             {"kind": "stream", "error": "..."}
+_SUBPROCESS_SSE_SCRIPT = r"""
+import json, sys, urllib.request, urllib.error
+
+
+def emit(kind, payload):
+    sys.stdout.write("%s %s\n" % (kind, json.dumps(payload)))
+    sys.stdout.flush()
+
+
+try:
+    url = sys.argv[1]
+    headers = json.loads(sys.argv[2])
+    timeout = float(sys.argv[3])
+    fmt = sys.argv[4]
+    body = sys.stdin.buffer.read()
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if fmt == "anthropic":
+                text_blocks = {}
+                tool_blocks = {}
+                stop_reason = "end_turn"
+                current_event = ""
+                while True:
+                    raw = resp.readline()
+                    if raw == b"":
+                        break
+                    line = raw.decode("utf-8", "replace").rstrip("\r\n")
+                    if line.startswith("event:"):
+                        current_event = line[6:].strip()
+                        continue
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[5:].strip()
+                    try:
+                        event_data = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+                    etype = event_data.get("type", current_event)
+                    if etype == "content_block_start":
+                        idx = event_data.get("index", 0)
+                        block = event_data.get("content_block", {})
+                        btype = block.get("type")
+                        if btype == "text":
+                            text_blocks[idx] = block.get("text", "")
+                        elif btype == "tool_use":
+                            tool_blocks[idx] = {
+                                "id": block["id"],
+                                "name": block["name"],
+                                "input_json": "",
+                            }
+                    elif etype == "content_block_delta":
+                        idx = event_data.get("index", 0)
+                        delta = event_data.get("delta", {})
+                        dtype = delta.get("type")
+                        if dtype == "text_delta":
+                            chunk = delta.get("text", "")
+                            text_blocks[idx] = text_blocks.get(idx, "") + chunk
+                            if chunk:
+                                emit("SSE-DATA", {"content": chunk})
+                        elif dtype == "input_json_delta":
+                            partial = delta.get("partial_json", "")
+                            if idx in tool_blocks:
+                                tool_blocks[idx]["input_json"] += partial
+                    elif etype == "message_delta":
+                        sr = event_data.get("delta", {}).get("stop_reason")
+                        if sr:
+                            stop_reason = sr
+                    elif etype == "error":
+                        err = event_data.get("error", {})
+                        emit("SSE-ERROR", {"kind": "stream", "error": err.get("message", str(err))})
+                        sys.exit(0)
+                full_text = "\n".join(text_blocks[k] for k in sorted(text_blocks))
+                tool_calls = []
+                for k in sorted(tool_blocks):
+                    tb = tool_blocks[k]
+                    try:
+                        inp = json.loads(tb["input_json"]) if tb["input_json"] else {}
+                    except json.JSONDecodeError:
+                        inp = {}
+                    tool_calls.append({
+                        "id": tb["id"], "type": "function",
+                        "function": {"name": tb["name"], "arguments": json.dumps(inp)},
+                    })
+                message_out = {"content": full_text}
+                if tool_calls:
+                    message_out["tool_calls"] = tool_calls
+                finish = "tool_calls" if tool_calls else "stop"
+                if stop_reason == "max_tokens":
+                    finish = "stop"
+                emit("SSE-DONE", {"finish_reason": finish, "message": message_out})
+                sys.exit(0)
+
+            # fmt == "openai"
+            text_parts = []
+            tool_calls = {}
+            finish_reason = "stop"
+            reasoning = []
+            while True:
+                raw = resp.readline()
+                if raw == b"":
+                    break
+                line = raw.decode("utf-8", "replace").rstrip("\r\n")
+                if not line.startswith("data:"):
+                    continue
+                data_str = line[5:].strip()
+                if data_str == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+                choice = chunk.get("choices", [{}])[0]
+                fr = choice.get("finish_reason")
+                if fr is not None:
+                    finish_reason = fr
+                delta = choice.get("delta", {})
+                content = delta.get("content")
+                if content:
+                    text_parts.append(content)
+                    emit("SSE-DATA", {"content": content})
+                reasoning_part = delta.get("reasoning_content")
+                if reasoning_part:
+                    reasoning.append(reasoning_part)
+                for tc_delta in delta.get("tool_calls") or []:
+                    idx = tc_delta["index"]
+                    if idx not in tool_calls:
+                        tool_calls[idx] = {
+                            "id": "", "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        }
+                    tc = tool_calls[idx]
+                    if tc_delta.get("id"):
+                        tc["id"] += tc_delta["id"]
+                    fn = tc_delta.get("function", {})
+                    if fn.get("name"):
+                        tc["function"]["name"] += fn["name"]
+                    if fn.get("arguments"):
+                        tc["function"]["arguments"] += fn["arguments"]
+            tool_calls_list = [tool_calls[k] for k in sorted(tool_calls)]
+            message_out = {"content": "".join(text_parts)}
+            if tool_calls_list:
+                message_out["tool_calls"] = tool_calls_list
+            if reasoning:
+                message_out["reasoning_content"] = "".join(reasoning)
+            emit("SSE-DONE", {"finish_reason": finish_reason, "message": message_out})
+            sys.exit(0)
+    except urllib.error.HTTPError as e:
+        emit("SSE-ERROR", {"status": e.code, "body": e.read().decode("utf-8", "replace")})
+        sys.exit(0)
+    except Exception as e:
+        emit("SSE-ERROR", {"kind": "exception", "error": f"{type(e).__name__}: {e}"})
+        sys.exit(0)
+except Exception as e:
+    emit("SSE-ERROR", {"kind": "exception", "error": f"subprocess setup error: {type(e).__name__}: {e}"})
+    sys.exit(0)
+"""
+
 
 def _https_post_json(
     url: str,
@@ -290,35 +495,7 @@ def _https_post_json(
         )
 
     # Build a clean env using an explicit allowlist (mirrors ServerManager).
-    # KiCad's AppImage sets PYTHONHOME/PYTHONPATH/LD_LIBRARY_PATH for its own
-    # embedded interpreter; inheriting them would break the venv Python.
-    _ENV_ALLOWLIST = (
-        "PATH",
-        "HOME",
-        "USER",
-        "LOGNAME",
-        "LANG",
-        "LC_ALL",
-        "LC_CTYPE",
-        "TMPDIR",
-        "TEMP",
-        "TMP",
-        "XDG_RUNTIME_DIR",
-        "XDG_CONFIG_HOME",
-        "XDG_DATA_HOME",
-        "XDG_CACHE_HOME",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-        "http_proxy",
-        "https_proxy",
-        "no_proxy",
-        "SSL_CERT_FILE",
-        "SSL_CERT_DIR",
-        "REQUESTS_CA_BUNDLE",
-        "CURL_CA_BUNDLE",
-    )
-    clean_env = {k: os.environ[k] for k in _ENV_ALLOWLIST if k in os.environ}
+    clean_env = _subprocess_env()
 
     try:
         proc = subprocess.run(  # nosec B603 -- input is validated
@@ -345,6 +522,122 @@ def _https_post_json(
     if status == 0:
         raise RuntimeError(f"HTTPS request failed: {out.get('error', 'unknown error')}")
     return int(status), str(out.get("body", ""))
+
+
+def _subprocess_sse_stream(
+    url: str,
+    headers: dict[str, str],
+    payload: bytes,
+    timeout: float,
+    fmt: str,
+    on_text_delta: Callable[[str], None] | None,
+) -> dict[str, Any]:
+    """Stream an HTTP SSE response through the plugin-venv Python subprocess.
+
+    Mirrors the in-process streaming path when KiCad's embedded Python lacks
+    SSL: the subprocess owns the socket (its ``urlopen`` timeout is the same
+    per-read deadline as in-process), parses deltas, and relays them over
+    stdout via ``SSE-DATA`` / ``SSE-DONE`` / ``SSE-ERROR`` lines.
+
+    Returns the same shape as the in-process ``_stream_*`` methods, including
+    the ``{"error": ...}`` convention.
+    """
+    venv_python = _resolve_plugin_python()
+    if not venv_python:
+        return {
+            "error": (
+                "KiCad's embedded Python lacks SSL support and no plugin venv "
+                "Python was found. Run 'kicad_plugin/setup_plugin.sh' to create one."
+            )
+        }
+
+    proc = subprocess.Popen(  # nosec B603 -- input is validated
+        [
+            venv_python,
+            "-u",
+            "-I",
+            "-c",
+            _SUBPROCESS_SSE_SCRIPT,
+            url,
+            json.dumps(headers),
+            str(timeout),
+            fmt,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_subprocess_env(),
+    )
+    if proc.stdin is None or proc.stdout is None:
+        proc.kill()
+        return {"error": "HTTPS subprocess stream could not be started"}
+    try:
+        proc.stdin.write(payload)
+        proc.stdin.close()
+    except OSError as e:
+        proc.kill()
+        return {"error": f"HTTPS request failed: {e}"}
+
+    done: dict[str, Any] | None = None
+    error_result: dict[str, Any] | None = None
+    for raw in proc.stdout:
+        line = raw.decode("utf-8", "replace").rstrip("\r\n")
+        kind, _, body = line.partition(" ")
+        if kind == "SSE-DATA" and body:
+            try:
+                content = json.loads(body).get("content") or ""
+            except json.JSONDecodeError:
+                continue
+            if content and on_text_delta is not None:
+                try:
+                    on_text_delta(content)
+                except Exception as e:  # noqa: BLE001 -- UI callback errors must not kill the turn
+                    log.debug("Subprocess text delta callback error: %s", e)
+        elif kind == "SSE-DONE" and body:
+            try:
+                done = json.loads(body)
+            except json.JSONDecodeError as e:
+                return {"error": f"HTTPS subprocess returned invalid SSE-DONE: {e}"}
+        elif kind == "SSE-ERROR" and body:
+            try:
+                err = json.loads(body)
+            except json.JSONDecodeError:
+                error_result = {
+                    "error": f"HTTPS subprocess returned invalid SSE-ERROR: {body[:200]}"
+                }
+                break
+            if err.get("kind") == "exception":
+                error_result = {"error": f"HTTPS request failed: {err['error']}"}
+                break
+            status = err.get("status")
+            if status:
+                error_result = {"error": f"HTTP {status}: {err.get('body', '')[:200]}"}
+                break
+            error_result = {"error": f"HTTPS request failed: {err.get('error', 'unknown error')}"}
+            break
+
+    if error_result is not None:
+        return error_result
+    if done is None:
+        stderr_tail = ""
+        if proc.stderr is not None:
+            stderr_tail = proc.stderr.read().decode("utf-8", "replace")[:500]
+        return {
+            "error": "HTTPS subprocess stream ended unexpectedly "
+            f"(exit {proc.returncode}): {stderr_tail}"
+        }
+    try:
+        proc.wait(timeout=30)  # recycle; the relay exits right after SSE-DONE
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+    message: dict[str, Any] = {"content": (done.get("message") or {}).get("content", "")}
+    done_message = done.get("message") or {}
+    if done_message.get("tool_calls"):
+        message["tool_calls"] = done_message["tool_calls"]
+    if done_message.get("reasoning_content"):
+        message["reasoning_content"] = done_message["reasoning_content"]
+    return {"finish_reason": done.get("finish_reason", "stop"), "message": message}
 
 
 # ---------------------------------------------------------------------------
@@ -1686,19 +1979,14 @@ class LLMClient:
                 if _NO_HTTPS_MARKER not in str(e.reason):
                     return {"error": f"HTTPS request failed: {e}"}
                 _in_process_ssl = False
-                # Fall through to non-streaming fallback below.
+                # Fall through to subprocess streaming below.
             except Exception as e:
                 return {"error": f"Streaming request failed: {e}"}
 
-        # In-process SSL unavailable: fall back to non-streaming via subprocess.
-        result = self._call_openai(system, tools)
-        content = result.get("message", {}).get("content", "")
-        if content:
-            try:
-                on_text_delta(content)
-            except Exception as e:
-                log.debug("Non-streaming callback error: %s", e)
-        return result
+        # In-process SSL unavailable: stream via the plugin-venv Python subprocess.
+        return _subprocess_sse_stream(
+            url, headers, payload, timeout=300, fmt="openai", on_text_delta=on_text_delta
+        )
 
     def _ollama_messages(self) -> list[dict[str, Any]]:
         """Convert self._history to Ollama /api/chat message format.
@@ -1961,19 +2249,14 @@ class LLMClient:
                 if _NO_HTTPS_MARKER not in str(e.reason):
                     return {"error": f"HTTPS request failed: {e}"}
                 _in_process_ssl = False
-                # Fall through to non-streaming fallback below.
+                # Fall through to subprocess streaming below.
             except Exception as e:
                 return {"error": f"Streaming request failed: {e}"}
 
-        # In-process SSL unavailable: fall back to non-streaming via subprocess.
-        result = self._call_anthropic(system, tools)
-        content = result.get("message", {}).get("content", "")
-        if content:
-            try:
-                on_text_delta(content)
-            except Exception as e:
-                log.debug("Non-streaming callback error: %s", e)
-        return result
+        # In-process SSL unavailable: stream via the plugin-venv Python subprocess.
+        return _subprocess_sse_stream(
+            url, headers, encoded, timeout=300, fmt="anthropic", on_text_delta=on_text_delta
+        )
 
     def _call_openai(self, system: str, tools: list[dict]) -> dict[str, Any]:
         base = (self._settings.llm_base_url or "https://api.openai.com").rstrip("/")
@@ -2000,7 +2283,7 @@ class LLMClient:
             "Authorization": f"Bearer {self._settings.llm_api_key}",
         }
         try:
-            status, text = _https_post_json(url, headers, payload, timeout=60)
+            status, text = _https_post_json(url, headers, payload, timeout=300)
         except RuntimeError as e:
             return {"error": str(e)}
 
@@ -2043,7 +2326,7 @@ class LLMClient:
         headers = {"Content-Type": "application/json"}
 
         try:
-            status, text = _https_post_json(url, headers, payload, timeout=60)
+            status, text = _https_post_json(url, headers, payload, timeout=300)
         except RuntimeError as e:
             return {"error": str(e)}
 
@@ -2103,7 +2386,7 @@ class LLMClient:
             "anthropic-version": "2023-06-01",
         }
         try:
-            status, text = _https_post_json(url, headers, encoded, timeout=60)
+            status, text = _https_post_json(url, headers, encoded, timeout=300)
         except RuntimeError as e:
             return {"error": str(e)}
 

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -127,12 +127,14 @@ if _WX_AVAILABLE:
             # True once the shell HTML (CSS + JS framework + empty containers)
             # has been successfully loaded into the WebView.
             self._shell_loaded: bool = False
-            # True while any RunScript call is in-flight.  On Windows WebView2,
-            # RunScript pumps the message loop; we guard against re-entrant
-            # RunScript calls with this flag.
+            # True while any WebView script is in-flight.  On Windows WebView2,
+            # RunScript pumps the message loop; re-entrant RunScript calls are
+            # guarded by _run_script, the only place that writes this flag.
             self._js_running: bool = False
-            # Set when a render is skipped (due to shell not loaded or
-            # _js_running).  The next opportunity triggers a deferred render.
+            # Set when a render is skipped (script in flight / shell not
+            # loaded / page loading).  Flushed as a full-conversation rebuild
+            # by whoever releases the render lock, or by the shell-load
+            # completion path.
             self._render_pending: bool = False
             # True when the stream-wrapper table is visible in the shell.
             self._stream_wrapper_visible: bool = False
@@ -740,6 +742,7 @@ if _WX_AVAILABLE:
             # Reset streaming state and start the flush timer
             self._stream_buffer.clear()
             self._pending_ai_text = ""
+            self._stream_delta_chars = 0
             self._tool_calls_made = False
             self._schematic_edited = False
             self._pcb_edited = False
@@ -750,8 +753,12 @@ if _WX_AVAILABLE:
             def _on_delta(chunk: str) -> None:
                 # Called from background thread — just push to buffer; timer handles UI
                 if self._cancel_event and self._cancel_event.is_set():
+                    if not state.get("cancel_dropped"):
+                        state["cancel_dropped"] = True
+                        log.debug("chat: dropping streamed chunks after cancel")
                     return
                 state["ai_turn_started"] = True
+                self._stream_delta_chars += len(chunk)
                 self._stream_buffer.append(chunk)
 
             def _run():
@@ -1314,6 +1321,16 @@ if _WX_AVAILABLE:
             self._stream_timer.Stop()
             self._on_stream_flush(None)
 
+            log.info(
+                "chat: _on_reply was_streamed=%s reply_len=%d pending_len=%d "
+                "buffer_left=%d delta_chars=%d",
+                was_streamed,
+                len(reply),
+                len(self._pending_ai_text),
+                len(self._stream_buffer),
+                getattr(self, "_stream_delta_chars", 0),
+            )
+
             # Hide streaming preview before appending the final entry
             if self._use_webview:
                 self._hide_stream_wrapper()
@@ -1337,12 +1354,19 @@ if _WX_AVAILABLE:
                         "text": self._pending_ai_text,
                         "timestamp": datetime.datetime.now().strftime("%H:%M:%S"),
                     }
+                    log.info(
+                        "chat: finalising streamed entry text_len=%d tail=%r",
+                        len(entry["text"]),
+                        entry["text"][-80:],
+                    )
                     self._conv_entries.append(entry)
                     self._pending_ai_text = ""
                     if self._use_webview and self._shell_loaded:
                         self._append_entry_js(entry, force_scroll_to_bottom=True)
                     else:
                         self._render_conversation(force_scroll_to_bottom=True)
+            # Any deferral during the turn is flushed by the lock holder's
+            # release (_run_script), so no turn-end safety net is needed.
             self._busy = False
             self._cancel_event = None
             self._toggle_send_stop(busy=False)
@@ -1372,8 +1396,14 @@ if _WX_AVAILABLE:
                 # Incremental DOM update — should always succeed with shell loaded
                 if self._incremental_stream_update():
                     return
-                # Shell not loaded yet — defer
-                self._render_pending = True
+                # Deferred (lock busy / shell not loaded) or update failed:
+                # _run_script already recorded _render_pending, so a full
+                # rebuild will replay (and the next flush re-shows stream
+                # text).  Nothing to bookkeep here.
+                log.warning(
+                    "chat: stream flush deferred render (pending=%d chars)",
+                    len(self._pending_ai_text),
+                )
             else:
                 self._render_conversation(force_scroll_to_bottom=self._follow_output_to_bottom)
 
@@ -1381,9 +1411,11 @@ if _WX_AVAILABLE:
             """Update streaming AI text via _updateStream JS call.
 
             The #pending-ai-text div always exists in the shell HTML, so this
-            should always succeed when the shell is loaded.
+            should always succeed when the shell is loaded.  Runs under the
+            render protocol via _run_script; on deferral or failure the
+            pending full-rebuild replay covers the missed incremental update.
             """
-            if not self._use_webview or not self._shell_loaded or self._js_running:
+            if not self._use_webview:
                 return False
 
             import json as _json
@@ -1392,17 +1424,13 @@ if _WX_AVAILABLE:
             scroll_arg = "true" if self._follow_output_to_bottom else "false"
             js = f"_updateStream({_json.dumps(body_html)}, {scroll_arg})"
 
-            self._js_running = True
-            try:
-                ok, result = self._conv_view.RunScript(js)
-                if not ok:
-                    log.warning("_incremental_stream_update: RunScript failed")
-                return ok
-            except Exception as e:
-                log.warning("_incremental_stream_update: exception: %s", e)
-                return False
-            finally:
-                self._js_running = False
+            return bool(
+                self._run_script(
+                    js,
+                    force_scroll_to_bottom=self._follow_output_to_bottom,
+                    retry_on_failure=True,
+                )[0]
+            )
 
         def _on_page_watchdog(self, event) -> None:
             """Safety net: detect shell load timeout.
@@ -1463,6 +1491,10 @@ if _WX_AVAILABLE:
             # If there is pending streamed text that preceded this tool call,
             # finalise it as an AI entry now so the timeline order is correct.
             if self._pending_ai_text:
+                log.debug(
+                    "chat: mid-turn finalise of streamed text len=%d",
+                    len(self._pending_ai_text),
+                )
                 self._conv_entries.append({"type": "ai", "text": self._pending_ai_text})
                 self._pending_ai_text = ""
             # Append as a permanent timeline entry so tool calls appear in
@@ -2529,49 +2561,57 @@ if _WX_AVAILABLE:
             Called 1 second after EVT_WEBVIEW_LOADED to give scripts time to execute.
             """
             log.debug("_verify_shell_and_render: starting verification")
-            self._js_running = True
             js_works = False
 
+            # Each probe runs under the render-protocol flag via
+            # _run_script(probe=True): before _shell_loaded is confirmed the
+            # normal acquire would defer instead of probing, so probe=True
+            # skips the shell-loaded gate while still excluding re-entrant
+            # renders from the probe windows.
             try:
                 # Check font
-                ok, result = self._conv_view.RunScript("getComputedStyle(document.body).fontFamily")
+                _, result = self._run_script(
+                    "getComputedStyle(document.body).fontFamily", probe=True
+                )
                 log.info("_verify_shell_and_render: font=%r", result)
 
                 # Check all window functions (what's actually defined in window)
-                ok, result = self._conv_view.RunScript(
-                    "Object.keys(window).filter(k => typeof window[k] === 'function' && k.startsWith('_')).join(',')"
+                _, result = self._run_script(
+                    "Object.keys(window).filter(k => typeof window[k] === 'function' && k.startsWith('_')).join(',')",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: window functions starting with _ =%r", result)
 
                 # Check scripts in document
-                ok, result = self._conv_view.RunScript(
-                    "document.scripts.length + ',' + (document.scripts[0] ? document.scripts[0].src : 'inline') + ',' + (document.scripts[0] ? document.scripts[0].innerHTML.length : 0)"
+                _, result = self._run_script(
+                    "document.scripts.length + ',' + (document.scripts[0] ? document.scripts[0].src : 'inline') + ',' + (document.scripts[0] ? document.scripts[0].innerHTML.length : 0)",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: scripts info=%r", result)
 
                 # Check for JS errors in the console
-                ok, result = self._conv_view.RunScript(
-                    "try { eval('1+1'); 'no_error'; } catch(e) { e.message; }"
+                _, result = self._run_script(
+                    "try { eval('1+1'); 'no_error'; } catch(e) { e.message; }", probe=True
                 )
                 log.info("_verify_shell_and_render: eval test=%r", result)
 
                 # Try to check for syntax errors in the script
-                ok, result = self._conv_view.RunScript(
-                    "try { new Function(document.scripts[0].innerHTML); 'syntax_ok'; } catch(e) { 'error:' + e.message; }"
+                _, result = self._run_script(
+                    "try { new Function(document.scripts[0].innerHTML); 'syntax_ok'; } catch(e) { 'error:' + e.message; }",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: script syntax check=%r", result)
 
                 # Try to call JS function
-                ok, result = self._conv_view.RunScript(
-                    "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }"
+                ok, result = self._run_script(
+                    "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: JS call result=%r", result)
                 if ok and result and ("ok" in str(result) or "error" in str(result).lower()):
                     js_works = True
             except Exception as e:
                 log.error("_verify_shell_and_render: exception: %s", e)
-            finally:
-                self._js_running = False
 
             if js_works:
                 self._shell_loaded = True
@@ -2646,10 +2686,10 @@ if _WX_AVAILABLE:
             """Full conversation update via RunScript (WebView path).
 
             Serializes all entries as JSON and calls _updateConversation()
-            in the shell.
+            in the shell.  Locking/deferral is handled by _run_script.
             """
-            if not self._try_acquire_render_lock():
-                return  # _try_acquire_render_lock already set _render_pending
+            if not self._use_webview:
+                return
 
             import json as _json
 
@@ -2665,31 +2705,21 @@ if _WX_AVAILABLE:
                 len(js),
             )
 
-            try:
-                ok, result = self._conv_view.RunScript(js)
-                if ok:
-                    self._stream_wrapper_visible = False
-                    result_str = str(result) if result else ""
-                    if result_str.startswith("error:"):
-                        log.error(
-                            "_updateConversation JS error: %s (js_size=%d, entries=%d)",
-                            result_str,
-                            len(js),
-                            len(js_entries),
-                        )
-                    else:
-                        log.debug("_updateConversation JS result: %s", result_str)
-                else:
-                    log.error(
-                        "_updateConversation RunScript FAILED: js_size=%d, result=%r, entries=%d",
-                        len(js),
-                        result,
-                        len(js_entries),
-                    )
-            except Exception as e:
-                log.error("_updateConversation exception: %s", e)
-            finally:
-                self._release_render_lock(force_scroll_to_bottom)
+            ok, result = self._run_script(js, force_scroll_to_bottom)
+            if not ok:
+                log.debug("_updateConversation deferred (pending rebuild scheduled)")
+                return
+            self._stream_wrapper_visible = False
+            result_str = str(result) if result else ""
+            if result_str.startswith("error:"):
+                log.error(
+                    "_updateConversation JS error: %s (js_size=%d, entries=%d)",
+                    result_str,
+                    len(js),
+                    len(js_entries),
+                )
+            else:
+                log.debug("_updateConversation JS result: %s", result_str)
 
         def _process_pending_render(self, force_scroll_to_bottom: bool) -> None:
             """Process any pending render after _js_running is reset."""
@@ -2698,13 +2728,66 @@ if _WX_AVAILABLE:
                 wx.CallAfter(self._update_conversation, force_scroll_to_bottom)
 
         # ------------------------------------------------------------------ #
+        # Render protocol: single RunScript funnel
+        # ------------------------------------------------------------------ #
+        # Every conversation-rendering script goes through _run_script, which
+        # owns the _js_running / _render_pending bookkeeping.  RunScript on
+        # Windows WebView2 pumps the message loop, so a script submitted
+        # while another is in flight gets re-entrant instead of serialized;
+        # the _js_running flag turns that into "defer and replay as a full
+        # rebuild".  Callers of _run_script never touch lock state.
+
+        def _run_script(
+            self,
+            js: str,
+            force_scroll_to_bottom: bool = False,
+            retry_on_failure: bool = False,
+            probe: bool = False,
+        ) -> tuple[bool, object]:
+            """Run a WebView script under the render protocol.
+
+            Acquires the render lock (deferring -- _render_pending set -- when
+            another script is in flight or the shell is not confirmed loaded),
+            runs the script, then releases; the release flushes any deferral
+            as a wx.CallAfter full-conversation rebuild once the current
+            event stack has unwound.
+
+            probe=True runs before the shell is confirmed loaded (shell
+            verification): takes the lock flag to keep re-entrant renders out,
+            but skips the shell-loaded gate.
+
+            retry_on_failure=True records a pending rebuild when the script
+            itself fails, so a full rebuild replays the missed update.
+            """
+            if not self._use_webview:
+                return False, None
+            if not self._try_acquire_render_lock(probe=probe):
+                return False, None  # deferred: _render_pending already set
+            try:
+                ok, result = self._conv_view.RunScript(js)
+                if not ok:
+                    log.warning("_run_script: RunScript failed: %r", result)
+                    if retry_on_failure:
+                        self._render_pending = True
+                return ok, result
+            except Exception as e:
+                log.warning("_run_script exception: %s", e)
+                if retry_on_failure:
+                    self._render_pending = True
+                return False, None
+            finally:
+                self._release_render_lock(force_scroll_to_bottom)
+
+        # ------------------------------------------------------------------ #
         # Render lock helpers: encapsulate sync state management
         # ------------------------------------------------------------------ #
-        def _try_acquire_render_lock(self) -> bool:
+        def _try_acquire_render_lock(self, probe: bool = False) -> bool:
             """Try to acquire the render lock. Returns True if acquired.
 
-            If acquisition fails (shell not loaded or another render in progress),
-            sets _render_pending so the render will be retried later.
+            If acquisition fails (shell not loaded or another render in
+            progress), sets _render_pending so the render will be retried
+            later.  With probe=True the shell-loaded gate is skipped (shell
+            verification runs before _shell_loaded is confirmed).
             """
             self._render_pending = False  # Reset first to allow recursion
 
@@ -2712,51 +2795,54 @@ if _WX_AVAILABLE:
                 self._render_pending = True
                 return False
 
-            # If shell_loaded is False, try to detect if it actually is loaded
-            # (EVT_WEBVIEW_LOADED may not fire on all Windows WebView2 versions)
-            if not self._shell_loaded:
-                # Try to detect shell state by checking if the conversation div exists
-                # AND if JS functions are defined. Try multiple times in case scripts
-                # haven't executed yet.
-                shell_loaded_detected = False
-                for attempt in range(3):
-                    try:
-                        ok, result = self._conv_view.RunScript(
-                            "document.getElementById('conversation') ? 'loaded' : 'not_loaded'"
-                        )
-                        if ok and result and "loaded" in str(result):
-                            # Also verify JS functions exist by trying to call one
-                            ok2, result2 = self._conv_view.RunScript(
-                                "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }"
-                            )
-                            log.info("JS test attempt %d: %r", attempt + 1, result2)
-                            if (
-                                ok2
-                                and result2
-                                and ("ok" in str(result2) or "error" in str(result2).lower())
-                            ):
-                                log.info("Detected shell and JS working (attempt %d)", attempt + 1)
-                                self._shell_loaded = True
-                                self._page_loading = False
-                                shell_loaded_detected = True
-                                break
-                            else:
-                                log.warning(
-                                    "Shell loaded but JS not working (attempt %d)", attempt + 1
-                                )
-                        else:
-                            break
-                    except Exception as e:
-                        log.warning("Failed to detect shell state (attempt %d): %s", attempt + 1, e)
-                        break
+            # Claim first: shell detection (below) runs raw RunScript probes,
+            # so the flag must be held while they are in flight to keep
+            # re-entrant renders out of the detection window too.
+            self._js_running = True
 
-                if not shell_loaded_detected:
-                    log.warning("Shell loaded but JS not working after 3 attempts, allowing retry")
+            if not probe and not self._shell_loaded:
+                if not self._detect_shell_loaded():
+                    self._js_running = False
                     self._render_pending = True
                     return False
 
-            self._js_running = True
             return True
+
+        def _detect_shell_loaded(self) -> bool:
+            """Probe the WebView for a working shell (div + JS functions).
+
+            EVT_WEBVIEW_LOADED may not fire on all Windows WebView2 versions,
+            so renders probe for shell readiness.  Runs with the render lock
+            held (_js_running=True).
+            """
+            for attempt in range(3):
+                try:
+                    ok, result = self._conv_view.RunScript(
+                        "document.getElementById('conversation') ? 'loaded' : 'not_loaded'"
+                    )
+                    if ok and result and "loaded" in str(result):
+                        # Also verify JS functions exist by trying to call one
+                        ok2, result2 = self._conv_view.RunScript(
+                            "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }"
+                        )
+                        log.info("JS test attempt %d: %r", attempt + 1, result2)
+                        if (
+                            ok2
+                            and result2
+                            and ("ok" in str(result2) or "error" in str(result2).lower())
+                        ):
+                            log.info("Detected shell and JS working (attempt %d)", attempt + 1)
+                            self._shell_loaded = True
+                            self._page_loading = False
+                            return True
+                        log.warning("Shell loaded but JS not working (attempt %d)", attempt + 1)
+                    else:
+                        break
+                except Exception as e:
+                    log.warning("Failed to detect shell state (attempt %d): %s", attempt + 1, e)
+                    break
+            log.warning("Shell loaded but JS not working after 3 attempts, allowing retry")
+            return False
 
         def _release_render_lock(self, force_scroll_to_bottom: bool) -> None:
             """Release the render lock and process pending if needed."""
@@ -2765,80 +2851,64 @@ if _WX_AVAILABLE:
 
         def _append_entry_js(self, entry: dict, force_scroll_to_bottom: bool = False) -> None:
             """Append a single entry via JS _appendEntry (WebView path)."""
-            if not self._try_acquire_render_lock():
-                return  # _try_acquire_render_lock already set _render_pending
-
             import json as _json
 
             prepared = self._prepare_single_entry(entry)
             scroll = '"bottom"' if force_scroll_to_bottom else '"preserve"'
             js = f"_appendEntry({_json.dumps(_json.dumps(prepared))}, {scroll})"
-            log.debug("_appendEntry: type=%s, scroll=%s", entry.get("type"), scroll)
+            text = entry.get("text") or ""
+            log.debug(
+                "_appendEntry: type=%s, text_len=%d, tail=%r, scroll=%s",
+                entry.get("type"),
+                len(text),
+                text[-80:],
+                scroll,
+            )
 
-            try:
-                ok, result = self._conv_view.RunScript(js)
-                if ok:
-                    self._stream_wrapper_visible = False
-                    result_str = str(result) if result else ""
-                    if result_str.startswith("error:"):
-                        log.error(
-                            "_appendEntry JS error: %s (type=%s, js_size=%d)",
-                            result_str,
-                            entry.get("type"),
-                            len(js),
-                        )
-                    else:
-                        log.debug("_appendEntry JS result: %s", result_str)
-                else:
-                    log.error(
-                        "_appendEntry RunScript FAILED: result=%r, type=%s, js_size=%d",
-                        result,
-                        entry.get("type"),
-                        len(js),
-                    )
-                    self._render_pending = True
-            except Exception:
-                self._render_pending = True
-            finally:
-                self._release_render_lock(force_scroll_to_bottom)
+            ok, result = self._run_script(js, force_scroll_to_bottom, retry_on_failure=True)
+            if not ok:
+                # Deferred (lock busy / shell not loaded) or script failed —
+                # acquire/retry_on_failure already recorded a pending full
+                # rebuild that will replay this entry.
+                log.warning(
+                    "chat: append_entry_js deferred/retry (type=%s, text_len=%d) — pending rebuild scheduled",
+                    entry.get("type"),
+                    len(text),
+                )
+                return
+            self._stream_wrapper_visible = False
+            result_str = str(result) if result else ""
+            if result_str.startswith("error:"):
+                log.error(
+                    "_appendEntry JS error: %s (type=%s, js_size=%d)",
+                    result_str,
+                    entry.get("type"),
+                    len(js),
+                )
+            else:
+                log.debug("_appendEntry JS result: %s", result_str)
 
         def _show_stream_wrapper(self) -> None:
             """Make the stream-wrapper table visible (first streaming chunk)."""
             if not self._shell_loaded or self._stream_wrapper_visible:
                 return  # No-op
 
-            # Use the lock but handle the case where we don't need full update
-            if not self._try_acquire_render_lock():
-                return
-
-            try:
-                ok, _ = self._conv_view.RunScript(
-                    "document.getElementById('stream-wrapper').style.display=''"
-                )
-                if ok:
-                    self._stream_wrapper_visible = True
-            finally:
-                self._release_render_lock(False)
+            ok, _ = self._run_script("document.getElementById('stream-wrapper').style.display=''")
+            if ok:
+                self._stream_wrapper_visible = True
 
         def _hide_stream_wrapper(self) -> None:
             """Hide the stream-wrapper table and clear pending text."""
             if not self._shell_loaded or not self._stream_wrapper_visible:
                 return  # No-op
 
-            # Use the lock but handle the case where we don't need full update
-            if not self._try_acquire_render_lock():
-                return
-
-            try:
-                ok, _ = self._conv_view.RunScript(
-                    "var w=document.getElementById('stream-wrapper');"
-                    "if(w)w.style.display='none';"
-                    "document.getElementById('pending-ai-text').innerHTML='';"
-                )
-                if ok:
-                    self._stream_wrapper_visible = False
-            finally:
-                self._release_render_lock(False)
+            ok, _ = self._run_script(
+                "var w=document.getElementById('stream-wrapper');"
+                "if(w)w.style.display='none';"
+                "document.getElementById('pending-ai-text').innerHTML='';"
+            )
+            if ok:
+                self._stream_wrapper_visible = False
 
         def _render_conversation(self, force_scroll_to_bottom: bool = False) -> None:
             """Re-render the conversation.  Routes to WebView or HtmlWindow path."""

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -1,13 +1,57 @@
 """Tests for LLMClient history management (dedup + compaction)."""
 
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
+import os
+import sys
+import threading
 import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kicad_plugin.llm_client import LLMClient
+from kicad_plugin.llm_client import LLMClient, _subprocess_sse_stream
 from kicad_plugin.tool_registry import TOOL_POLICIES
+
+
+class _SSETestServer(ThreadingHTTPServer):
+    """Threaded localhost server that answers POST with an SSE body."""
+
+    def __init__(self, lines, status=200, body=b""):
+        self._lines = lines
+        self._status = status
+        self._body = body
+        super().__init__(("127.0.0.1", 0), self._make_handler(), bind_and_activate=True)
+        self._thread = threading.Thread(target=self.serve_forever, daemon=True)
+        self._thread.start()
+
+    def _make_handler(self):
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                self.send_response(server._status)
+                if server._status == 200:
+                    payload = "".join(line + "\n" for line in server._lines)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Content-Length", str(len(payload.encode())))
+                    self.end_headers()
+                    self.wfile.write(payload.encode())
+                    self.wfile.flush()
+                else:
+                    self.send_header("Content-Type", "text/plain")
+                    self.send_header("Content-Length", str(len(server._body)))
+                    self.end_headers()
+                    self.wfile.write(server._body)
+
+            def log_message(self, *args):  # silence test-server noise
+                pass
+
+        return Handler
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.server_port}"
 
 
 def _make_client(
@@ -980,15 +1024,15 @@ class TestStreaming:
         assert args == {"path": "sch.kicad_sch"}
         assert result["finish_reason"] == "tool_calls"
 
-    def test_stream_openai_ssl_fallback(self):
+    def test_stream_openai_ssl_fallback_streams_via_subprocess(self):
         import urllib.error
 
         client = _make_client()
         chunks = []
 
-        fallback_result = {
+        subprocess_result = {
             "finish_reason": "stop",
-            "message": {"content": "Fallback text", "tool_calls": []},
+            "message": {"content": "Relayed text", "tool_calls": []},
         }
 
         with (
@@ -996,13 +1040,50 @@ class TestStreaming:
                 "urllib.request.urlopen",
                 side_effect=urllib.error.URLError("unknown url type: https"),
             ),
-            patch.object(client, "_call_openai", return_value=fallback_result) as mock_call,
+            patch("kicad_plugin.llm_client._in_process_ssl", None),
+            patch(
+                "kicad_plugin.llm_client._subprocess_sse_stream",
+                return_value=subprocess_result,
+            ) as mock_stream,
         ):
             result = client._stream_openai("sys", [], on_text_delta=chunks.append)
 
-        mock_call.assert_called_once()
-        assert chunks == ["Fallback text"]
-        assert result["message"]["content"] == "Fallback text"
+        mock_stream.assert_called_once()
+        call_kwargs = mock_stream.call_args.kwargs
+        assert call_kwargs["fmt"] == "openai"
+        assert call_kwargs["timeout"] == 300
+        assert result["message"]["content"] == "Relayed text"
+
+    def test_stream_anthropic_ssl_fallback_streams_via_subprocess(self):
+        import urllib.error
+
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        chunks = []
+
+        subprocess_result = {
+            "finish_reason": "tool_calls",
+            "message": {"content": "", "tool_calls": [{"id": "tu1"}]},
+        }
+
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=urllib.error.URLError("unknown url type: https"),
+            ),
+            patch("kicad_plugin.llm_client._in_process_ssl", None),
+            patch(
+                "kicad_plugin.llm_client._subprocess_sse_stream",
+                return_value=subprocess_result,
+            ) as mock_stream,
+        ):
+            result = client._stream_anthropic("sys", [], on_text_delta=chunks.append)
+
+        mock_stream.assert_called_once()
+        call_kwargs = mock_stream.call_args.kwargs
+        assert call_kwargs["fmt"] == "anthropic"
+        assert call_kwargs["timeout"] == 300
+        assert result["message"]["tool_calls"] == [{"id": "tu1"}]
 
     def test_run_passes_on_text_delta_to_call_llm(self):
         client = _make_client()
@@ -1020,6 +1101,150 @@ class TestStreaming:
         # _call_llm must have been called with on_text_delta=on_delta
         call_kwargs = client._call_llm.call_args
         assert call_kwargs.kwargs.get("on_text_delta") is on_delta
+
+
+class TestSubprocessSSEStream:
+    """End-to-end relay: _subprocess_sse_stream runs a real subprocess Python
+    against a local HTTP server speaking SSE, verifying deltas, aggregation,
+    and error surfacing across the pipe protocol."""
+
+    def _relay(self, lines, status=200, body=b"", fmt="openai"):
+        server = _SSETestServer(lines, status=status, body=body)
+        chunks = []
+        try:
+            with (
+                patch(
+                    "kicad_plugin.llm_client._resolve_plugin_python",
+                    return_value=sys.executable,
+                ),
+                # Keep proxy env vars out of the subprocess so it reaches 127.0.0.1 directly.
+                patch(
+                    "kicad_plugin.llm_client._subprocess_env",
+                    return_value={"PATH": os.environ.get("PATH", "")},
+                ),
+            ):
+                result = _subprocess_sse_stream(
+                    url=server.url,
+                    headers={"Content-Type": "application/json"},
+                    payload=b'{"model":"t","stream":true}',
+                    timeout=30,
+                    fmt=fmt,
+                    on_text_delta=chunks.append,
+                )
+        finally:
+            server.shutdown()
+        return result, chunks
+
+    def test_openai_text_deltas_and_aggregation(self):
+        lines = [
+            'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+        result, chunks = self._relay(lines, fmt="openai")
+
+        assert "error" not in result
+        assert chunks == ["Hello", " world"]
+        assert result["message"]["content"] == "Hello world"
+        assert result["finish_reason"] == "stop"
+
+    def test_openai_tool_calls_and_reasoning_aggregated(self):
+        lines = [
+            'data: {"choices":[{"delta":{"reasoning_content":"think "},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"reasoning_content":"hard"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc1","function":{"name":"add_wire","arguments":""}}]},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"x\\":1}"}}]},"finish_reason":"tool_calls"}]}',
+            "data: [DONE]",
+        ]
+        result, chunks = self._relay(lines, fmt="openai")
+
+        assert "error" not in result
+        assert chunks == []
+        tc = result["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["id"] == "tc1"
+        assert tc[0]["function"]["name"] == "add_wire"
+        assert tc[0]["function"]["arguments"] == '{"x":1}'
+        assert result["message"]["reasoning_content"] == "think hard"
+        assert result["finish_reason"] == "tool_calls"
+
+    def test_anthropic_text_and_tool_use(self):
+        lines = [
+            "event: content_block_start",
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+            "",
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+            "",
+            "event: content_block_start",
+            'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu1","name":"get_netlist","input":{}}}',
+            "",
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"}}',
+            "",
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\\"sch.kicad_sch\\"}"}}',
+            "",
+            "event: message_delta",
+            'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}',
+        ]
+        result, chunks = self._relay(lines, fmt="anthropic")
+
+        assert "error" not in result
+        assert chunks == ["Hello"]
+        assert result["message"]["content"] == "Hello"
+        tc = result["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["id"] == "tu1"
+        assert tc[0]["function"]["name"] == "get_netlist"
+        args = json.loads(tc[0]["function"]["arguments"])
+        assert args == {"path": "sch.kicad_sch"}
+        assert result["finish_reason"] == "tool_calls"
+
+    def test_http_error_surfaces_status_and_body(self):
+        result, chunks = self._relay([], status=429, body=b"rate limited", fmt="openai")
+
+        assert chunks == []
+        assert result["error"] == "HTTP 429: rate limited"
+
+    def test_delta_callback_error_does_not_abort_stream(self):
+        lines = [
+            'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+        server = _SSETestServer(lines)
+        seen = []
+
+        def boom(chunk):
+            seen.append(chunk)
+            raise ValueError("ui hiccup")
+
+        try:
+            with (
+                patch(
+                    "kicad_plugin.llm_client._resolve_plugin_python",
+                    return_value=sys.executable,
+                ),
+                patch(
+                    "kicad_plugin.llm_client._subprocess_env",
+                    return_value={"PATH": os.environ.get("PATH", "")},
+                ),
+            ):
+                result = _subprocess_sse_stream(
+                    url=server.url,
+                    headers={"Content-Type": "application/json"},
+                    payload=b"{}",
+                    timeout=30,
+                    fmt="openai",
+                    on_text_delta=boom,
+                )
+        finally:
+            server.shutdown()
+
+        assert seen == ["Hello", " world"]
+        assert result["message"]["content"] == "Hello world"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #77

## Problem

[LLM error] HTTPS request failed: TimeoutError: The read operation timed out

When KiCad's embedded Python lacks SSL, LLM streaming calls fell back to a one-shot **non-streaming** subprocess POST with a 60s timeout covering the whole response. Long/slow responses timed out, and the streaming UX was lost. Timeouts were hardcoded and inconsistent (streaming 300s per-read vs non-streaming 60s vs compact-history 60s).

## Changes

`kicad_plugin/llm_client.py`
- **Subprocess SSE relay**: new `_SUBPROCESS_SSE_SCRIPT` (OpenAI-compatible + Anthropic SSE parsing) + `_subprocess_sse_stream()` parent reader. The plugin-venv subprocess parses deltas and relays them over stdout (`SSE-DATA` / `SSE-DONE` / `SSE-ERROR` protocol), preserving streaming UX and the same per-read 300s timeout as the in-process path (no total-duration cap).
- `_stream_openai` / `_stream_anthropic` SSL fallbacks now route through the streaming subprocess instead of the non-streaming `_call_*` path.
- Unified non-streaming LLM timeouts 60s → 300s (`_call_openai` / `_call_ollama` / `_call_anthropic`), which also extends the compact-history summary timeout.
- Extracted shared `_subprocess_env()` allowlist for both subprocess paths.

`tests/unit/plugin/test_llm_client.py`
- Updated SSL-fallback wiring tests (assert subprocess streaming, `fmt`, `timeout=300`).
- New end-to-end relay tests against a local SSE server: text delta aggregation, tool_calls + reasoning aggregation, Anthropic tool_use, HTTP 429 surfacing, delta-callback error tolerance.

## Verification

- `tests/unit`: 1012 passed, 17 skipped
- ruff check / ruff format / bandit: clean (pre-commit passed)