### PR TITLE
fix(plugin): reload KiCad on every turn exit despite failed tool calls

### DIFF
--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -1237,13 +1237,18 @@ class LLMClient:
 
         self._emit_tool_callback(on_tool_call, tool_name, args, result)
 
+        # Mark the path dirty even when the tool call fails: a failed edit may
+        # still have partially modified the file (e.g. IPC routing tools), so
+        # the end-of-turn reload must still run — keeping the actual refresh
+        # consistent with the UI's refresh entry.
+        if policy.mark_dirty and path:
+            state.dirty_paths.add(path)
+
         if not self._tool_result_succeeded(result):
             return result
 
         if policy.track_snapshot and path:
             state.snapshotted_paths.add(path)
-        if policy.mark_dirty and path:
-            state.dirty_paths.add(path)
         if policy.clear_dirty_paths_arg:
             reload_paths = args.get(policy.clear_dirty_paths_arg, [])
             if isinstance(reload_paths, list):
@@ -1310,60 +1315,79 @@ class LLMClient:
             )
 
         state = _ToolExecutionState()
+        reply: str | None = None
+        is_final_text = False
 
-        for _ in range(20):  # max 20 iterations (guard against infinite loops)
-            response = self._call_llm(system, tools, on_text_delta=on_text_delta)
+        try:
+            for _ in range(20):  # max 20 iterations (guard against infinite loops)
+                response = self._call_llm(system, tools, on_text_delta=on_text_delta)
 
-            if response.get("error"):
-                return f"[LLM error] {response['error']}"
+                if response.get("error"):
+                    reply = f"[LLM error] {response['error']}"
+                    break
 
-            message = response.get("message", {})
-            tool_calls = message.get("tool_calls") or []
+                message = response.get("message", {})
+                tool_calls = message.get("tool_calls") or []
 
-            if not tool_calls:
-                # Final text response
-                text = message.get("content") or ""
-                reload_warning = self._auto_reload_modified_files(state, on_tool_call)
-                if reload_warning:
-                    text = (
-                        f"{text}\n\n[Framework warning] {reload_warning}"
-                        if text
-                        else f"[Framework warning] {reload_warning}"
+                if not tool_calls:
+                    # Final text response
+                    reply = message.get("content") or ""
+                    is_final_text = True
+                    break
+
+                # Execute tool calls
+                # Save message, preserving thinking content for DeepSeek models
+                msg_to_save = {"role": "assistant"}
+                if message.get("content"):
+                    msg_to_save["content"] = message["content"]
+                if message.get("reasoning_content"):
+                    msg_to_save["reasoning_content"] = message["reasoning_content"]
+                if message.get("tool_calls"):
+                    msg_to_save["tool_calls"] = message["tool_calls"]
+                self._history.append(msg_to_save)
+                tool_results = []
+                for tc in tool_calls:
+                    name = tc["function"]["name"]
+                    try:
+                        args = json.loads(tc["function"].get("arguments", "{}"))
+                    except json.JSONDecodeError:
+                        args = {}
+
+                    result = self._execute_tool_with_policy(name, args, state, on_tool_call)
+
+                    tool_results.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc["id"],
+                            "content": json.dumps(result),
+                        }
                     )
-                self._history.append({"role": "assistant", "content": text})
-                return text
 
-            # Execute tool calls
-            # Save message, preserving thinking content for DeepSeek models
-            msg_to_save = {"role": "assistant"}
-            if message.get("content"):
-                msg_to_save["content"] = message["content"]
-            if message.get("reasoning_content"):
-                msg_to_save["reasoning_content"] = message["reasoning_content"]
-            if message.get("tool_calls"):
-                msg_to_save["tool_calls"] = message["tool_calls"]
-            self._history.append(msg_to_save)
-            tool_results = []
-            for tc in tool_calls:
-                name = tc["function"]["name"]
-                try:
-                    args = json.loads(tc["function"].get("arguments", "{}"))
-                except json.JSONDecodeError:
-                    args = {}
-
-                result = self._execute_tool_with_policy(name, args, state, on_tool_call)
-
-                tool_results.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc["id"],
-                        "content": json.dumps(result),
-                    }
+                self._history.extend(tool_results)
+            else:
+                reply = (
+                    "[Error] Maximum tool-call iterations reached. Please try a simpler request."
+                )
+        finally:
+            # Single shared flush for every exit path (final reply, LLM error,
+            # iteration cap, or an escaping exception): keep the KiCad reload in
+            # sync with the UI refresh display even when tools or the LLM failed.
+            # Wrapped so a reload failure can never mask the turn's own result.
+            try:
+                reload_warning = self._auto_reload_modified_files(state, on_tool_call)
+            except Exception as e:
+                log.warning("Auto-reload at end of turn failed: %s", e)
+                reload_warning = None
+            if reload_warning and reply is not None:
+                reply = (
+                    f"{reply}\n\n[Framework warning] {reload_warning}"
+                    if reply
+                    else f"[Framework warning] {reload_warning}"
                 )
 
-            self._history.extend(tool_results)
-
-        return "[Error] Maximum tool-call iterations reached. Please try a simpler request."
+        if is_final_text:
+            self._history.append({"role": "assistant", "content": reply})
+        return reply if reply is not None else "[Error] Unknown failure."
 
     @staticmethod
     def _build_user_content(

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -4,6 +4,8 @@ import json
 import types
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from kicad_plugin.llm_client import LLMClient
 from kicad_plugin.tool_registry import TOOL_POLICIES
 
@@ -458,6 +460,201 @@ class TestRunIntegration:
             "set_footprint_position",
             "reload_kicad",
         ]
+
+    def test_failed_mutation_still_reloads_dirty_path_at_turn_end(self):
+        """A failed PCB mutation still marks the path dirty so reload_kicad
+        runs at turn end, keeping the UI refresh consistent with the action."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc1",
+                        "type": "function",
+                        "function": {
+                            "name": "pcb_route_pad_to_pad",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "pad1": "A1", "pad2": "B2"}
+                            ),
+                        },
+                    }
+                ],
+            },
+        }
+        final_response = {"finish_reason": "stop", "message": {"content": "done"}}
+        client._call_llm = MagicMock(side_effect=[tool_response, final_response])
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[{"function": {"name": "pcb_route_pad_to_pad"}}]
+        )
+        on_tool_call = MagicMock()
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = [
+                {"success": True},  # save_document
+                {"success": True, "version_id": "v1"},
+                {"success": False, "error": "routing failed"},  # pcb_route_pad_to_pad fails
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []},
+            ]
+            result = client.run("route A1 to B2", context_block="", on_tool_call=on_tool_call)
+
+        assert result == "done"
+        assert mock_call_tool.call_args_list == [
+            ((client._mcp_base_url, "save_document", {"file_path": "/tmp/board.kicad_pcb"}),),
+            ((client._mcp_base_url, "save_file_version", {"file_path": "/tmp/board.kicad_pcb"}),),
+            (
+                (
+                    client._mcp_base_url,
+                    "pcb_route_pad_to_pad",
+                    {"pcb_path": "/tmp/board.kicad_pcb", "pad1": "A1", "pad2": "B2"},
+                ),
+            ),
+            ((client._mcp_base_url, "reload_kicad", {"paths": ["/tmp/board.kicad_pcb"]}),),
+        ]
+        assert [call.args[0] for call in on_tool_call.call_args_list] == [
+            "save_document",
+            "save_file_version",
+            "pcb_route_pad_to_pad",
+            "reload_kicad",
+        ]
+
+    def test_llm_error_after_mutation_still_reloads_dirty_path(self):
+        """An [LLM error] exit still flushes dirty paths via the shared
+        end-of-turn reload, matching the UI refresh display."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc1",
+                        "type": "function",
+                        "function": {
+                            "name": "set_footprint_position",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R1", "x": 1.0}
+                            ),
+                        },
+                    }
+                ],
+            },
+        }
+        client._call_llm = MagicMock(side_effect=[tool_response, {"error": "API down"}])
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[{"function": {"name": "set_footprint_position"}}]
+        )
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = [
+                {"success": True},  # save_document
+                {"success": True, "version_id": "v1"},
+                {"success": True, "pcb_path": "/tmp/board.kicad_pcb"},
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []},
+            ]
+            result = client.run("move R1", context_block="")
+
+        assert result == "[LLM error] API down"
+        assert mock_call_tool.call_args_list[-1] == (
+            (client._mcp_base_url, "reload_kicad", {"paths": ["/tmp/board.kicad_pcb"]}),
+        )
+
+    def test_max_iterations_exit_still_reloads_dirty_path(self):
+        """Hitting the iteration cap still flushes dirty paths via the shared
+        end-of-turn reload."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc-loop",
+                        "type": "function",
+                        "function": {
+                            "name": "set_footprint_position",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R1", "x": 1.0}
+                            ),
+                        },
+                    }
+                ],
+            },
+        }
+        client._call_llm = MagicMock(return_value=tool_response)  # never stops calling tools
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[{"function": {"name": "set_footprint_position"}}]
+        )
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = lambda base, name, args: (
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []}
+                if name == "reload_kicad"
+                else {"success": True}
+            )
+            result = client.run("move R1", context_block="")
+
+        assert (
+            result == "[Error] Maximum tool-call iterations reached. Please try a simpler request."
+        )
+        assert mock_call_tool.call_args_list[-1][0][1] == "reload_kicad"
+        assert mock_call_tool.call_args_list[-1][0][2] == {"paths": ["/tmp/board.kicad_pcb"]}
+
+    def test_tool_exception_still_reloads_dirty_path(self):
+        """An exception escaping run() still flushes dirty paths from earlier
+        successful mutations in the same turn."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc1",
+                        "type": "function",
+                        "function": {
+                            "name": "set_footprint_position",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R1", "x": 1.0}
+                            ),
+                        },
+                    },
+                    {
+                        "id": "tc2",
+                        "type": "function",
+                        "function": {
+                            "name": "flip_footprint",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R2"}
+                            ),
+                        },
+                    },
+                ],
+            },
+        }
+        client._call_llm = MagicMock(side_effect=[tool_response])
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[
+                {"function": {"name": "set_footprint_position"}},
+                {"function": {"name": "flip_footprint"}},
+            ]
+        )
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = [
+                {"success": True},  # save_document (snapshot for set_footprint_position)
+                {"success": True, "version_id": "v1"},
+                {"success": True, "pcb_path": "/tmp/board.kicad_pcb"},
+                # flip_footprint reuses the same-turn snapshot (no save calls)
+                RuntimeError("boom"),  # flip_footprint raises
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []},
+            ]
+            with pytest.raises(RuntimeError, match="boom"):
+                client.run("edit board", context_block="")
+
+        assert mock_call_tool.call_args_list[-1][0][1] == "reload_kicad"
+        assert mock_call_tool.call_args_list[-1][0][2] == {"paths": ["/tmp/board.kicad_pcb"]}
 
     def test_framework_snapshots_each_file_once_per_turn(self):
         client = _make_client()


### PR DESCRIPTION
Fixes #79

## Summary

Fixes two gaps that made `reload_kicad` — and the board-view refresh display
— inconsistent when a tool call fails:

1. **Failed tools now mark the path dirty.** `_execute_tool_with_policy`
   adds the path to `state.dirty_paths` even when the main tool call fails
   (e.g. `pcb_route_pad_to_pad` may leave partial IPC changes), so the
   end-of-turn `reload_kicad` runs. Previously the failure path returned
   early before marking, while the panel's `_pcb_edited` flag is
   name-based and set the "⟳ Board view refreshed." status anyway.

2. **End-of-turn reload is one shared flush on every exit path.** `run()` is
   restructured to a single exit point with `try/finally` that calls
   `_auto_reload_modified_files` once — on final reply, `[LLM error]`,
   iteration cap and escaping exceptions alike. The reload itself is
   wrapped so its failure never masks the turn's own result.

## Changes

- `kicad_plugin/llm_client.py`
- `tests/unit/plugin/test_llm_client.py` (+4 regression tests)

## Verification

- `pytest tests/unit/plugin/test_llm_client.py`: 51 passed
- `ruff check` / `ruff format --check` / `bandit`: clean
- Note: 10 pre-existing `test_settings.py` failures in this environment are
  unrelated (require `KICAD_VERSION` / `KICAD10_SYMBOL_DIR`, set in CI).