### PR TITLE
fix(router): route to duplicate-named and edge-mounted pads

### DIFF
--- a/docs/issue_backlog.md
+++ b/docs/issue_backlog.md
@@ -1,0 +1,73 @@
+# Issue Backlog
+
+Known issues discovered during review but not fixed in the originating PR.
+Each entry records the evidence, the impact, and the proposed fix so the work
+can be picked up independently.
+
+## NPTH pad type index bug in world_model
+
+**Status:** open (pre-existing, not introduced by PR #82)
+
+### Symptom
+
+`kcaa/router/world_model.py` uses the wrong index when checking whether a pad
+node is a non-plated through-hole (NPTH) pad:
+
+- `_pad_obstacle` checks `pad_node[1] == "np_thru_hole"` to decide whether to
+  skip the pad
+- `_npth_obstacle` checks `pad_node[1] != "np_thru_hole"` to decide whether to
+  skip the hole
+
+### Evidence
+
+Pad node structure (confirmed from real KiCad files, e.g.
+`/home/user1/pcb/ninja-keyboard/ninja-keyboard.kicad_pcb`, 309 NPTH pads):
+
+```
+['pad', '', 'np_thru_hole', 'circle', [at ...], [size ...], [drill ...], [layers '*.Cu' '*.Mask']]
+    [0]   [1]      [2]          [3]
+   token  name    type        shape
+```
+
+- Pad **name** is at `[1]` (empty string for NPTH), pad **type** is at `[2]`.
+- All 309 ninja-keyboard NPTH pads have the same layout; `sub[2] ==
+  'np_thru_hole'` matched all 309, `sub[1]` matched none.
+- Behavioral check: `_npth_obstacle` created 0/309 obstacles on
+  ninja-keyboard; world model reported 0 `drill`-kind obstacles for a board
+  with 309 NPTH holes.
+
+### Impact
+
+- `_npth_obstacle` always returns `None`: NPTH drill holes are never
+  registered as obstacles.
+- `_pad_obstacle` never skips NPTH pads: they are treated as ordinary plated
+  pads. In practice the KiCad-written `layers "*.Cu" "*.Mask"` makes them
+  rectangular pad-kind obstacles across all copper layers, so holes are
+  still roughly blocked — but as axis-aligned rectangles from `size`, not as
+  circular drill obstacles.
+- Legacy/hand-written files without a `layers` node (e.g. the fixture in
+  `tests/unit/tools/fixtures/test_group_placement.kicad_pcb`) produce **no**
+  obstacle at all for NPTH holes — tracks could cross them.
+- Side effect: `pad-kind` count inflates (~309 on ninja-keyboard) and
+  clearance semantics use the rectangular pad envelope rather than the
+  drilled circle.
+
+### Fix
+
+In `_pad_obstacle` and `_npth_obstacle`, read the type from `pad_node[2]`
+with `str()` conversion (the values are `sexpdata.Symbol`, which does not
+compare equal to `str`):
+
+```python
+pad_type = str(pad_node[2]) if len(pad_node) > 2 else ""
+```
+
+Also note the equivalent check at `router.py` (~line 1634,
+`sub[2] == "np_thru_hole"`) already uses the correct index.
+
+### Validation
+
+- Unit: fixture with NPTH pads (`test_group_placement.kicad_pcb`) should
+  yield `drill`-kind obstacles for its two NPTH holes.
+- Real board: ninja-keyboard world model should report ~309 `drill`-kind
+  obstacles instead of 0.

--- a/docs/issue_backlog.md
+++ b/docs/issue_backlog.md
@@ -71,3 +71,70 @@ Also note the equivalent check at `router.py` (~line 1634,
   yield `drill`-kind obstacles for its two NPTH holes.
 - Real board: ninja-keyboard world model should report ~309 `drill`-kind
   obstacles instead of 0.
+---
+
+## Edge.Cuts internal openings are not routing obstacles
+
+**Status:** fixed on `fix/duplicate-pad-routing` (commit after `de8ff31`);
+implemented as `_edge_cuts_openings` + `opening`-kind world-model obstacles
+(see below for the original analysis)
+
+### Symptom
+
+`kcaa/router/world_model.py` only uses Edge.Cuts for two things:
+
+- `_board_bbox` — the AABB of all Edge.Cuts items (outer envelope),
+- `router._check_segments_in_board` — verifies segments stay inside that
+  AABB rectangle.
+
+Neither models **internal openings**: closed Edge.Cuts loops fully inside
+the board (cutouts, routing slots, mounting windows). The router treats
+the board as a solid rectangle and can place tracks across a physical
+void — a real fabrication defect.
+
+### Evidence
+
+Real board `/home/user1/pcb/ninja-keyboard/ninja-keyboard.kicad_pcb`:
+
+- 76 Edge.Cuts items total; **61 internal `fp_rect` openings** (3.4 x 3.0 mm,
+  fully inside the board AABB, e.g. SL61 at x[430.6, 434.0] y[251.0, 254.0])
+  plus 7 `gr_circle` items.
+- `world_model` builds **0** obstacles from any of them; only the outer
+  AABB `(158.475, 139.475, 444.225, 256.725)` is used for the board fence.
+- A* would happily route across any of those 61 holes.
+
+### Impact
+
+Tracks routed across a cutout are floating copper — electrically valid,
+fabrication-invalid (the copper has no substrate, and the DRC clearance
+rules around the cutout edge are not honored). KiCad will flag it in DRC,
+but the router should avoid producing it.
+
+### Fix (proposed)
+
+In `world_model.py`:
+
+1. Collect all Edge.Cuts graphics (board-level `gr_*` and footprint-level
+   `fp_*`, transformed into world coordinates like `_board_bbox` does) as
+   shapely linework.
+2. `unary_union` the linework, `polygonize` it, take the outer face (the
+   one with maximum area), and read its `interiors` — each interior ring
+   is a closed opening loop.
+3. Add one obstacle per opening: polygon = the ring, layers = ALL copper
+   layers (a cutout severs every layer), kind = `"opening"`, net = None.
+
+The router's existing `_inflate_obstacles` (width/2 + clearance) then
+applies automatically — tracks keep full clearance from the opening edge.
+
+Open loops (notches open to the board edge, like the micro:bit card bay)
+are NOT openings — they stay part of the outline AABB, and the
+`_check_segments_in_board` fence still applies.
+
+### Validation
+
+- Unit: fixture board with an internal rectangle + circle opening →
+  `world_model` yields `opening`-kind obstacles at the right position;
+  route that would cross the opening detours around it.
+- Real board: ninja-keyboard world model reports 61+ `opening` obstacles
+  (one per internal fp_rect); regression-check matrix-bit-card J2/3 ->
+  U11/3v3 route is still produced (bay is an open notch, not an opening).

--- a/docs/issue_backlog.md
+++ b/docs/issue_backlog.md
@@ -6,7 +6,9 @@ can be picked up independently.
 
 ## NPTH pad type index bug in world_model
 
-**Status:** open (pre-existing, not introduced by PR #82)
+**Status:** fixed for circular NPTH on `fix/duplicate-pad-routing`
+(commit after `77e8301`); oval/slot drill support remains open (see
+sub-entry below)
 
 ### Symptom
 
@@ -138,3 +140,61 @@ are NOT openings — they stay part of the outline AABB, and the
 - Real board: ninja-keyboard world model reports 61+ `opening` obstacles
   (one per internal fp_rect); regression-check matrix-bit-card J2/3 ->
   U11/3v3 route is still produced (bay is an open notch, not an opening).
+
+## NPTH oval/slot drill shapes are not supported
+
+**Status:** open (discovered while fixing the NPTH index bug)
+
+### Symptom
+
+`_npth_obstacle` only reads a single drill value:
+
+```python
+drill = float(drill_sub[1])
+```
+
+A KiCad oval drill node is `(drill oval <width> <length>)` — `drill_sub[1]`
+is the `Symbol('oval')` tag, so `float()` raises `TypeError` and the
+function returns `None`. Oval/slot NPTH holes are silently dropped from the
+world model.
+
+### Evidence
+
+Real KiCad file `/home/user1/pcb/ninja-keyboard/.history/ninja-keyboard.kicad_pcb`:
+
+```
+(pad "MP" thru_hole rect (at 7.5 -3.1 180) (size 3 2.5)
+    (drill oval 2.5 2) (layers "*.Cu" "*.Mask") ...)
+```
+
+Multiple `(drill oval w l)` nodes exist in the file history. The router
+would generate no obstacle for any of them. (The current
+`ninja-keyboard.kicad_pcb` uses 309 circular NPTH drills only.)
+
+### Unresolved question
+
+KiCad's oval-drill semantics for `(drill oval w l)` is not confirmed from
+primary source at write time:
+- Is `l` the total slot length (outer ends) or the center-to-center
+  distance of the two end circles?
+- Does the slot's major axis follow the pad's own `at` rotation, the
+  footprint rotation, or neither (fixed along one axis)?
+
+The pad examples show mixed data (`(size 3 2.5)` with `(drill oval 2.5 2)`;
+`(size 1 1.6)` with `(drill oval 0.6 1.2)`) — size and drill axes do not
+obviously align, so the axis rule needs verification before implementing.
+
+### Fix (proposed)
+
+Shape the obstacle as a stadium/capsule: `LineString` between the two end
+circle centers, buffered by `width / 2` (shapely:
+`LineString([(-d, 0), (d, 0)]).buffer(w / 2, cap_style="round")`), where
+`d` depends on the resolved `l` semantics. Rotate by the pad's own `at`
+rotation plus the footprint rotation (verify which KiCad actually applies).
+
+### Validation
+
+- Unit: NPTH oval pad node -> obstacle shape whose bounding box matches
+  the resolved slot extent.
+- Real board: ninja-keyboard history file with `(drill oval ...)` pads
+  yields `drill`-kind obstacles.

--- a/docs/pcb-routing.md
+++ b/docs/pcb-routing.md
@@ -157,3 +157,21 @@ the same-named pad whose copper is actually on `B.Cu` (typically the
 thru-hole pad), not merely the first occurrence in the footprint.  A
 thru-hole pad's center is a valid track terminus — the plated barrel
 carries the connection.
+
+### Same-net pad copper and drill holes
+
+The world model drops same-net pad copper entirely (the route must be
+able to land on its own endpoint pads), so a track may run across
+same-net pad *copper* without a DRC error — same net, no conflict.
+However, a same-net **thru-hole pad's drill hole** physically severs
+any track crossing it (the drill removes the copper path).  The router
+re-adds the drill hole of every same-net `thru_hole` pad as a circular
+obstacle on every routing layer, so A* routes around the hole instead
+of running a track through it.  The endpoint pads' own holes are
+exempt — the track terminates *at* the pad center, and the plated
+barrel connects all layers there.
+
+Vias must never land on any same-net pad face (a DFM defect: solder
+wicking, annular-ring breakout).  Via-forbidden zones cover **every**
+same-net pad, not just the two endpoint pads — a multi-layer route's
+vias are kept off all same-net fingers and annuli.

--- a/docs/pcb-routing.md
+++ b/docs/pcb-routing.md
@@ -31,7 +31,10 @@ copper on other layers is a parallel plane and is ignored.  The board
 bounds check exempts the two endpoint pads' rectangles: a pad whose
 copper straddles the board edge (edge-mounted connectors) is a legal
 terminus, even though the track must otherwise stay inside the
-Edge.Cuts outline.
+Edge.Cuts outline.  The outline includes Edge.Cuts profiles drawn
+*inside* footprints — an edge-mounted connector (e.g. a card bay)
+describes the notch it sits in with its own Edge.Cuts items, and that
+region is real board area, so tracks may run into it.
 
 ## Multi-layer routing (via insertion)
 

--- a/docs/pcb-routing.md
+++ b/docs/pcb-routing.md
@@ -26,6 +26,13 @@ to the board on the same layer as the source pad.  Obstacles include:
 * Existing tracks of *other* nets.
 * Keepout zones on the active layer.
 
+Only copper on the requested routing layer blocks a single-layer route;
+copper on other layers is a parallel plane and is ignored.  The board
+bounds check exempts the two endpoint pads' rectangles: a pad whose
+copper straddles the board edge (edge-mounted connectors) is a legal
+terminus, even though the track must otherwise stay inside the
+Edge.Cuts outline.
+
 ## Multi-layer routing (via insertion)
 
 If the source pad is on a different layer from the destination pad,
@@ -131,10 +138,19 @@ for the human-readable summary.
 
 | Failure | Meaning |
 | --- | --- |
-| `RouteFailure: Pad <ref>/<pad> not found` | Pad name is wrong or pad is on a different layer than requested. |
-| `RouteFailure: Pad <ref>/<pad> has no copper shape on layer '<layer>'` | The destination pad does not have a copper shape on the requested `end_layer`. |
+| `RouteFailure: Pad <ref>/<pad> not found` | No pad with that name exists on the footprint.  A pad that exists but has no copper on the requested layer fails with the layer-naming error below instead. |
+| `RouteFailure: Pad <ref>/<pad> has no copper shape on layer '<layer>'` | The pad exists, but no same-named pad has a copper shape on the requested layer. |
 | `RouteFailure: No obstacle-avoiding path from <a> to <b> across layers [...]` | No combination of exit points / via transitions yields a clear path.  Check obstacles and via pairs. |
 | `RouteFailure: Via at (x, y) would extend outside the board` | At least one via pad does not fit inside the Edge.Cuts board outline.  Move the route or shrink the board. |
 
 The tool returns `{"error": "..."}` on any of the above; the board
 file is **not** modified on failure.
+
+A footprint may declare several pads with the same name — edge-connector
+fingers sharing a net, e.g. a micro:bit edge connector exposing several
+`3v3` pads (SMD fingers plus one thru-hole pad).  The router resolves
+the pad by the requested layer: routing to `U11/3v3` on `B.Cu` targets
+the same-named pad whose copper is actually on `B.Cu` (typically the
+thru-hole pad), not merely the first occurrence in the footprint.  A
+thru-hole pad's center is a valid track terminus — the plated barrel
+carries the connection.

--- a/docs/pcb-routing.md
+++ b/docs/pcb-routing.md
@@ -38,10 +38,10 @@ region is real board area, so tracks may run into it.
 
 ## Multi-layer routing (via insertion)
 
-If the source pad is on a different layer from the destination pad,
-the router will insert through-hole vias at every layer transition.
-You must supply the destination layer and the set of via pairs the
-router is allowed to use:
+If the source and destination pads are on different copper layers (e.g.
+an SMD pad on F.Cu and an SMD pad on In1.Cu), the router inserts vias to
+reach the destination.  Specify the via layer pairs the router is
+allowed to use:
 
 ```python
 await pcb_route_pad_to_pad(
@@ -49,14 +49,14 @@ await pcb_route_pad_to_pad(
     ref_a="R1", pad_a="2",
     ref_b="U1", pad_b="5",
     net="VCC",
-    layer="F.Cu",                # start layer
-    target_layer="In1.Cu",        # end layer
     via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
 )
 ```
 
-If `target_layer` is supplied and differs from `layer` and
-`via_pairs` is omitted, the router defaults to a single F<->B pair.
+Layer selection is automatic: SMD/connect pads use their fixed layer;
+thru-hole pads (`*.Cu`) pick a shared copper layer, preferring
+`layer_hint` when it is valid.  When both pads are thru-hole and share
+a layer, the route stays on a single layer (no vias).
 
 ### Response shape
 

--- a/docs/pcb-routing.md
+++ b/docs/pcb-routing.md
@@ -161,15 +161,19 @@ carries the connection.
 ### Same-net pad copper and drill holes
 
 The world model drops same-net pad copper entirely (the route must be
-able to land on its own endpoint pads), so a track may run across
-same-net pad *copper* without a DRC error — same net, no conflict.
-However, a same-net **thru-hole pad's drill hole** physically severs
-any track crossing it (the drill removes the copper path).  The router
-re-adds the drill hole of every same-net `thru_hole` pad as a circular
-obstacle on every routing layer, so A* routes around the hole instead
-of running a track through it.  The endpoint pads' own holes are
-exempt — the track terminates *at* the pad center, and the plated
-barrel connects all layers there.
+able to land on its own endpoint pads).  The router re-adds every
+same-net pad as a transit obstacle on the copper layers it covers so
+the track centreline never enters another same-net pad's copper — the
+track terminates on the endpoint pad only, and other same-net pads
+should be connected by separate tracks later.  The buffer is zero (no
+DRC clearance): same net needs no clearance, the obstacle just keeps
+the track *centreline* off the pad copper.  The track edge may still
+touch the pad edge for wide tracks in tight geometry — this is not a
+DRC error (same net) and is preferable to failing the route.  The two
+endpoint pads are exempt on their own terminal layers so the track can
+start/end at their centres; a same-net thru-hole pad's drill hole is
+covered by its pad-copper obstacle (non-endpoint pads), so a track
+never crosses a hole the drill physically severs.
 
 Vias must never land on any same-net pad face (a DFM defect: solder
 wicking, annular-ring breakout).  Via-forbidden zones cover **every**

--- a/docs/pcb-routing.md
+++ b/docs/pcb-routing.md
@@ -163,14 +163,13 @@ carries the connection.
 The world model drops same-net pad copper entirely (the route must be
 able to land on its own endpoint pads).  The router re-adds every
 same-net pad as a transit obstacle on the copper layers it covers so
-the track centreline never enters another same-net pad's copper — the
-track terminates on the endpoint pad only, and other same-net pads
-should be connected by separate tracks later.  The buffer is zero (no
-DRC clearance): same net needs no clearance, the obstacle just keeps
-the track *centreline* off the pad copper.  The track edge may still
-touch the pad edge for wide tracks in tight geometry — this is not a
-DRC error (same net) and is preferable to failing the route.  The two
-endpoint pads are exempt on their own terminal layers so the track can
+the track never overlaps other same-net pad copper — it terminates on
+the endpoint pad only and connects to other same-net pads by separate
+tracks later.  Buffer is ``width/2 + clearance``: the track edge must
+keep a full clearance gap from the pad copper, same as for any other
+obstacle.  If this makes the route impossible at the requested width,
+that is the correct answer — try a narrower track.  The two endpoint
+pads are exempt on their own terminal layers so the track can
 start/end at their centres; a same-net thru-hole pad's drill hole is
 covered by its pad-copper obstacle (non-endpoint pads), so a track
 never crosses a hole the drill physically severs.

--- a/kcaa/router/grid_a_star.py
+++ b/kcaa/router/grid_a_star.py
@@ -56,6 +56,14 @@ _DIRECTIONS = [
 _CARD_COST = 1.0
 _DIAG_COST = math.sqrt(2.0)
 
+# Turn penalty (mm-equivalent) added when the path changes direction.
+# 0.3 mm ≈ 3 cells at 0.1 mm resolution — discourages zigzag without
+# blocking legitimate detours.  Set to 0 to disable (pure shortest path).
+_TURN_PENALTY = 0.3
+
+# Number of movement directions (8-directional grid).
+_N_DIRS = 8
+
 # Default via cost (mm added to the path for each via transition).
 _VIA_COST = 2.0
 
@@ -231,7 +239,9 @@ def _octile_dist(gx: int, gy: int, ex: int, ey: int) -> float:
     """Octile distance heuristic (admissible for 8-direction movement)."""
     dx = abs(gx - ex)
     dy = abs(gy - ey)
-    return _CARD_COST * abs(dx - dy) + (_DIAG_COST - _CARD_COST) * min(dx, dy)
+    if dx > dy:
+        return _DIAG_COST * dy + (dx - dy)
+    return _DIAG_COST * dx + (dy - dx)
 
 
 def grid_a_star(
@@ -243,6 +253,7 @@ def grid_a_star(
     via_from: dict[int, set[int]] | None = None,
     via_cost: float = _VIA_COST,
     via_forbidden_zones: list | None = None,
+    turn_penalty: float = _TURN_PENALTY,
 ) -> AStarResult:
     """Run A* on one or more walkability grids.
 
@@ -265,6 +276,8 @@ def grid_a_star(
         via_cost: Distance-equivalent cost per via transition (mm).
         via_forbidden_zones: Optional list of ``shapely`` Polygon objects
             where vias are forbidden (e.g. start/end pad AABBs).
+        turn_penalty: Distance-equivalent cost added when the path
+            changes direction.  0 disables (pure shortest path).
 
     Returns:
         :class:`AStarResult` with ``path`` as ``list[(x, y, layer_idx)]``,
@@ -288,13 +301,21 @@ def grid_a_star(
     if not grids[end_layer_idx].is_free(ex, ey):
         return AStarResult(path=None)
 
-    def _encode(gx: int, gy: int, li: int) -> int:
-        return (gy * W + gx) * n_layers + li
+    # State encoding: (cell, layer, arrival_direction).
+    # arrival_direction is 0-7 (index into _DIRECTIONS) or _N_DIRS for
+    # the start node (no previous move).  This lets A* distinguish
+    # reaching a cell from different directions and apply a turn penalty
+    # when the direction changes.
+    _NO_DIR = _N_DIRS  # sentinel for "no previous direction"
 
-    start_id = _encode(sx, sy, start_layer_idx)
-    end_id = _encode(ex, ey, end_layer_idx)
+    def _encode(gx: int, gy: int, li: int, di: int) -> int:
+        return ((gy * W + gx) * n_layers + li) * (_N_DIRS + 1) + di
 
-    g_score = {start_id: 0.0}
+    # The goal is any state at (ex, ey, end_layer) regardless of direction.
+    # We check for the cell-level match inside the loop.
+    start_id = _encode(sx, sy, start_layer_idx, _NO_DIR)
+
+    g_score: dict[int, float] = {start_id: 0.0}
     parent: dict[int, int | None] = {start_id: None}
     open_heap = [(_octile_dist(sx, sy, ex, ey), start_id)]
     closed: set[int] = set()
@@ -307,45 +328,55 @@ def grid_a_star(
         closed.add(cur_id)
         visited += 1
 
-        if cur_id == end_id:
-            path: list[tuple[float, float, int]] = []
-            nid = cur_id
-            while nid is not None:
-                li = nid % n_layers
-                rest = nid // n_layers
-                gy_p = rest // W
-                gx_p = rest % W
-                wx, wy = ref.to_world(gx_p, gy_p)
-                path.append((wx, wy, li))
-                nid = parent[nid]
-            path.reverse()
-
-            # Compute length from world-coordinate distance (ignore
-            # layer — via cost is already baked into g_score).
-            total_len = 0.0
-            for i in range(1, len(path)):
-                px, py, _ = path[i - 1]
-                cx, cy, _ = path[i]
-                total_len += math.hypot(cx - px, cy - py)
-            return AStarResult(path=path, cells_visited=visited, path_length_mm=total_len)
-
-        li = cur_id % n_layers
-        rest = cur_id // n_layers
-        cy = rest // W
-        cx = rest % W
+        # Decode state.
+        di = cur_id % (_N_DIRS + 1)
+        rest = cur_id // (_N_DIRS + 1)
+        li = rest % n_layers
+        rest2 = rest // n_layers
+        cy = rest2 // W
+        cx = rest2 % W
         cur_g = g_score[cur_id]
         cur_grid = grids[li]
 
+        # Goal check: any direction at the target cell on the target layer.
+        if cx == ex and cy == ey and li == end_layer_idx:
+            path: list[tuple[float, float, int]] = []
+            nid: int | None = cur_id
+            while nid is not None:
+                rest_n = nid // (_N_DIRS + 1)
+                li_n = rest_n % n_layers
+                rest2_n = rest_n // n_layers
+                gy_p = rest2_n // W
+                gx_p = rest2_n % W
+                wx, wy = ref.to_world(gx_p, gy_p)
+                path.append((wx, wy, li_n))
+                nid = parent[nid]
+            path.reverse()
+
+            total_len = 0.0
+            for i in range(1, len(path)):
+                px, py, _ = path[i - 1]
+                cx_p, cy_p, _ = path[i]
+                total_len += math.hypot(cx_p - px, cy_p - py)
+            return AStarResult(path=path, cells_visited=visited, path_length_mm=total_len)
+
         # ---- Same-layer 8-dir moves ----
-        for dx, dy, is_diag in _DIRECTIONS:
+        for dir_idx, (dx, dy, is_diag) in enumerate(_DIRECTIONS):
             nx, ny = cx + dx, cy + dy
             if not cur_grid.is_free(nx, ny):
                 continue
-            nid = _encode(nx, ny, li)
+            nid = _encode(nx, ny, li, dir_idx)
             if nid in closed:
                 continue
             step = _DIAG_COST if is_diag else _CARD_COST
-            tentative = cur_g + step
+            # Turn penalty: if this move's direction differs from the
+            # arrival direction (and we have a previous direction), add
+            # the penalty.  45° changes (cardinal→diagonal) cost the
+            # same as 90° changes — both are one turn.
+            tp = 0.0
+            if turn_penalty > 0 and di != _NO_DIR and di != dir_idx:
+                tp = turn_penalty
+            tentative = cur_g + step + tp
             if tentative < g_score.get(nid, float("inf")):
                 g_score[nid] = tentative
                 heapq.heappush(
@@ -364,7 +395,8 @@ def grid_a_star(
                     wx, wy = ref.to_world(cx, cy)
                     if any(z.contains(Point(wx, wy)) for z in via_forbidden_zones):
                         continue
-                nid = _encode(cx, cy, tgt_li)
+                # Via resets direction (layer change is not a "turn").
+                nid = _encode(cx, cy, tgt_li, _NO_DIR)
                 if nid in closed:
                     continue
                 tentative = cur_g + via_cost
@@ -422,6 +454,7 @@ def hierarchical_a_star(
     end_world: tuple[float, float],
     fine_resolution: float = GRID_RESOLUTION,
     route_bbox: tuple[float, float, float, float] | None = None,
+    turn_penalty: float = _TURN_PENALTY,
 ) -> AStarResult:
     """Run hierarchical A* with auto-detection of single-pass vs two-pass.
 
@@ -457,11 +490,11 @@ def hierarchical_a_star(
 
     if fine_cells < _SINGLE_PASS_THRESHOLD:
         grid = build_grid_map(obstacles, bbox, resolution=fine_resolution)
-        return grid_a_star([grid], start_world, end_world)
+        return grid_a_star([grid], start_world, end_world, turn_penalty=turn_penalty)
 
     coarse_res = fine_resolution * COARSE_FACTOR
     coarse_grid = build_grid_map(obstacles, bbox, resolution=coarse_res)
-    coarse_result = grid_a_star([coarse_grid], start_world, end_world)
+    coarse_result = grid_a_star([coarse_grid], start_world, end_world, turn_penalty=turn_penalty)
     if coarse_result.path is None:
         return AStarResult(path=None, cells_visited=coarse_result.cells_visited)
 
@@ -477,7 +510,7 @@ def hierarchical_a_star(
     )
 
     fine_grid = build_grid_map(obstacles, band, resolution=fine_resolution)
-    result = grid_a_star([fine_grid], start_world, end_world)
+    result = grid_a_star([fine_grid], start_world, end_world, turn_penalty=turn_penalty)
     if result.path is not None:
         result.cells_visited += coarse_result.cells_visited
     else:
@@ -535,6 +568,7 @@ def multi_layer_a_star(
     fine_resolution: float = GRID_RESOLUTION,
     via_cost: float = _VIA_COST,
     via_forbidden_zones: list | None = None,
+    turn_penalty: float = _TURN_PENALTY,
 ) -> MultiLayerAStarResult:
     """Run A* across multiple copper layers.
 
@@ -583,6 +617,7 @@ def multi_layer_a_star(
         via_from=via_from or None,
         via_cost=via_cost,
         via_forbidden_zones=via_forbidden_zones,
+        turn_penalty=turn_penalty,
     )
     if result.path is None:
         return MultiLayerAStarResult(path=None, cells_visited=result.cells_visited)

--- a/kcaa/router/grid_a_star.py
+++ b/kcaa/router/grid_a_star.py
@@ -718,6 +718,13 @@ def _grid_line_clear(
     return True
 
 
+def _is_45_family(x0: float, y0: float, x1: float, y1: float) -> bool:
+    """True when the segment (x0,y0)-(x1,y1) is axis-aligned or a 45° diagonal."""
+    dx = abs(x1 - x0)
+    dy = abs(y1 - y0)
+    return abs(dx) < 1e-6 or abs(dy) < 1e-6 or abs(dx - dy) < 1e-6
+
+
 def shortcut_path(
     pts: list[tuple[float, float]],
     obstacles: list,
@@ -728,17 +735,11 @@ def shortcut_path(
 
     Builds a walkability grid once, then for each point tries to skip
     as many subsequent points as possible while keeping the line clear.
-    Only 0°/45°/90°/135° shortcuts are preferred, but near-45° angles
-    are accepted (``snap_to_45_path_safe`` fixes angles afterward).
-
-    Args:
-        pts: Ordered ``(x, y)`` points (after collinear simplification).
-        obstacles: Inflated obstacle list (Polygon objects).
-        bbox: ``(min_x, min_y, max_x, max_y)`` of the route area.
-        resolution: Grid cell size in mm.
-
-    Returns:
-        Simplified polyline with redundant points removed.
+    Only 0°/45°/90°/135° shortcuts are accepted.  A shortcut that would
+    skip a direction change all the way through (producing a near-45°
+    long diagonal) is REJECTED: snapping that back to the 45° family
+    later would have to force a Manhattan corner (often a 90° turn), so
+    it is better to keep the original 45°+axis-aligned waypoints.
     """
     if len(pts) <= 2:
         return list(pts)
@@ -749,6 +750,13 @@ def shortcut_path(
     while i < len(pts) - 1:
         best_next = i + 1
         for k in range(len(pts) - 1, i, -1):
+            if not _is_45_family(
+                result[-1][0],
+                result[-1][1],
+                pts[k][0],
+                pts[k][1],
+            ):
+                continue
             if _grid_line_clear(
                 grid,
                 result[-1][0],

--- a/kcaa/router/grid_a_star.py
+++ b/kcaa/router/grid_a_star.py
@@ -693,7 +693,8 @@ def shortcut_path(
 
     Builds a walkability grid once, then for each point tries to skip
     as many subsequent points as possible while keeping the line clear.
-    Only 0°/45°/90°/135° shortcuts are accepted.
+    Only 0°/45°/90°/135° shortcuts are preferred, but near-45° angles
+    are accepted (``snap_to_45_path_safe`` fixes angles afterward).
 
     Args:
         pts: Ordered ``(x, y)`` points (after collinear simplification).
@@ -713,10 +714,6 @@ def shortcut_path(
     while i < len(pts) - 1:
         best_next = i + 1
         for k in range(len(pts) - 1, i, -1):
-            dx = pts[k][0] - result[-1][0]
-            dy = pts[k][1] - result[-1][1]
-            if abs(dx) > 1e-9 and abs(dy) > 1e-9 and abs(abs(dx) - abs(dy)) > 1e-9:
-                continue  # not 0/45/90/135°
             if _grid_line_clear(
                 grid,
                 result[-1][0],

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -562,6 +562,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             layer_obstacles,
             pad_a_xy,
             pad_b_xy,
+            fine_resolution=grid_res,
             route_bbox=route_bbox,
             turn_penalty=req.turn_penalty,
         )

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -44,7 +44,7 @@ import logging
 import math
 import os
 
-from shapely.geometry import Point, Polygon
+from shapely.geometry import Polygon
 from shapely.geometry import box as _shapely_box
 
 from kcaa.router.grid_a_star import (
@@ -347,66 +347,43 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
                 pad_b_world_size,
             )
 
-    # Same-net thru-hole pads have a drilled barrel that physically severs
-    # any track crossing it — but the world model drops same-net pad
-    # copper entirely (so the route can land on its own pads), which also
-    # drops the hole.  Re-add ONLY the drill hole of each same-net
-    # ``thru_hole`` pad as a circular obstacle on every copper layer: a
-    # track may run across same-net pad *copper* (same net, no DRC error),
-    # but never across the *hole* (the drill removes the copper path).
-    # Geometry mirrors :func:`kcaa.router.world_model._npth_obstacle`.
-    pad_delta = width / 2.0 + clearance
-    _tht_hole_shapes: list = []
-    for item in data:
-        if not _is_list(item) or str(item[0]) != "footprint":
+    # The world model drops same-net pad copper entirely (the route must
+    # land on its own endpoint pads).  Re-add every same-net pad as a
+    # transit obstacle on the copper layers it covers so the track never
+    # overlaps other same-net pad copper — it terminates on the endpoint
+    # pad only and connects to other same-net pads by separate tracks
+    # later.  Buffer by ``width/2`` (no clearance): same net needs no
+    # DRC clearance, the buffer just keeps the track *edge* off the pad
+    # copper.  The two endpoint pads are exempt on their own terminal
+    # layers so the track can start/end at their centres.
+    pad_half = 0.0  # same-net: no DRC clearance, block only the pad copper itself
+    _sn_shapes: list = []
+    for poly, players, _ref, _pname, center in _same_net_pad_polygons(data, req.net):
+        is_end = (abs(center[0] - pad_a_xy[0]) < 1e-6 and abs(center[1] - pad_a_xy[1]) < 1e-6) or (
+            abs(center[0] - pad_b_xy[0]) < 1e-6 and abs(center[1] - pad_b_xy[1]) < 1e-6
+        )
+        buf = poly.buffer(pad_half)
+        if buf.is_empty or not buf.is_valid:
             continue
-        fp_x, fp_y, fp_rot = _node_at3(item)
-        for sub in item:
-            if not _is_list(sub) or str(sub[0]) != "pad":
+        _sn_shapes.append(buf)
+        for layer in players:
+            if layer not in obstacles_by_layer:
                 continue
-            if _get_net(sub) != req.net:
+            if is_end and (layer == req.start_layer or layer == req.end_layer):
                 continue
-            if len(sub) < 3 or str(sub[2]) != "thru_hole":
-                continue
-            at = _get_sub(sub, "at")
-            if at is None or len(at) < 3:
-                continue
-            try:
-                lx, ly = float(at[1]), float(at[2])
-            except (TypeError, ValueError):
-                continue
-            drill_sub = _get_sub(sub, "drill")
-            if drill_sub is None or len(drill_sub) < 2:
-                continue
-            try:
-                drill = float(drill_sub[1])
-            except (TypeError, ValueError):
-                continue
-            wx_off, wy_off = _rotate(lx, ly, fp_rot)
-            wx, wy = fp_x + wx_off, fp_y + wy_off
-            # Skip endpoint pads: the route must start/end at the pad
-            # centre (on the hole), and the plated barrel connects all
-            # layers there — no obstacle needed at the termination.
-            if (abs(wx - pad_a_xy[0]) < 1e-6 and abs(wy - pad_a_xy[1]) < 1e-6) or (
-                abs(wx - pad_b_xy[0]) < 1e-6 and abs(wy - pad_b_xy[1]) < 1e-6
-            ):
-                continue
-            hole = Point(wx, wy).buffer(drill / 2.0 + pad_delta)
-            _tht_hole_shapes.append(hole)
-            for layer in obstacles_by_layer:
-                obstacles_by_layer[layer].append(
-                    Obstacle(
-                        shape=hole,
-                        layers=frozenset({layer}),
-                        net=req.net,
-                        kind="drill",
-                    )
+            obstacles_by_layer[layer].append(
+                Obstacle(
+                    shape=buf,
+                    layers=frozenset({layer}),
+                    net=req.net,
+                    kind="pad",
                 )
+            )
 
     # Route bounding box must cover the endpoint pads and every same-net
-    # THT hole obstacle: a detour around a wide drill can extend past the
-    # ±5 mm endpoint margin.
-    _hb = [s.bounds for s in _tht_hole_shapes]
+    # pad obstacle: a detour around a wide pad cluster can extend past
+    # the ±5 mm endpoint margin.
+    _hb = [s.bounds for s in _sn_shapes]
     _hx0 = min((b[0] for b in _hb), default=pad_a_xy[0])
     _hy0 = min((b[1] for b in _hb), default=pad_a_xy[1])
     _hx1 = max((b[2] for b in _hb), default=pad_a_xy[0])

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -470,6 +470,8 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             turn_penalty=req.turn_penalty,
         )
         if ml_result.path is None:
+            # Dump the failure state so the blockage can be inspected.
+            _dump_viz("fail-multi-astar", [], _pad_viz, buffered, route_bbox)
             raise RouteFailure(
                 f"No obstacle-avoiding multi-layer path from "
                 f"{req.ref_a}/{req.pad_a} to {req.ref_b}/{req.pad_b} at "
@@ -567,6 +569,9 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             turn_penalty=req.turn_penalty,
         )
         if result.path is None:
+            # Dump the failure state so the blockage can be inspected
+            # (same viz format as the success stages).
+            _dump_viz("fail-astar", [], _pad_viz, layer_obstacles, route_bbox)
             raise RouteFailure(
                 f"No obstacle-avoiding path from {req.ref_a}/{req.pad_a} to "
                 f"{req.ref_b}/{req.pad_b} at {req.width or 0.5}mm "

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -903,7 +903,7 @@ def _postprocess_layer_segment(
     stage_prefix: str,
     pad_viz: list[tuple[str, tuple[float, float, float, float]]],
 ) -> list[tuple[float, float]]:
-    """Run simplify → shortcut → snap45 on a single layer's path points.
+    """Run simplify → shortcut → snap45 on a single layer's path.
 
     Each step dumps a viz file with ``stage_prefix`` prepended, so
     multi-layer dumps carry the layer name (e.g. ``layer-F.Cu-2-simplify``)
@@ -918,10 +918,14 @@ def _postprocess_layer_segment(
     pts = shortcut_path(pts, obstacles, route_bbox, resolution=grid_res)
     _log_path(f"{stage_prefix}shortcut", pts)
     _dump_viz(f"{stage_prefix}3-shortcut", pts, pad_viz, obstacles, route_bbox)
-
     pts = snap_to_45_path_safe(pts, obstacles, route_bbox, resolution=grid_res)
     _log_path(f"{stage_prefix}snap45", pts)
     _dump_viz(f"{stage_prefix}4-snap45", pts, pad_viz, obstacles, route_bbox)
+
+    # Re-simplify: snap45 may create new collinear points.
+    pts = simplify_path(pts)
+    _log_path(f"{stage_prefix}resimplify", pts)
+    _dump_viz(f"{stage_prefix}5-resimplify", pts, pad_viz, obstacles, route_bbox)
 
     return pts
 

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -248,13 +248,24 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     if via_drill is None:
         via_drill = _resolve_via_drill(req.pcb_path, net=req.net)
 
-    # Pad center coordinates.
-    pad_a_xy = _find_pad_center(data, req.ref_a, req.pad_a)
-    pad_b_xy = _find_pad_center(data, req.ref_b, req.pad_b)
+    # Pad center coordinates. The layer keeps center and size on the SAME
+    # pad when a footprint declares several pads with one name.
+    pad_a_xy = _find_pad_center(data, req.ref_a, req.pad_a, req.start_layer)
+    pad_b_xy = _find_pad_center(data, req.ref_b, req.pad_b, req.end_layer)
     if pad_a_xy is None:
-        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
+        if _find_pad_center(data, req.ref_a, req.pad_a) is None:
+            raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
+        raise RouteFailure(
+            f"Pad {req.ref_a}/{req.pad_a} has no copper shape on layer "
+            f"{req.start_layer!r}; cannot route from there."
+        )
     if pad_b_xy is None:
-        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
+        if _find_pad_center(data, req.ref_b, req.pad_b) is None:
+            raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
+        raise RouteFailure(
+            f"Pad {req.ref_b}/{req.pad_b} has no copper shape on layer "
+            f"{req.end_layer!r}; cannot route to there."
+        )
 
     # Validate pads exist on the requested copper layers before doing
     # anything else (gives a clear error, not a confusing A* failure).
@@ -500,8 +511,13 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         layers_used = _layers_used(all_nodes)
     else:
         # ── Single-layer: hierarchical A* ───────────────────────────
+        # Only copper on the routing layer can block the track; other
+        # layers are parallel physical planes and must not poison the
+        # grid (the multi-layer branch groups by layer for the same
+        # reason).
+        layer_obstacles = obstacles_by_layer[req.start_layer]
         result = hierarchical_a_star(
-            buffered,
+            layer_obstacles,
             pad_a_xy,
             pad_b_xy,
             fine_resolution=grid_res,
@@ -585,7 +601,14 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             req.pcb_path,
         )
     else:
-        _check_segments_in_board(segs, model.board_bbox)
+        # Endpoint pads may straddle the board edge (edge connectors);
+        # their copper is a legal terminus, so exempt those rectangles
+        # from the board fence.
+        pad_zones: list[tuple[float, float, float, float]] = []
+        for pxy, psize in ((pad_a_xy, pad_a_world_size), (pad_b_xy, pad_b_world_size)):
+            if psize is not None:
+                pad_zones.append((pxy[0], pxy[1], psize[0] / 2.0, psize[1] / 2.0))
+        _check_segments_in_board(segs, model.board_bbox, pad_zones=pad_zones or None)
         if vias:
             _check_vias_in_board(vias, model.board_bbox)
 
@@ -1070,6 +1093,7 @@ def _build_pad_wire(
 def _check_segments_in_board(
     segs: list[OutputSegment],
     board_bbox: tuple[float, float, float, float],
+    pad_zones: list[tuple[float, float, float, float]] | None = None,
 ) -> None:
     """Raise :class:`RouteFailure` if any segment leaves the Edge.Cuts AABB.
 
@@ -1080,10 +1104,17 @@ def _check_segments_in_board(
     copper would still touch but not cross the edge); a track whose
     centerline is on the wrong side of the shrunk boundary fails.
 
+    ``pad_zones`` relaxes the fence around the route's endpoint pads:
+    footprints mounted on the board edge (edge connectors) legitimately
+    straddle the outline, so copper running onto those pads must not be
+    rejected. Each zone is ``(cx, cy, half_w, half_h)`` in world coords
+    and is unioned into the region a segment's copper may occupy.
+
     Args:
         segs: The segments produced by :func:`postprocess`.
         board_bbox: ``(minx, miny, maxx, maxy)`` from
             :func:`kcaa.router.world_model._board_bbox`.
+        pad_zones: Optional endpoint-pad rectangles to exempt.
 
     Raises:
         RouteFailure: The first segment that would leave the board.
@@ -1107,7 +1138,7 @@ def _check_segments_in_board(
                 f"Track width {seg.width} mm is wider than the board "
                 f"(shrunk bbox {shrunk_bbox} is degenerate)."
             )
-        board_poly = Polygon(
+        allowed = Polygon(
             [
                 (shrunk_bbox[0], shrunk_bbox[1]),
                 (shrunk_bbox[2], shrunk_bbox[1]),
@@ -1115,8 +1146,20 @@ def _check_segments_in_board(
                 (shrunk_bbox[0], shrunk_bbox[3]),
             ]
         )
+        if pad_zones:
+            for cx, cy, hw, hh in pad_zones:
+                allowed = allowed.union(
+                    Polygon(
+                        [
+                            (cx - hw, cy - hh),
+                            (cx + hw, cy - hh),
+                            (cx + hw, cy + hh),
+                            (cx - hw, cy + hh),
+                        ]
+                    )
+                )
         line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
-        if not board_poly.covers(line):
+        if not allowed.covers(line):
             raise RouteFailure(
                 f"Segment {i} from ({seg.x1:.3f},{seg.y1:.3f}) to "
                 f"({seg.x2:.3f},{seg.y2:.3f}) would extend outside the "
@@ -1224,8 +1267,15 @@ def _find_pad_center(
     data: list,
     ref: str,
     pad_name: str,
+    layer: str | None = None,
 ) -> tuple[float, float] | None:
-    """Return the (x, y) center of the named pad on the given footprint ref."""
+    """Return the (x, y) center of the named pad on the given footprint ref.
+
+    When ``layer`` is given, only pads whose copper covers that layer are
+    considered — a footprint may declare several pads with the same name
+    (e.g. edge-connector fingers sharing a net), and the center must match
+    the pad whose shape :func:`_find_pad_size` would return.
+    """
     fp = _find_footprint(data, ref)
     if fp is None:
         return None
@@ -1237,6 +1287,8 @@ def _find_pad_center(
             continue
         name = _get_pad_name(sub)
         if name != pad_name:
+            continue
+        if layer is not None and layer not in _pad_layers(sub):
             continue
         # Pad ``at`` is in footprint-local coords.
         at = _get_sub(sub, "at")
@@ -1261,8 +1313,9 @@ def _find_pad_size(
 ) -> tuple[float, float] | None:
     """Return the (w, h) of the pad shape, for the requested copper layer.
 
-    Returns ``None`` if the pad is not on ``layer`` or not SMD (e.g. thru-hole
-    pads are circular and need a different exit strategy).
+    A footprint may declare several pads with the same name (e.g. edge-
+    connector fingers sharing a net). Returns the first pad whose copper
+    covers ``layer``, and ``None`` only if no same-named pad is on it.
     """
     fp = _find_footprint(data, ref)
     if fp is None:
@@ -1275,14 +1328,15 @@ def _find_pad_size(
         if _get_pad_name(sub) != pad_name:
             continue
         if layer not in _pad_layers(sub):
-            return None
+            # Another pad with this name may carry the requested layer.
+            continue
         size_sub = _get_sub(sub, "size")
         if size_sub is None or len(size_sub) < 3:
-            return None
+            continue
         try:
             return float(size_sub[1]), float(size_sub[2])
         except (TypeError, ValueError):
-            return None
+            continue
     return None
 
 

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -352,11 +352,13 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     # transit obstacle on the copper layers it covers so the track never
     # overlaps other same-net pad copper — it terminates on the endpoint
     # pad only and connects to other same-net pads by separate tracks
-    # later.  Buffer by ``width/2`` (no clearance): same net needs no
-    # DRC clearance, the buffer just keeps the track *edge* off the pad
-    # copper.  The two endpoint pads are exempt on their own terminal
-    # layers so the track can start/end at their centres.
-    pad_half = 0.0  # same-net: no DRC clearance, block only the pad copper itself
+    # later.  Buffer by ``width / 2 + clearance``: the track edge must
+    # keep a clearance gap from the pad copper, same as for any other
+    # obstacle.  If this makes the route impossible at the requested
+    # width, that is the correct answer — the user should try a
+    # narrower track.  The two endpoint pads are exempt on their own
+    # terminal layers so the track can start/end at their centres.
+    pad_half = width / 2.0 + clearance
     _sn_shapes: list = []
     for poly, players, _ref, _pname, center in _same_net_pad_polygons(data, req.net):
         is_end = (abs(center[0] - pad_a_xy[0]) < 1e-6 and abs(center[1] - pad_a_xy[1]) < 1e-6) or (

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -113,13 +113,19 @@ class RouteRequest:
     The pads may live on different copper layers; in that case the router
     will insert one or more vias to switch layers.
 
+    Layer selection is automatic: the router inspects each pad's type and
+    copper layers.  For SMD/connect pads the layer is fixed by the pad
+    itself.  For thru-hole pads (``*.Cu``) the router picks the best
+    shared copper layer, preferring ``layer_hint`` when it is valid.
+
     Attributes:
         pcb_path: Absolute path to the ``.kicad_pcb`` file.
         ref_a / pad_a: Reference designator and pad number for one end.
         ref_b / pad_b: Reference designator and pad number for the other end.
         net: Net name shared by both pads.
-        start_layer: Copper layer the pad-A copper shape is on.
-        end_layer: Copper layer the pad-B copper shape is on.
+        layer_hint: Preferred copper layer for thru-hole pads.  When
+            ``None`` (default) the router picks the best layer
+            automatically.  Ignored for SMD pads whose layer is fixed.
         via_pairs: Allowed (top, bottom) layer pairs that may carry a
             through-via. Default is ``(("F.Cu", "B.Cu"),)``. Pass an
             explicit tuple to restrict transitions (e.g. to forbid inner-
@@ -145,8 +151,7 @@ class RouteRequest:
     ref_b: str
     pad_b: str
     net: str
-    start_layer: str = "F.Cu"
-    end_layer: str = "F.Cu"
+    layer_hint: str | None = None
     via_pairs: tuple[tuple[str, str], ...] = (("F.Cu", "B.Cu"),)
     width: float | None = None  # if None, use DRC default for the net
     clearance: float | None = None
@@ -187,8 +192,11 @@ class RouteResult:
 
 def auto_route_pair(req: RouteRequest) -> RouteResult:
     """Connect pad ``req.pad_a`` on ``req.ref_a`` to pad ``req.pad_b`` on
-    ``req.ref_b`` on the same net ``req.net`` and same layer ``req.start_layer``
-    (and ``req.end_layer`` for the destination pad).
+    ``req.ref_b`` on the same net ``req.net``.
+
+    Layers are auto-resolved from pad types: SMD pads use their fixed
+    layer; thru-hole pads use a shared copper layer (preferring
+    ``req.layer_hint``).
 
     Returns:
         A :class:`RouteResult` containing the segments and (optionally) vias.
@@ -198,18 +206,8 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     """
     data = load_pcb(req.pcb_path)
 
-    # Validate requested layers against the PCB early. The visibility graph
-    # query below assumes both layers exist; checking later would produce
-    # a less informative error path.
+    # Validate via_pairs against the PCB layers early.
     pcb_layers = _pcb_layer_names(data)
-    for layer in (req.start_layer, req.end_layer):
-        if layer not in pcb_layers:
-            raise RouteFailure(
-                f"Layer {layer!r} is not present in PCB {req.pcb_path}; "
-                f"PCB layers are {pcb_layers}."
-            )
-    # via_pairs must reference layers that exist too — otherwise A* would
-    # never use those edges and the user might not notice.
     for top, bot in req.via_pairs:
         if top not in pcb_layers:
             raise RouteFailure(
@@ -220,6 +218,15 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             raise RouteFailure(
                 f"via_pairs contains bottom layer {bot!r} which is not in PCB "
                 f"{req.pcb_path}; PCB layers are {pcb_layers}."
+            )
+
+    # Auto-resolve start/end layers from pad types + layer_hint.
+    start_layer, end_layer = _resolve_layers(data, req)
+    for layer in (start_layer, end_layer):
+        if layer not in pcb_layers:
+            raise RouteFailure(
+                f"Layer {layer!r} is not present in PCB {req.pcb_path}; "
+                f"PCB layers are {pcb_layers}."
             )
 
     # DRC defaults from the .kicad_pro / board file. Fail loudly if the
@@ -251,34 +258,34 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
 
     # Pad center coordinates. The layer keeps center and size on the SAME
     # pad when a footprint declares several pads with one name.
-    pad_a_xy = _find_pad_center(data, req.ref_a, req.pad_a, req.start_layer)
-    pad_b_xy = _find_pad_center(data, req.ref_b, req.pad_b, req.end_layer)
+    pad_a_xy = _find_pad_center(data, req.ref_a, req.pad_a, start_layer)
+    pad_b_xy = _find_pad_center(data, req.ref_b, req.pad_b, end_layer)
     if pad_a_xy is None:
         if _find_pad_center(data, req.ref_a, req.pad_a) is None:
             raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
         raise RouteFailure(
             f"Pad {req.ref_a}/{req.pad_a} has no copper shape on layer "
-            f"{req.start_layer!r}; cannot route from there."
+            f"{start_layer!r}; cannot route from there."
         )
     if pad_b_xy is None:
         if _find_pad_center(data, req.ref_b, req.pad_b) is None:
             raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
         raise RouteFailure(
             f"Pad {req.ref_b}/{req.pad_b} has no copper shape on layer "
-            f"{req.end_layer!r}; cannot route to there."
+            f"{end_layer!r}; cannot route to there."
         )
 
-    # Validate pads exist on the requested copper layers before doing
+    # Validate pads exist on the resolved copper layers before doing
     # anything else (gives a clear error, not a confusing A* failure).
-    if _find_pad_size(data, req.ref_a, req.pad_a, req.start_layer) is None:
+    if _find_pad_size(data, req.ref_a, req.pad_a, start_layer) is None:
         raise RouteFailure(
             f"Pad {req.ref_a}/{req.pad_a} has no copper shape on layer "
-            f"{req.start_layer!r}; cannot route from there."
+            f"{start_layer!r}; cannot route from there."
         )
-    if _find_pad_size(data, req.ref_b, req.pad_b, req.end_layer) is None:
+    if _find_pad_size(data, req.ref_b, req.pad_b, end_layer) is None:
         raise RouteFailure(
             f"Pad {req.ref_b}/{req.pad_b} has no copper shape on layer "
-            f"{req.end_layer!r}; cannot route to there."
+            f"{end_layer!r}; cannot route to there."
         )
 
     # World model: only existing copper (tracks, vias, keepouts) blocks the
@@ -296,7 +303,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     buffered = _inflate_obstacles(model.obstacles, width / 2.0 + clearance)
 
     # Group inflated obstacles by layer for multi-layer routing.
-    routing_layers = _routing_layers(req)
+    routing_layers = _routing_layers(req, start_layer, end_layer)
     obstacles_by_layer: dict[str, list] = {}
     for rl in routing_layers:
         obstacles_by_layer[rl] = [o for o in buffered if rl in o.layers]
@@ -315,8 +322,8 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             return local_h, local_w
         return local_w, local_h
 
-    pad_a_size = _find_pad_size(data, req.ref_a, req.pad_a, req.start_layer)
-    pad_b_size = _find_pad_size(data, req.ref_b, req.pad_b, req.end_layer)
+    pad_a_size = _find_pad_size(data, req.ref_a, req.pad_a, start_layer)
+    pad_b_size = _find_pad_size(data, req.ref_b, req.pad_b, end_layer)
     pad_a_world_size = (
         _world_size(pad_a_size[0], pad_a_size[1], _fp_rotation(data, req.ref_a))
         if pad_a_size
@@ -333,16 +340,16 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     # For multi-layer routing, clear the start/end pad areas from the
     # obstacle grid so A* can start from / end at the pad centres.
     # Existing copper (e.g. a track from another net) may occupy the pad.
-    if req.start_layer != req.end_layer:
+    if start_layer != end_layer:
         if pad_a_world_size is not None:
-            obstacles_by_layer[req.start_layer] = _subtract_pad_aabb(
-                obstacles_by_layer[req.start_layer],
+            obstacles_by_layer[start_layer] = _subtract_pad_aabb(
+                obstacles_by_layer[start_layer],
                 pad_a_xy,
                 pad_a_world_size,
             )
         if pad_b_world_size is not None:
-            obstacles_by_layer[req.end_layer] = _subtract_pad_aabb(
-                obstacles_by_layer[req.end_layer],
+            obstacles_by_layer[end_layer] = _subtract_pad_aabb(
+                obstacles_by_layer[end_layer],
                 pad_b_xy,
                 pad_b_world_size,
             )
@@ -371,7 +378,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         for layer in players:
             if layer not in obstacles_by_layer:
                 continue
-            if is_end and (layer == req.start_layer or layer == req.end_layer):
+            if is_end and layer in (start_layer, end_layer):
                 continue
             obstacles_by_layer[layer].append(
                 Obstacle(
@@ -434,7 +441,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
                 )
             )
 
-    if req.start_layer != req.end_layer:
+    if start_layer != end_layer:
         # ── Multi-layer: grid A* with via edges ──────────────────────
         # Via-forbidden zones cover EVERY same-net pad, not just the two
         # endpoint pads: a via on any same-net pad face is a DFM defect
@@ -449,8 +456,8 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             obstacles_by_layer,
             pad_a_xy,
             pad_b_xy,
-            req.start_layer,
-            req.end_layer,
+            start_layer,
+            end_layer,
             req.via_pairs,
             route_bbox,
             grid_res,
@@ -461,7 +468,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             raise RouteFailure(
                 f"No obstacle-avoiding multi-layer path from "
                 f"{req.ref_a}/{req.pad_a} to {req.ref_b}/{req.pad_b} at "
-                f"{width}mm track width ({req.start_layer} → {req.end_layer})."
+                f"{width}mm track width ({start_layer} → {end_layer})."
             )
         print(
             f"  [route] multi-layer A*: {len(ml_result.path)} pts"
@@ -545,7 +552,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         # layers are parallel physical planes and must not poison the
         # grid (the multi-layer branch groups by layer for the same
         # reason).
-        layer_obstacles = obstacles_by_layer[req.start_layer]
+        layer_obstacles = obstacles_by_layer[start_layer]
         result = hierarchical_a_star(
             layer_obstacles,
             pad_a_xy,
@@ -557,7 +564,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             raise RouteFailure(
                 f"No obstacle-avoiding path from {req.ref_a}/{req.pad_a} to "
                 f"{req.ref_b}/{req.pad_b} at {req.width or 0.5}mm "
-                f"track width on layer {req.start_layer}."
+                f"track width on layer {start_layer}."
             )
         print(f"  [route] A*: {len(result.path)} pts  cells_visited={result.cells_visited}")
 
@@ -599,7 +606,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         _log_path("align-endpoints", best_path_pts)
         _dump_viz("6-align-endpoints", best_path_pts, _pad_viz, buffered, route_bbox)
 
-        path_nodes = path_to_nodes(best_path_pts, req.start_layer)
+        path_nodes = path_to_nodes(best_path_pts, start_layer)
         segs, vias = postprocess_path(
             path_nodes,
             width=width,
@@ -1236,7 +1243,11 @@ def _check_vias_in_board(
 # ---------------------------------------------------------------------------
 
 
-def _routing_layers(req: RouteRequest) -> list[str]:
+def _routing_layers(
+    req: RouteRequest,
+    start_layer: str,
+    end_layer: str,
+) -> list[str]:
     """Return the ordered list of layers the router must consider.
 
     Includes ``start_layer`` and ``end_layer`` and every layer referenced
@@ -1244,7 +1255,7 @@ def _routing_layers(req: RouteRequest) -> list[str]:
     """
     seen: set[str] = set()
     out: list[str] = []
-    for layer in (req.start_layer, req.end_layer):
+    for layer in (start_layer, end_layer):
         if layer not in seen:
             out.append(layer)
             seen.add(layer)
@@ -1403,6 +1414,38 @@ def _get_pad_name(pad_node: list) -> str:
     return ""
 
 
+def _pad_type(pad_node: list) -> str:
+    """Return the pad type: ``thru_hole``, ``smd``, or ``connect``."""
+    if len(pad_node) > 2:
+        return str(pad_node[2])
+    return ""
+
+
+def _find_pad_node(
+    data: list,
+    ref: str,
+    pad_name: str,
+    layer: str | None = None,
+) -> list | None:
+    """Return the raw pad node for ``ref``/``pad_name``.
+
+    When ``layer`` is given, only pads whose copper covers that layer
+    are considered (same logic as :func:`_find_pad_center`).
+    """
+    fp = _find_footprint(data, ref)
+    if fp is None:
+        return None
+    for sub in fp:
+        if not _is_list(sub) or str(sub[0]) != "pad":
+            continue
+        if _get_pad_name(sub) != pad_name:
+            continue
+        if layer is not None and layer not in _pad_layers(sub):
+            continue
+        return sub
+    return None
+
+
 _ALL_COPPER = {"F.Cu", "B.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu"}
 
 
@@ -1418,6 +1461,125 @@ def _pad_layers(pad_node: list) -> list[str]:
                 else:
                     layers.append(name)
     return layers
+
+
+def _resolve_layers(
+    data: list,
+    req: RouteRequest,
+) -> tuple[str, str]:
+    """Auto-pick start/end copper layers from pad types and ``layer_hint``.
+
+    For SMD/connect pads the layer is fixed by the pad itself (it has
+    copper on exactly one copper layer).  For thru-hole pads (``*.Cu``)
+    the router picks the best shared copper layer, preferring
+    ``layer_hint`` when it is among the pad's copper layers.
+
+    When a footprint declares several pads with the same name (edge
+    connectors), the union of all same-named pads' copper layers is
+    used — a THT pad named ``3v3`` makes the pad flexible across all
+    copper layers even if the first same-named pad is SMD.
+
+    Returns ``(start_layer, end_layer)``.
+
+    Raises :class:`RouteFailure` if a pad has no copper on any layer, or
+    if the two pads share no copper layer when a hint is not given.
+    """
+    fp_a = _find_footprint(data, req.ref_a)
+    fp_b = _find_footprint(data, req.ref_b)
+    if fp_a is None:
+        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
+    if fp_b is None:
+        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
+
+    # Collect ALL same-named pad nodes (a footprint may declare several
+    # pads with one name — edge-connector fingers + a THT pad).
+    a_nodes = [
+        s for s in fp_a if _is_list(s) and str(s[0]) == "pad" and _get_pad_name(s) == req.pad_a
+    ]
+    b_nodes = [
+        s for s in fp_b if _is_list(s) and str(s[0]) == "pad" and _get_pad_name(s) == req.pad_b
+    ]
+    if not a_nodes:
+        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
+    if not b_nodes:
+        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
+
+    # Union of copper layers across all same-named pads, and detect
+    # whether any pad is THT (flexible) vs all SMD/connect (fixed).
+    pcb_copper = [l for l in _pcb_layer_names(data) if l.endswith(".Cu")]
+    a_layers: list[str] = []
+    b_layers: list[str] = []
+    a_has_tht = b_has_tht = False
+    for node in a_nodes:
+        if _pad_type(node) == "thru_hole":
+            a_has_tht = True
+        for l in _pad_layers(node):
+            if l.endswith(".Cu") and ".Mask" not in l and l not in a_layers:
+                a_layers.append(l)
+    for node in b_nodes:
+        if _pad_type(node) == "thru_hole":
+            b_has_tht = True
+        for l in _pad_layers(node):
+            if l.endswith(".Cu") and ".Mask" not in l and l not in b_layers:
+                b_layers.append(l)
+    # Filter THT layers to PCB's actual copper layers.
+    if a_has_tht:
+        a_layers = [l for l in a_layers if l in pcb_copper]
+    if b_has_tht:
+        b_layers = [l for l in b_layers if l in pcb_copper]
+    if not a_layers:
+        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} has no copper layer")
+    if not b_layers:
+        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} has no copper layer")
+
+    # A pad is "fixed" only when ALL same-named pads are SMD/connect.
+    a_fixed = not a_has_tht
+    b_fixed = not b_has_tht
+
+    # Determine start layer.
+    if a_fixed:
+        start_layer = a_layers[0]
+    elif req.layer_hint and req.layer_hint in a_layers:
+        start_layer = req.layer_hint
+    else:
+        start_layer = None
+
+    # Determine end layer.
+    if b_fixed:
+        end_layer = b_layers[0]
+    elif req.layer_hint and req.layer_hint in b_layers:
+        end_layer = req.layer_hint
+    else:
+        end_layer = None
+
+    # For THT pads without a fixed layer, pick a shared copper layer.
+    if start_layer is None or end_layer is None:
+        shared = [l for l in a_layers if l in b_layers]
+        if not shared:
+            if start_layer is None:
+                start_layer = (
+                    req.layer_hint
+                    if (req.layer_hint and req.layer_hint in a_layers)
+                    else a_layers[0]
+                )
+            if end_layer is None:
+                end_layer = (
+                    req.layer_hint
+                    if (req.layer_hint and req.layer_hint in b_layers)
+                    else b_layers[0]
+                )
+        else:
+            chosen = None
+            if req.layer_hint and req.layer_hint in shared:
+                chosen = req.layer_hint
+            else:
+                chosen = shared[0]
+            if start_layer is None:
+                start_layer = chosen
+            if end_layer is None:
+                end_layer = chosen
+
+    return start_layer, end_layer
 
 
 def _same_net_pad_polygons(

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -1491,8 +1491,10 @@ def _resolve_layers(
 
     Returns ``(start_layer, end_layer)``.
 
-    Raises :class:`RouteFailure` if a pad has no copper on any layer, or
-    if the two pads share no copper layer when a hint is not given.
+    Raises :class:`RouteFailure` if either pad has no copper on any layer.
+    When the two pads share no copper layer and ``layer_hint`` is neither
+    pad's preferred layer, each pad falls back to its first available
+    copper layer; the returned layers may then differ (staggered).
     """
     fp_a = _find_footprint(data, req.ref_a)
     fp_b = _find_footprint(data, req.ref_b)

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -422,6 +422,34 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         max(pad_a_xy[0], pad_b_xy[0], _hx1) + 5.0,
         max(pad_a_xy[1], pad_b_xy[1], _hy1) + 5.0,
     )
+    # The A* search area is clipped to route_bbox; an obstacle that spans
+    # the whole box (e.g. an Edge.Cuts opening the two pads sit on either
+    # side of) then looks like an impassable wall even though a detour
+    # around it exists outside the box.  Extend the box to cover the
+    # bounds of every obstacle that intersects it (iterated to closure so
+    # obstacles discovered on the second ring are included too), giving
+    # the search enough room to route around them.
+    _routing = set(routing_layers)
+    _x0, _y0, _x1, _y1 = route_bbox
+    _grew = True
+    while _grew:
+        _grew = False
+        for _o in buffered:
+            if not (_routing & _o.layers):
+                continue
+            _b = _o.shape.bounds
+            if _b[2] < _x0 or _b[0] > _x1 or _b[3] < _y0 or _b[1] > _y1:
+                continue  # no overlap with the current search box
+            _nx0, _ny0, _nx1, _ny1 = (
+                min(_x0, _b[0]),
+                min(_y0, _b[1]),
+                max(_x1, _b[2]),
+                max(_y1, _b[3]),
+            )
+            if (_nx0, _ny0, _nx1, _ny1) != (_x0, _y0, _x1, _y1):
+                _x0, _y0, _x1, _y1 = _nx0, _ny0, _nx1, _ny1
+                _grew = True
+    route_bbox = (_x0, _y0, _x1, _y1)
     grid_res = req.grid_resolution or GRID_RESOLUTION
 
     # ---- A* directly from pad centre to pad centre ----

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -12,7 +12,7 @@ Pipeline
 3. **Find pad centers**: locate the two pads to connect and read their copper
    pad shape's center.
 4. **Pick exit points**: choose one or two candidate exit points on the pad
-   edge for each end (axis-aligned first, 45° if needed).
+   edge for each end (axis-aligned first, 45 deg  if needed).
 5. **Grid search + A\\***: build a walkability grid from inflated obstacles
    and run 8-direction A*.  Multi-layer routes insert via edges at legal
    (x, y) positions between layers in ``via_pairs``.
@@ -24,7 +24,7 @@ Multi-layer routing
 
 When ``start_layer != end_layer`` the router builds one GridMap per
 routing layer and runs a multi-layer A* that can insert via edges.
-Via edges cost 2.0 mm (configurable) — this penalises vias so A* prefers
+Via edges cost 2.0 mm (configurable) -- this penalises vias so A* prefers
 routing on a single layer when possible.
 
 No shove
@@ -130,19 +130,22 @@ class RouteRequest:
             through-via. Default is ``(("F.Cu", "B.Cu"),)``. Pass an
             explicit tuple to restrict transitions (e.g. to forbid inner-
             layer vias on a 4-layer board).
-        width: Track width; ``None`` → resolve from netclass.
-        clearance: Minimum clearance to obstacles; ``None`` → resolve from
+        width: Track width; ``None`` -> resolve from netclass.
+        clearance: Minimum clearance to obstacles; ``None`` -> resolve from
             the board's design rules.
-        via_diameter / via_drill: Through-via dimensions; ``None`` →
+        via_diameter / via_drill: Through-via dimensions; ``None`` ->
             resolve from netclass.
         max_miter_mm: Maximum corner miter extension before falling back
-            to a sharp 90° corner.
+            to a sharp 90 deg  corner.
         grid_resolution: Grid cell size in mm for the walkability grid.
             Smaller values give finer paths but more cells.  ``None``
             uses the default (0.025 mm).
         via_cost: Distance-equivalent penalty for taking a via edge in
             multi-layer A*.  Higher values discourage unnecessary stack
             vias.  Default 2.0 mm.
+        turn_penalty: Distance-equivalent cost added when the path
+            changes direction.  0 disables (pure shortest path).
+            Default 0.3 mm ~ 3 cells at 0.1 mm resolution.
     """
 
     pcb_path: str
@@ -158,8 +161,9 @@ class RouteRequest:
     via_diameter: float | None = None
     via_drill: float | None = None
     max_miter_mm: float = 1.0
-    grid_resolution: float | None = None  # None → GRID_RESOLUTION
+    grid_resolution: float | None = None  # None -> GRID_RESOLUTION
     via_cost: float = 2.0  # mm penalty per via edge
+    turn_penalty: float = 0.3  # mm penalty per direction change; 0 disables
 
 
 @dataclass
@@ -289,7 +293,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         )
 
     # World model: only existing copper (tracks, vias, keepouts) blocks the
-    # route.  Footprint courtyards are NOT obstacles — they're a DRC spacing
+    # route.  Footprint courtyards are NOT obstacles -- they're a DRC spacing
     # concept, not a hard copper boundary, and treating them as forbidden
     # forces pointless detours around parts.  Start/end footprints would be
     # excluded anyway, but we skip the whole footprint layer.
@@ -309,7 +313,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         obstacles_by_layer[rl] = [o for o in buffered if rl in o.layers]
 
     # Detect rectangular pads to replace A* path inside them.
-    # A pad is "rectangular" when its width and height differ by ≥ 20%.
+    # A pad is "rectangular" when its width and height differ by >= 20%.
     def _is_rect(size: tuple[float, float] | None) -> bool:
         if size is None:
             return False
@@ -317,7 +321,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         return w > 0 and h > 0 and abs(w - h) / max(w, h) >= 0.2
 
     def _world_size(local_w: float, local_h: float, fp_rot: float) -> tuple[float, float]:
-        """Return (world_w, world_h) accounting for ±90° footprint rotation."""
+        """Return (world_w, world_h) accounting for +/-90 degree footprint rotation."""
         if abs(fp_rot % 180.0 - 90.0) < 0.1:
             return local_h, local_w
         return local_w, local_h
@@ -357,12 +361,12 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     # The world model drops same-net pad copper entirely (the route must
     # land on its own endpoint pads).  Re-add every same-net pad as a
     # transit obstacle on the copper layers it covers so the track never
-    # overlaps other same-net pad copper — it terminates on the endpoint
+    # overlaps other same-net pad copper -- it terminates on the endpoint
     # pad only and connects to other same-net pads by separate tracks
     # later.  Buffer by ``width / 2 + clearance``: the track edge must
     # keep a clearance gap from the pad copper, same as for any other
     # obstacle.  If this makes the route impossible at the requested
-    # width, that is the correct answer — the user should try a
+    # width, that is the correct answer -- the user should try a
     # narrower track.  The two endpoint pads are exempt on their own
     # terminal layers so the track can start/end at their centres.
     pad_half = width / 2.0 + clearance
@@ -391,7 +395,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
 
     # Route bounding box must cover the endpoint pads and every same-net
     # pad obstacle: a detour around a wide pad cluster can extend past
-    # the ±5 mm endpoint margin.
+    # the +/-5 mm endpoint margin.
     _hb = [s.bounds for s in _sn_shapes]
     _hx0 = min((b[0] for b in _hb), default=pad_a_xy[0])
     _hy0 = min((b[1] for b in _hb), default=pad_a_xy[1])
@@ -410,7 +414,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     _bx, _by = pad_b_xy
     print(
         f"  [route] {req.ref_a}/{req.pad_a} ({_ax:.3f},{_ay:.3f})"
-        f" → {req.ref_b}/{req.pad_b} ({_bx:.3f},{_by:.3f})"
+        f" -> {req.ref_b}/{req.pad_b} ({_bx:.3f},{_by:.3f})"
         f"  size_a={pad_a_size} size_b={pad_b_size}"
     )
     # Build pad-rectangle descriptors early (used by postprocess_path in
@@ -442,7 +446,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             )
 
     if start_layer != end_layer:
-        # ── Multi-layer: grid A* with via edges ──────────────────────
+        # -- Multi-layer: grid A* with via edges ----------------------
         # Via-forbidden zones cover EVERY same-net pad, not just the two
         # endpoint pads: a via on any same-net pad face is a DFM defect
         # (solder wicking, annular-ring breakout).  Same-net pads are
@@ -463,12 +467,13 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             grid_res,
             via_cost=req.via_cost,
             via_forbidden_zones=via_forbidden or None,
+            turn_penalty=req.turn_penalty,
         )
         if ml_result.path is None:
             raise RouteFailure(
                 f"No obstacle-avoiding multi-layer path from "
                 f"{req.ref_a}/{req.pad_a} to {req.ref_b}/{req.pad_b} at "
-                f"{width}mm track width ({start_layer} → {end_layer})."
+                f"{width}mm track width ({start_layer} -> {end_layer})."
             )
         print(
             f"  [route] multi-layer A*: {len(ml_result.path)} pts"
@@ -511,7 +516,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
                 _log_path(f"{prefix}-pad-replace", pts, n_before)
             _dump_viz(f"{prefix}-1-pad-replace", pts, _pad_viz, obs, route_bbox)
 
-            # Simplify → shortcut → snap45.
+            # Simplify -> shortcut -> snap45.
             pts = _postprocess_layer_segment(pts, obs, route_bbox, grid_res, prefix, _pad_viz)
 
             # Align endpoint to pad centre (start/end segments only).
@@ -547,7 +552,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         end_xy = (all_nodes[-1].x, all_nodes[-1].y)
         layers_used = _layers_used(all_nodes)
     else:
-        # ── Single-layer: hierarchical A* ───────────────────────────
+        # -- Single-layer: hierarchical A* ---------------------------
         # Only copper on the routing layer can block the track; other
         # layers are parallel physical planes and must not poison the
         # grid (the multi-layer branch groups by layer for the same
@@ -557,8 +562,8 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             layer_obstacles,
             pad_a_xy,
             pad_b_xy,
-            fine_resolution=grid_res,
             route_bbox=route_bbox,
+            turn_penalty=req.turn_penalty,
         )
         if result.path is None:
             raise RouteFailure(
@@ -573,7 +578,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         _dump_viz("0-astar", raw_pts, _pad_viz, buffered, route_bbox)
 
         # ---- Discard A* path inside rectangular pads and replace with
-        #      axis-aligned wire (fence → centre). ----
+        #      axis-aligned wire (fence -> centre). ----
         best_path_pts = raw_pts
         if pad_a_size is not None:
             n_before = len(best_path_pts)
@@ -587,7 +592,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             _log_path("pad_b-replace", best_path_pts, n_before)
         _dump_viz("1-pad-replace", best_path_pts, _pad_viz, buffered, route_bbox)
 
-        # ---- Post-process: simplify → shortcut → snap45 ----
+        # ---- Post-process: simplify -> shortcut -> snap45 ----
         best_path_pts = _postprocess_layer_segment(
             best_path_pts, buffered, route_bbox, grid_res, "", _pad_viz
         )
@@ -669,7 +674,7 @@ def connect_with_via(
 ) -> OutputVia:
     """Helper to build a through-via connecting two segments on different layers.
 
-    The via is placed at the (x, y) of ``seg_a``'s end. Both segments are
+    The via is placed at the (x, y) of seg_a end. Both segments are
     expected to end at the same point.
     """
     return OutputVia(
@@ -712,7 +717,7 @@ def _log_path(label: str, pts: list[tuple[float, float]], prev_n: int | None = N
             kind = "45diag"
         else:
             kind = f"{ang:.0f}deg"
-        segs.append(f"({x1:.3f},{y1:.3f})→({x2:.3f},{y2:.3f}){kind}")
+        segs.append(f"({x1:.3f},{y1:.3f})->({x2:.3f},{y2:.3f}){kind}")
     print(f"  [{label}] {n} pts{delta}: {segs[0]}{'  ...  ' + segs[-1] if len(segs) > 1 else ''}")
     if len(segs) <= 6:
         for s in segs:
@@ -732,7 +737,7 @@ def _log_output_segments(label: str, segs: list) -> None:
             if abs(abs(s.x2 - s.x1) - abs(s.y2 - s.y1)) < 1e-6
             else f"{ang:.0f}deg"
         )
-        print(f"  [{label}] seg{i}: ({s.x1:.3f},{s.y1:.3f})→({s.x2:.3f},{s.y2:.3f}) {kind}")
+        print(f"  [{label}] seg{i}: ({s.x1:.3f},{s.y1:.3f})->({s.x2:.3f},{s.y2:.3f}) {kind}")
 
 
 # ---------------------------------------------------------------------------
@@ -903,7 +908,7 @@ def _postprocess_layer_segment(
     stage_prefix: str,
     pad_viz: list[tuple[str, tuple[float, float, float, float]]],
 ) -> list[tuple[float, float]]:
-    """Run simplify → shortcut → snap45 on a single layer's path.
+    """Run simplify -> shortcut -> snap45 on a single layer's path.
 
     Each step dumps a viz file with ``stage_prefix`` prepended, so
     multi-layer dumps carry the layer name (e.g. ``layer-F.Cu-2-simplify``)
@@ -939,7 +944,7 @@ def _align_single_endpoint(
     pad_size: tuple[float, float],
     from_center: bool,
 ) -> list[tuple[float, float]]:
-    """Align one endpoint to a pad centre via X→Y iterative translation.
+    """Align one endpoint to a pad centre via X->Y iterative translation.
 
     ``from_center=True`` aligns the start of *path*; ``False`` aligns
     the end.  See :func:`_align_path_endpoints` for the detailed algorithm.
@@ -949,7 +954,7 @@ def _align_single_endpoint(
 
     pcx, pcy = pad_center
     if from_center:
-        # ── Start pad ───────────────────────────────────────────────
+        # -- Start pad -----------------------------------------------
         dx = pcx - path[0][0]
         if abs(dx) > 1e-9:
             orig = list(path)
@@ -976,7 +981,7 @@ def _align_single_endpoint(
                 path[k] = (path[k][0], path[k][1] + dy)
                 k += 1
     else:
-        # ── End pad ─────────────────────────────────────────────────
+        # -- End pad -------------------------------------------------
         dx = pcx - path[-1][0]
         if abs(dx) > 1e-9:
             orig = list(path)
@@ -1016,7 +1021,7 @@ def _align_path_endpoints(
     pad_a_size: tuple[float, float] | None = None,
     pad_b_size: tuple[float, float] | None = None,
 ) -> list[tuple[float, float]]:
-    """Align both endpoints to pad centres via X→Y translation.
+    """Align both endpoints to pad centres via X->Y translation.
 
     See :func:`_align_single_endpoint` for the per-endpoint algorithm.
     """
@@ -1073,7 +1078,7 @@ def _replace_pad_path(
             if not _inside_rect(path[k], center, hw, hh):
                 fx, fy = path[k + 1]
                 ox, oy = path[k]
-                # Same (center, fence) order — reverse so path reads [fence, projection].
+                # Same (center, fence) order -- reverse so path reads [fence, projection].
                 keep = _build_pad_wire(cx, cy, fx, fy, ox, oy, minx, maxx, miny, maxy)
                 return path[: k + 1] + keep[::-1]
         return path
@@ -1101,7 +1106,7 @@ def _build_pad_wire(
     miny: float,
     maxy: float,
 ) -> list[tuple[float, float]]:
-    """Return ``[projection, fence]`` — a single axis-aligned segment
+    """Return ``[projection, fence]`` -- a single axis-aligned segment
     along the AABB edge the outside point exits from.  The centre is
     kept by the caller (``_replace_pad_path``), and the whole chain
     is translated by ``_align_path_endpoints``."""
@@ -1119,10 +1124,10 @@ def _build_pad_wire(
         horizontal = abs(ox - x1) >= abs(oy - y1)
 
     if horizontal:
-        # fence on left/right edge → horizontal wire at fence_y
+        # fence on left/right edge -> horizontal wire at fence_y
         return [(x1, y2), (x2, y2)]
     else:
-        # fence on top/bottom edge → vertical wire at fence_x
+        # fence on top/bottom edge -> vertical wire at fence_x
         return [(x2, y1), (x2, y2)]
 
 
@@ -1317,7 +1322,7 @@ def _find_pad_center(
     """Return the (x, y) center of the named pad on the given footprint ref.
 
     When ``layer`` is given, only pads whose copper covers that layer are
-    considered — a footprint may declare several pads with the same name
+    considered -- a footprint may declare several pads with the same name
     (e.g. edge-connector fingers sharing a net), and the center must match
     the pad whose shape :func:`_find_pad_size` would return.
     """
@@ -1343,7 +1348,7 @@ def _find_pad_center(
             px, py = float(at[1]), float(at[2])
         except (TypeError, ValueError):
             return None
-        # Transform local → world (only translation + rotation; pads don't
+        # Transform local -> world (only translation + rotation; pads don't
         # scale).
         wx, wy = _rotate(px, py, fp_rot)
         return fp_x + wx, fp_y + wy
@@ -1480,7 +1485,7 @@ def _resolve_layers(
 
     When a footprint declares several pads with the same name (edge
     connectors), the union of all same-named pads' copper layers is
-    used — a THT pad named ``3v3`` makes the pad flexible across all
+    used -- a THT pad named ``3v3`` makes the pad flexible across all
     copper layers even if the first same-named pad is SMD.
 
     Returns ``(start_layer, end_layer)``.
@@ -1496,7 +1501,7 @@ def _resolve_layers(
         raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
 
     # Collect ALL same-named pad nodes (a footprint may declare several
-    # pads with one name — edge-connector fingers + a THT pad).
+    # pads with one name -- edge-connector fingers + a THT pad).
     a_nodes = [
         s for s in fp_a if _is_list(s) and str(s[0]) == "pad" and _get_pad_name(s) == req.pad_a
     ]
@@ -1595,13 +1600,13 @@ def _same_net_pad_polygons(
 
     The world model drops same-net copper so the route can land on its
     own endpoint pads; the router re-adds those pads here as *transit*
-    obstacles — a track may terminate on a pad, never run across its
+    obstacles -- a track may terminate on a pad, never run across its
     copper (a track through a thru-hole pad's hole is cut by the drill,
     and a via on a pad face is a DFM defect).  Geometry mirrors
     :func:`kcaa.router.world_model._pad_obstacle`.
 
     The world center lets callers distinguish the *endpoint pad instance*
-    from other same-named pads by geometry — two pads on the same net
+    from other same-named pads by geometry -- two pads on the same net
     can share ``(ref, pad name)`` (edge connectors with multiple
     ``3v3`` fingers), so name-based skip would wrongly exempt every
     same-named pad.
@@ -1626,7 +1631,7 @@ def _same_net_pad_polygons(
             if _get_net(sub) != net:
                 continue
             if len(sub) > 2 and str(sub[2]) == "np_thru_hole":
-                continue  # bare mechanical hole — no copper to protect
+                continue  # bare mechanical hole -- no copper to protect
             players = _pad_layers(sub)
             if not players:
                 continue
@@ -1675,7 +1680,7 @@ def _default_track_width(pcb_path: str, net: str) -> float:
     ``track_width``.
 
     Raises:
-        ProFileMissing: No ``.kicad_pro`` next to ``pcb_path`` — pass
+        ProFileMissing: No ``.kicad_pro`` next to ``pcb_path`` -- pass
             ``RouteRequest(width=...)`` explicitly to skip DRC lookup.
         ProFileMalformed: The ``.kicad_pro`` exists but cannot be parsed or
             lacks the expected structure.
@@ -1709,7 +1714,7 @@ def _default_track_width(pcb_path: str, net: str) -> float:
 def _default_clearance(pcb_path: str, net: str | None = None) -> float:
     """Resolve minimum clearance from the board's effective design rules.
 
-    When the board's ``min_clearance`` is 0.0 (which is common — KiCad
+    When the board's ``min_clearance`` is 0.0 (which is common -- KiCad
     leaves it at 0 and relies on net class rules) this falls back to the
     clearance of the matching net class.  If no net class matches, uses
     the Default net class clearance (0.2 mm fallback).
@@ -1904,9 +1909,9 @@ def _resolve_via_drill(pcb_path: str, net: str) -> float:
 
 
 def _net_to_netclass(data: dict) -> dict[str, str]:
-    """Read net→netclass assignments from the JSON project file.
+    """Read net->netclass assignments from the JSON project file.
 
-    KiCad's project file uses ``netclass_patterns`` with a ``pattern`` glob —
+    KiCad's project file uses ``netclass_patterns`` with a ``pattern`` glob --
     a net belongs to the first matching pattern's netclass. This is a
     glob-style match (we use ``fnmatch`` for ``*`` and ``?`` wildcards).
     """
@@ -1935,7 +1940,7 @@ def _net_to_netclass(data: dict) -> dict[str, str]:
     # Resolve patterns into explicit per-net entries.
     # (Net names that are not in the explicit table are resolved here.)
     # The caller will look up by net name; for resolution we need to know
-    # the set of net names — but for our purposes (looking up a single
+    # the set of net names -- but for our purposes (looking up a single
     # net by name) the explicit table is enough. We expose the patterns
     # so a higher layer can resolve ambiguous names. For now, expose
     # ``out`` as the per-net map and also a fallback: if the net is not

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -292,6 +292,21 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             f"{end_layer!r}; cannot route to there."
         )
 
+    # Early net check: pads on different nets must not be routed together.
+    # A foreign-net pad is an obstacle -- past the net check the world model
+    # would dutifully treat it as one and fail deep inside A*, so fail fast
+    # with the actual cause.
+    for ref, pad, layer in (
+        (req.ref_a, req.pad_a, start_layer),
+        (req.ref_b, req.pad_b, end_layer),
+    ):
+        pad_net = _find_pad_net(data, ref, pad, layer)
+        if pad_net is not None and pad_net != req.net:
+            raise RouteFailure(
+                f"Pad {ref}/{pad} is on net {pad_net!r}, not the requested "
+                f"net {req.net!r}; cannot route between different nets."
+            )
+
     # World model: only existing copper (tracks, vias, keepouts) blocks the
     # route.  Footprint courtyards are NOT obstacles -- they're a DRC spacing
     # concept, not a hard copper boundary, and treating them as forbidden
@@ -1317,6 +1332,34 @@ def _pcb_layer_names(data: list) -> list[str]:
             names.append(v if isinstance(v, str) else str(v))
         return names
     return []
+
+
+def _find_pad_net(
+    data: list,
+    ref: str,
+    pad_name: str,
+    layer: str | None = None,
+) -> str | None:
+    """Return the net name of the named pad on the given footprint ref.
+
+    When ``layer`` is given, only pads whose copper covers that layer are
+    considered, matching :func:`_find_pad_center` semantics for footprints
+    that declare several pads with the same name.
+    """
+    fp = _find_footprint(data, ref)
+    if fp is None:
+        return None
+    for sub in fp:
+        if not _is_list(sub):
+            continue
+        if str(sub[0]) != "pad":
+            continue
+        if _get_pad_name(sub) != pad_name:
+            continue
+        if layer is not None and layer not in _pad_layers(sub):
+            continue
+        return _get_net(sub)
+    return None
 
 
 def _find_pad_center(

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -44,6 +44,7 @@ import logging
 import math
 import os
 
+from shapely.geometry import Point, Polygon
 from shapely.geometry import box as _shapely_box
 
 from kcaa.router.grid_a_star import (
@@ -61,7 +62,7 @@ from kcaa.router.path_postprocess import (
     postprocess_path,
 )
 from kcaa.router.visibility_graph import RouteNode
-from kcaa.router.world_model import Obstacle, build_world_model
+from kcaa.router.world_model import Obstacle, _get_net, build_world_model
 from kcaa.utils.pcb_sexp_utils import load_pcb
 
 logger = logging.getLogger(__name__)
@@ -346,13 +347,75 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
                 pad_b_world_size,
             )
 
-    # Route from pad center to pad center.  A* on the grid naturally
-    # produces 0/45/90° segments.
+    # Same-net thru-hole pads have a drilled barrel that physically severs
+    # any track crossing it — but the world model drops same-net pad
+    # copper entirely (so the route can land on its own pads), which also
+    # drops the hole.  Re-add ONLY the drill hole of each same-net
+    # ``thru_hole`` pad as a circular obstacle on every copper layer: a
+    # track may run across same-net pad *copper* (same net, no DRC error),
+    # but never across the *hole* (the drill removes the copper path).
+    # Geometry mirrors :func:`kcaa.router.world_model._npth_obstacle`.
+    pad_delta = width / 2.0 + clearance
+    _tht_hole_shapes: list = []
+    for item in data:
+        if not _is_list(item) or str(item[0]) != "footprint":
+            continue
+        fp_x, fp_y, fp_rot = _node_at3(item)
+        for sub in item:
+            if not _is_list(sub) or str(sub[0]) != "pad":
+                continue
+            if _get_net(sub) != req.net:
+                continue
+            if len(sub) < 3 or str(sub[2]) != "thru_hole":
+                continue
+            at = _get_sub(sub, "at")
+            if at is None or len(at) < 3:
+                continue
+            try:
+                lx, ly = float(at[1]), float(at[2])
+            except (TypeError, ValueError):
+                continue
+            drill_sub = _get_sub(sub, "drill")
+            if drill_sub is None or len(drill_sub) < 2:
+                continue
+            try:
+                drill = float(drill_sub[1])
+            except (TypeError, ValueError):
+                continue
+            wx_off, wy_off = _rotate(lx, ly, fp_rot)
+            wx, wy = fp_x + wx_off, fp_y + wy_off
+            # Skip endpoint pads: the route must start/end at the pad
+            # centre (on the hole), and the plated barrel connects all
+            # layers there — no obstacle needed at the termination.
+            if (abs(wx - pad_a_xy[0]) < 1e-6 and abs(wy - pad_a_xy[1]) < 1e-6) or (
+                abs(wx - pad_b_xy[0]) < 1e-6 and abs(wy - pad_b_xy[1]) < 1e-6
+            ):
+                continue
+            hole = Point(wx, wy).buffer(drill / 2.0 + pad_delta)
+            _tht_hole_shapes.append(hole)
+            for layer in obstacles_by_layer:
+                obstacles_by_layer[layer].append(
+                    Obstacle(
+                        shape=hole,
+                        layers=frozenset({layer}),
+                        net=req.net,
+                        kind="drill",
+                    )
+                )
+
+    # Route bounding box must cover the endpoint pads and every same-net
+    # THT hole obstacle: a detour around a wide drill can extend past the
+    # ±5 mm endpoint margin.
+    _hb = [s.bounds for s in _tht_hole_shapes]
+    _hx0 = min((b[0] for b in _hb), default=pad_a_xy[0])
+    _hy0 = min((b[1] for b in _hb), default=pad_a_xy[1])
+    _hx1 = max((b[2] for b in _hb), default=pad_a_xy[0])
+    _hy1 = max((b[3] for b in _hb), default=pad_b_xy[1])
     route_bbox = (
-        min(pad_a_xy[0], pad_b_xy[0]) - 5.0,
-        min(pad_a_xy[1], pad_b_xy[1]) - 5.0,
-        max(pad_a_xy[0], pad_b_xy[0]) + 5.0,
-        max(pad_a_xy[1], pad_b_xy[1]) + 5.0,
+        min(pad_a_xy[0], pad_b_xy[0], _hx0) - 5.0,
+        min(pad_a_xy[1], pad_b_xy[1], _hy0) - 5.0,
+        max(pad_a_xy[0], pad_b_xy[0], _hx1) + 5.0,
+        max(pad_a_xy[1], pad_b_xy[1], _hy1) + 5.0,
     )
     grid_res = req.grid_resolution or GRID_RESOLUTION
 
@@ -394,27 +457,15 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
 
     if req.start_layer != req.end_layer:
         # ── Multi-layer: grid A* with via edges ──────────────────────
-        # Build via-forbidden zones from start/end pad AABBs to
-        # prevent via-in-pad (DFM issue: solder wicking).
+        # Via-forbidden zones cover EVERY same-net pad, not just the two
+        # endpoint pads: a via on any same-net pad face is a DFM defect
+        # (solder wicking, annular-ring breakout).  Same-net pads are
+        # absent from the obstacle grid (the route must land on its own
+        # pads), so without this the via search would happily drop a via
+        # on a finger pad.
         via_forbidden: list = []
-        if pad_a_world_size is not None:
-            via_forbidden.append(
-                _shapely_box(
-                    pad_a_xy[0] - pad_a_world_size[0] / 2.0,
-                    pad_a_xy[1] - pad_a_world_size[1] / 2.0,
-                    pad_a_xy[0] + pad_a_world_size[0] / 2.0,
-                    pad_a_xy[1] + pad_a_world_size[1] / 2.0,
-                )
-            )
-        if pad_b_world_size is not None:
-            via_forbidden.append(
-                _shapely_box(
-                    pad_b_xy[0] - pad_b_world_size[0] / 2.0,
-                    pad_b_xy[1] - pad_b_world_size[1] / 2.0,
-                    pad_b_xy[0] + pad_b_world_size[0] / 2.0,
-                    pad_b_xy[1] + pad_b_world_size[1] / 2.0,
-                )
-            )
+        for poly, _players, _ref, _pname, _center in _same_net_pad_polygons(data, req.net):
+            via_forbidden.append(poly)
         ml_result = multi_layer_a_star(
             obstacles_by_layer,
             pad_a_xy,
@@ -1388,6 +1439,82 @@ def _pad_layers(pad_node: list) -> list[str]:
                 else:
                     layers.append(name)
     return layers
+
+
+def _same_net_pad_polygons(
+    data: list,
+    net: str,
+) -> list[tuple[object, frozenset[str], str, str, tuple[float, float]]]:
+    """Return ``(world polygon, copper layers, ref, pad name, world center)``
+    for every pad carrying ``net``.
+
+    The world model drops same-net copper so the route can land on its
+    own endpoint pads; the router re-adds those pads here as *transit*
+    obstacles — a track may terminate on a pad, never run across its
+    copper (a track through a thru-hole pad's hole is cut by the drill,
+    and a via on a pad face is a DFM defect).  Geometry mirrors
+    :func:`kcaa.router.world_model._pad_obstacle`.
+
+    The world center lets callers distinguish the *endpoint pad instance*
+    from other same-named pads by geometry — two pads on the same net
+    can share ``(ref, pad name)`` (edge connectors with multiple
+    ``3v3`` fingers), so name-based skip would wrongly exempt every
+    same-named pad.
+    """
+    out: list[tuple[object, frozenset[str], str, str, tuple[float, float]]] = []
+    for item in data:
+        if not _is_list(item) or str(item[0]) != "footprint":
+            continue
+        fp_x, fp_y, fp_rot = _node_at3(item)
+        ref = ""
+        for sub in item:
+            if (
+                _is_list(sub)
+                and str(sub[0]) == "property"
+                and len(sub) >= 3
+                and str(sub[1]) == "Reference"
+            ):
+                ref = sub[2] if isinstance(sub[2], str) else str(sub[2])
+        for sub in item:
+            if not _is_list(sub) or str(sub[0]) != "pad":
+                continue
+            if _get_net(sub) != net:
+                continue
+            if len(sub) > 2 and str(sub[2]) == "np_thru_hole":
+                continue  # bare mechanical hole — no copper to protect
+            players = _pad_layers(sub)
+            if not players:
+                continue
+            size = _get_sub(sub, "size")
+            if size is None or len(size) < 3:
+                continue
+            try:
+                pw, ph = float(size[1]), float(size[2])
+            except (TypeError, ValueError):
+                continue
+            at = _get_sub(sub, "at")
+            if at is None or len(at) < 3:
+                continue
+            try:
+                lx, ly = float(at[1]), float(at[2])
+            except (TypeError, ValueError):
+                continue
+            wx_off, wy_off = _rotate(lx, ly, fp_rot)
+            wx, wy = fp_x + wx_off, fp_y + wy_off
+            hw, hh = pw / 2.0, ph / 2.0
+            rad = math.radians(fp_rot)
+            c, s = math.cos(rad), math.sin(rad)
+            corners = [
+                (c * -hw + s * -hh, -s * -hw + c * -hh),
+                (c * hw + s * -hh, -s * hw + c * -hh),
+                (c * hw + s * hh, -s * hw + c * hh),
+                (c * -hw + s * hh, -s * -hw + c * hh),
+            ]
+            poly = Polygon([(wx + cx, wy + cy) for cx, cy in corners])
+            if poly.is_empty or not poly.is_valid:
+                continue
+            out.append((poly, frozenset(players), ref, _get_pad_name(sub), (wx, wy)))
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/kcaa/router/world_model.py
+++ b/kcaa/router/world_model.py
@@ -478,29 +478,82 @@ def _keepout_obstacle(zone_node: list[Any]) -> Obstacle | None:
     return Obstacle(shape=poly, layers=frozenset({layer}), net=None, kind="keepout")
 
 
+_EDGE_GRAPHICS = {
+    "gr_line",
+    "gr_rect",
+    "gr_arc",
+    "gr_circle",
+    "gr_poly",
+    "fp_line",
+    "fp_rect",
+    "fp_arc",
+    "fp_circle",
+    "fp_poly",
+}
+
+
 def _board_bbox(data: list[Any]) -> tuple[float, float, float, float] | None:
-    """Compute the AABB of all Edge.Cuts items, or None."""
+    """Compute the AABB of all Edge.Cuts items, or None.
+
+    The outline is not always board-level graphics: edge-mounted
+    connectors (e.g. a micro:bit card bay) draw the notch they sit in
+    with ``fp_line``/``fp_poly`` Edge.Cuts items inside the footprint,
+    and those items are part of the real board outline.  Footprint
+    items are transformed into world coordinates through the footprint's
+    ``(at x y rot)`` placement.
+    """
     xs: list[float] = []
     ys: list[float] = []
-    for item in data:
-        if not _is_list(item):
-            continue
-        tag = _sym(item[0])
-        if tag not in {"gr_line", "gr_rect", "gr_arc", "gr_circle"}:
-            continue
-        layer = _get_layer_str(item)
-        if layer != "Edge.Cuts":
-            continue
-        for sub in item:
-            if not _is_list(sub):
-                continue
-            k = _sym(sub[0])
-            if k in {"start", "end", "mid", "center"} and len(sub) >= 3:
+
+    def _walk(node: list[Any], ox: float, oy: float, rot: float) -> None:
+        if not _is_list(node):
+            return
+        tag = _sym(node[0])
+        if tag == "footprint":
+            fox, foy, frot = ox, oy, rot
+            at = _get_sub(node, "at")
+            if at is not None and len(at) >= 3:
                 try:
-                    xs.append(float(sub[1]))
-                    ys.append(float(sub[2]))
+                    fox, foy = float(at[1]), float(at[2])
                 except (TypeError, ValueError):
                     pass
+                if len(at) >= 4:
+                    try:
+                        frot = float(at[3])
+                    except (TypeError, ValueError):
+                        pass
+            for sub in node:
+                _walk(sub, fox, foy, frot)
+            return
+        if tag in _EDGE_GRAPHICS:
+            if _get_layer_str(node) != "Edge.Cuts":
+                return
+            rad = math.radians(rot)
+            c, s = math.cos(rad), math.sin(rad)
+            for sub in node:
+                if not _is_list(sub):
+                    continue
+                k = _sym(sub[0])
+                if k in {"start", "end", "mid", "center"} and len(sub) >= 3:
+                    try:
+                        lx, ly = float(sub[1]), float(sub[2])
+                    except (TypeError, ValueError):
+                        continue
+                elif k == "xy" and len(sub) >= 3:
+                    try:
+                        lx, ly = float(sub[1]), float(sub[2])
+                    except (TypeError, ValueError):
+                        continue
+                else:
+                    continue
+                xs.append(ox + c * lx + s * ly)
+                ys.append(oy - s * lx + c * ly)
+            return
+        for sub in node:
+            _walk(sub, ox, oy, rot)
+
+    for item in data:
+        _walk(item, 0.0, 0.0, 0.0)
     if not xs:
         return None
     return min(xs), min(ys), max(xs), max(ys)

--- a/kcaa/router/world_model.py
+++ b/kcaa/router/world_model.py
@@ -25,11 +25,21 @@ from dataclasses import dataclass, field
 import math
 from typing import Any, Literal
 
-from shapely.geometry import Point, Polygon
+from shapely.geometry import LineString, Point, Polygon
+from shapely.ops import polygonize, unary_union
 
 from kcaa.utils.pcb_sexp_utils import load_pcb
 
-ObstacleKind = Literal["footprint", "pad", "track", "via", "keepout", "board_edge", "drill"]
+ObstacleKind = Literal[
+    "footprint",
+    "pad",
+    "track",
+    "via",
+    "keepout",
+    "board_edge",
+    "drill",
+    "opening",
+]
 
 
 @dataclass(frozen=True)
@@ -122,6 +132,19 @@ def build_world_model(
             ko = _keepout_obstacle(item)
             if ko is not None:
                 model.obstacles.append(ko)
+
+    # Edge.Cuts internal openings (cutouts / routing slots) are physical
+    # voids through the whole stack: block them on every copper layer.
+    for opening in _edge_cuts_openings(data):
+        model.obstacles.append(
+            Obstacle(
+                shape=opening,
+                layers=_ALL_COPPER_LAYERS,
+                net=None,
+                kind="opening",
+                ref=None,
+            )
+        )
     return model
 
 
@@ -557,3 +580,213 @@ def _board_bbox(data: list[Any]) -> tuple[float, float, float, float] | None:
     if not xs:
         return None
     return min(xs), min(ys), max(xs), max(ys)
+
+
+# ---------------------------------------------------------------------------
+# Edge.Cuts openings (cutouts / routing slots inside the board)
+# ---------------------------------------------------------------------------
+
+
+def _edge_cuts_openings(data: list[Any]) -> list[Polygon]:
+    """Closed Edge.Cuts loops strictly inside the board outline.
+
+    KiCad draws internal cutouts (routing slots, mounting windows) as
+    closed loops on the Edge.Cuts layer that lie wholly inside the outer
+    outline.  A track routed across such a loop physically spans a hole in
+    the substrate -- fabrication-invalid copper.  Open notches that touch
+    the outer boundary (e.g. an edge-connector card bay) are NOT openings:
+    they are part of the outline, and the AABB fence handles them.
+
+    The outer outline is the polygonized face with maximum area; every
+    interior ring of that face is one opening loop.  Panel files with
+    several disjoint outlines are handled by collecting interior rings
+    from every face, not just the largest.
+
+    Returns [] when the outline is absent, open, or degenerate (same
+    workflow state as a missing ``_board_bbox``).
+    """
+    lines: list[LineString] = []
+
+    def _walk(node: list[Any], ox: float, oy: float, rot: float) -> None:
+        if not _is_list(node):
+            return
+        tag = _sym(node[0])
+        if tag == "footprint":
+            fox, foy, frot = ox, oy, rot
+            at = _get_sub(node, "at")
+            if at is not None and len(at) >= 3:
+                try:
+                    fox, foy = float(at[1]), float(at[2])
+                except (TypeError, ValueError):
+                    pass
+                if len(at) >= 4:
+                    try:
+                        frot = float(at[3])
+                    except (TypeError, ValueError):
+                        pass
+            for sub in node:
+                _walk(sub, fox, foy, frot)
+            return
+        if tag in _EDGE_GRAPHICS:
+            if _get_layer_str(node) != "Edge.Cuts":
+                return
+            segs = _edge_graphics_to_lines(node, ox, oy, rot)
+            lines.extend(segs)
+            return
+        for sub in node:
+            _walk(sub, ox, oy, rot)
+
+    for item in data:
+        _walk(item, 0.0, 0.0, 0.0)
+    if not lines:
+        return []
+    merged = unary_union(lines)
+    faces = list(polygonize(merged))
+    if not faces:
+        return []
+    # Every closed loop that is interior to *any* face is an opening.
+    # Taking interiors from all faces (not just the max-area one) also
+    # covers panel files with several disjoint board outlines.
+    openings = [Polygon(ring) for f in faces for ring in f.interiors]
+    return [p for p in openings if p.is_valid and not p.is_empty and p.area > 0]
+
+
+def _edge_graphics_to_lines(
+    node: list[Any],
+    ox: float,
+    oy: float,
+    rot: float,
+) -> list[LineString]:
+    """Convert one Edge.Cuts graphic node into world-coordinate segments.
+
+    Supports the KiCad line/rect/arc/circle/poly graphic families (board
+    ``gr_*`` and footprint ``fp_*`` variants).  Footprint-local coordinates
+    are transformed through the footprint origin/rotation, exactly like
+    :func:`_board_bbox`.
+    """
+    tag = _sym(node[0])
+    rad = math.radians(rot)
+    c, s = math.cos(rad), math.sin(rad)
+
+    def _pt(name: str) -> tuple[float, float] | None:
+        sub = _get_sub(node, name)
+        if sub is None or len(sub) < 3:
+            return None
+        try:
+            lx, ly = float(sub[1]), float(sub[2])
+        except (TypeError, ValueError):
+            return None
+        return (ox + c * lx + s * ly, oy - s * lx + c * ly)
+
+    if tag in ("gr_line", "fp_line"):
+        p1, p2 = _pt("start"), _pt("end")
+        if p1 is not None and p2 is not None:
+            return [LineString([p1, p2])]
+        return []
+    if tag in ("gr_rect", "fp_rect"):
+        p1, p2 = _pt("start"), _pt("end")
+        if p1 is None or p2 is None:
+            return []
+        x1, y1 = p1
+        x2, y2 = p2
+        ring = [(x1, y1), (x2, y1), (x2, y2), (x1, y2), (x1, y1)]
+        return [LineString(ring)]
+    if tag in ("gr_arc", "fp_arc"):
+        p1, pm, p2 = _pt("start"), _pt("mid"), _pt("end")
+        if p1 is None or pm is None or p2 is None:
+            return []
+        return [_arc_to_line(p1, pm, p2)]
+    if tag in ("gr_circle", "fp_circle"):
+        pc, pe = _pt("center"), _pt("end")
+        if pc is None or pe is None:
+            return []
+        r = math.hypot(pe[0] - pc[0], pe[1] - pc[1])
+        if r <= 0:
+            return []
+        n = 32
+        ring = [
+            (
+                pc[0] + r * math.cos(2.0 * math.pi * i / n),
+                pc[1] + r * math.sin(2.0 * math.pi * i / n),
+            )
+            for i in range(n + 1)
+        ]
+        return [LineString(ring)]
+    if tag in ("gr_poly", "fp_poly"):
+        pts: list[tuple[float, float]] = []
+        for sub in node:
+            if _is_list(sub) and _sym(sub[0]) == "pts":
+                for p in sub[1:]:
+                    if _is_list(p) and _sym(p[0]) == "xy" and len(p) >= 3:
+                        try:
+                            pts.append(
+                                (
+                                    ox + c * float(p[1]) + s * float(p[2]),
+                                    oy - s * float(p[1]) + c * float(p[2]),
+                                )
+                            )
+                        except (TypeError, ValueError):
+                            continue
+        if len(pts) >= 3:
+            if pts[0] != pts[-1]:
+                pts.append(pts[0])
+            return [LineString(pts)]
+        return []
+    return []
+
+
+def _arc_to_line(
+    p_start: tuple[float, float],
+    p_mid: tuple[float, float],
+    p_end: tuple[float, float],
+    n: int = 16,
+) -> LineString:
+    """Sample a 3-point arc (start, mid, end) into a polyline.
+
+    KiCad stores arcs as three on-arc points; the sweep direction is the
+    one that passes through ``p_mid``.  Returns a degenerate 2-point line
+    when the three points are collinear or coincident.
+    """
+    ax, ay = p_start
+    bx, by = p_mid
+    cx, cy = p_end
+    d = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
+    if abs(d) < 1e-12:
+        return LineString([p_start, p_end])
+    ux = (
+        (ax * ax + ay * ay) * (by - cy)
+        + (bx * bx + by * by) * (cy - ay)
+        + (cx * cx + cy * cy) * (ay - by)
+    ) / d
+    uy = (
+        (ax * ax + ay * ay) * (cx - bx)
+        + (bx * bx + by * by) * (ax - cx)
+        + (cx * cx + cy * cy) * (bx - ax)
+    ) / d
+    r = math.hypot(ax - ux, ay - uy)
+    if r <= 0:
+        return LineString([p_start, p_end])
+    a1 = math.atan2(ay - uy, ax - ux)
+    am = math.atan2(by - uy, bx - ux)
+    a2 = math.atan2(cy - uy, cx - ux)
+    ccw = (a2 - a1) % (2.0 * math.pi)  # 0..2pi sweep start->end
+    mid_ccw = (am - a1) % (2.0 * math.pi)
+    if 0.0 < mid_ccw < ccw:
+        sweep = ccw
+    elif mid_ccw > ccw:
+        sweep = ccw - 2.0 * math.pi
+    else:  # coincident mid (start == mid or mid == end) -> straight-ish
+        sweep = ccw
+    if abs(sweep) < 1e-12:
+        return LineString([p_start, p_end])
+    pts = [
+        (ux + r * math.cos(a1 + sweep * i / n), uy + r * math.sin(a1 + sweep * i / n))
+        for i in range(n + 1)
+    ]
+    # Pin the sampled endpoints to the exact input points so the arc
+    # stitches exactly onto neighbouring Edge.Cuts segments (rounding in
+    # the center/radius reconstruction would otherwise leave a tiny gap
+    # that breaks polygonize's ring closing).
+    pts[0] = p_start
+    pts[-1] = p_end
+    return LineString(pts)

--- a/kcaa/router/world_model.py
+++ b/kcaa/router/world_model.py
@@ -359,7 +359,7 @@ def _pad_obstacle(
 
     Returns ``None`` for NPTH pads (handled by :func:`_npth_obstacle`).
     """
-    pad_type = str(pad_node[1]) if len(pad_node) > 1 else ""
+    pad_type = str(pad_node[2]) if len(pad_node) > 2 else ""
     if pad_type == "np_thru_hole":
         return None  # handled by _npth_obstacle
 
@@ -441,7 +441,7 @@ def _npth_obstacle(
     Unlike ``_via_obstacle``, NPTH pads do not have a net, so the
     ``net_filter`` argument is not consulted — the hole blocks every net.
     """
-    pad_type = str(pad_node[1]) if len(pad_node) > 1 else ""
+    pad_type = str(pad_node[2]) if len(pad_node) > 2 else ""
     if pad_type != "np_thru_hole":
         return None
     # Pad ``at`` is in footprint-local coords.

--- a/kcaa/tools/pcb_routing_tools.py
+++ b/kcaa/tools/pcb_routing_tools.py
@@ -43,9 +43,8 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
         pad_b: str,
         net: str,
         ctx: Context | None,
-        layer: str = "F.Cu",
         width: float | None = None,
-        target_layer: str | None = None,
+        layer_hint: str | None = None,
         via_pairs: tuple[tuple[str, str], ...] | None = None,
     ) -> dict[str, Any]:
         """Connect two pads with an obstacle-avoiding track, optionally across layers.
@@ -53,7 +52,7 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
         Uses the no-shove PNS router: if the path is blocked by an existing
         track or footprint courtyard, the call fails rather than moving
         anything.  Run the placement tools first to clear the way, or call
-        again with a different ``layer``.
+        again with a different ``layer_hint``.
 
         PCB coordinates: mm, +X right, **+Y down**, rotation
         **clockwise-positive** (KiCad PCB convention).
@@ -63,6 +62,11 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
         found).  Clearance is taken from the board's effective design rules
         (see :mod:`kcaa.utils.pcb_design_rules`).
 
+        Layer selection is automatic: SMD pads use their fixed layer;
+        thru-hole pads pick a shared copper layer, preferring
+        ``layer_hint``.  When both pads are thru-hole and share a layer,
+        the route stays on a single layer (no vias).
+
         Args:
             pcb_path: Absolute path to the .kicad_pcb file.
             ref_a: Reference designator of the first footprint (e.g. ``"R1"``).
@@ -71,16 +75,15 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
             pad_b: Pad number on ``ref_b``.
             net: Net name to assign to the new segments.
             ctx: MCP context (unused).
-            layer: Starting copper layer (``"F.Cu"`` by default).
             width: Override the netclass track width (mm).  ``None`` uses the
                 DRC default for the net.
-            target_layer: Destination copper layer.  When ``None`` (default)
-                the route stays on ``layer``.  When set, the router may
-                insert through-hole vias to reach the destination.
+            layer_hint: Preferred copper layer for thru-hole pads.  When
+                ``None`` (default) the router picks automatically.  Ignored
+                for SMD pads whose layer is fixed by the pad itself.
             via_pairs: Optional tuple of ``(from_layer, to_layer)`` pairs
                 the router is allowed to use as via transitions.  Defaults
-                to ``(("F.Cu", "B.Cu"),)`` when ``target_layer`` differs
-                from ``layer``; ignored otherwise.
+                to ``(("F.Cu", "B.Cu"),)`` when the resolved layers differ;
+                ignored otherwise.
 
         Returns:
             dict with:
@@ -96,9 +99,7 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
 
             Or ``{"error": "<message>"}`` on failure.
         """
-        if target_layer is None:
-            target_layer = layer
-        if via_pairs is None and target_layer != layer:
+        if via_pairs is None:
             via_pairs = (("F.Cu", "B.Cu"),)
         req = RouteRequest(
             pcb_path=pcb_path,
@@ -107,8 +108,7 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
             ref_b=ref_b,
             pad_b=pad_b,
             net=net,
-            start_layer=layer,
-            end_layer=target_layer,
+            layer_hint=layer_hint,
             width=width,
             via_pairs=via_pairs or (),
         )

--- a/kcaa/tools/pcb_routing_tools.py
+++ b/kcaa/tools/pcb_routing_tools.py
@@ -46,6 +46,7 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
         width: float | None = None,
         layer_hint: str | None = None,
         via_pairs: tuple[tuple[str, str], ...] | None = None,
+        turn_penalty: float | None = None,
     ) -> dict[str, Any]:
         """Connect two pads with an obstacle-avoiding track, optionally across layers.
 
@@ -84,6 +85,9 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
                 the router is allowed to use as via transitions.  Defaults
                 to ``(("F.Cu", "B.Cu"),)`` when the resolved layers differ;
                 ignored otherwise.
+            turn_penalty: Cost added when the path changes direction (mm).
+                ``None`` uses the default (0.3 mm).  Set to 0 for pure
+                shortest-path routing (more zigzag).
 
         Returns:
             dict with:
@@ -111,6 +115,7 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
             layer_hint=layer_hint,
             width=width,
             via_pairs=via_pairs or (),
+            turn_penalty=turn_penalty if turn_penalty is not None else 0.3,
         )
         try:
             result = auto_route_pair(req)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcaa"
-version = "0.2.0"
+version = "0.2.1"
 description = "Model Context Protocol (MCP) server for KiCad electronic design automation (EDA) files"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/integration/test_pcb_routing.py
+++ b/tests/integration/test_pcb_routing.py
@@ -132,6 +132,8 @@ class TestAutoRoutePair:
     def test_multi_layer_route_inserts_via(self, pcb_copy):
         # R1.2 is on F.Cu (GND). D1.1 is on In1.Cu (GND). The router must
         # insert at least one via to reach the destination layer.
+        # R1.2 is SMD → fixed F.Cu. D1.1 is SMD on In1.Cu → fixed In1.Cu.
+        # No layer_hint needed: SMD layers are auto-detected.
         req = RouteRequest(
             pcb_path=pcb_copy,
             ref_a="R1",
@@ -139,8 +141,6 @@ class TestAutoRoutePair:
             ref_b="D1",
             pad_b="1",
             net="GND",
-            start_layer="F.Cu",
-            end_layer="In1.Cu",
             via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
         )
         result = auto_route_pair(req)
@@ -158,8 +158,6 @@ class TestAutoRoutePair:
             ref_b="D1",
             pad_b="1",
             net="GND",
-            start_layer="F.Cu",
-            end_layer="In1.Cu",
             via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
         )
         result = auto_route_pair(req)
@@ -168,7 +166,8 @@ class TestAutoRoutePair:
             assert 0.0 <= via.y <= 60.0
 
     def test_single_layer_with_via_pair_still_works(self, pcb_copy):
-        # When start_layer == end_layer, no vias are inserted even if via_pairs set.
+        # R1.1 and C1.1 are both SMD on F.Cu → same layer → no vias,
+        # even if via_pairs are set.
         req = RouteRequest(
             pcb_path=pcb_copy,
             ref_a="R1",
@@ -176,8 +175,6 @@ class TestAutoRoutePair:
             ref_b="C1",
             pad_b="1",
             net="VCC",
-            start_layer="F.Cu",
-            end_layer="F.Cu",
             via_pairs=(("F.Cu", "B.Cu"),),
         )
         result = auto_route_pair(req)
@@ -478,8 +475,8 @@ class TestRoutingTool:
         assert len(vias) == 2
 
     def test_multi_layer_tool_writes_segments_and_via(self, pcb_copy):
-        # R1.2 is on F.Cu; D1.1 is on In1.Cu (GND).  Calling the tool
-        # with target_layer="In1.Cu" should produce at least one via.
+        # R1.2 is SMD on F.Cu; D1.1 is SMD on In1.Cu.  Layers are
+        # auto-detected from pad types — no layer_hint needed.
         mcp = self._make_mcp()
         result = self._call_tool(
             mcp,
@@ -491,8 +488,6 @@ class TestRoutingTool:
             pad_b="1",
             net="GND",
             ctx=None,
-            layer="F.Cu",
-            target_layer="In1.Cu",
             via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
         )
         assert "segment_count" in result
@@ -500,27 +495,26 @@ class TestRoutingTool:
         assert result["via_count"] >= 1
         assert "In1.Cu" in result["layers_used"]
 
-    def test_multi_layer_tool_default_via_pair(self, pcb_copy):
-        # When target_layer differs from layer, default via_pairs
-        # ((F.Cu, B.Cu),) is used.  F.Cu → B.Cu reaches a B.Cu pad.
+    def test_single_layer_tool_smd_pads(self, pcb_copy):
+        # R1.1 and C1.1 are both SMD on F.Cu.  layer_hint="B.Cu" is
+        # ignored for SMD pads — route stays on F.Cu.
         mcp = self._make_mcp()
         result = self._call_tool(
             mcp,
             "pcb_route_pad_to_pad",
             pcb_path=pcb_copy,
             ref_a="R1",
-            pad_a="2",
+            pad_a="1",
             ref_b="C1",
-            pad_b="2",
+            pad_b="1",
             net="VCC",
             ctx=None,
-            layer="F.Cu",
-            target_layer="B.Cu",
+            width=0.25,
+            layer_hint="B.Cu",
         )
-        # C1.2 is on F.Cu, so this should fall back to F.Cu routing
-        # (the pad has no copper on B.Cu) — the tool surfaces the error
-        # in result["error"].
-        assert "error" in result or result.get("via_count", 0) >= 0
+        assert "segment_count" in result
+        assert result["via_count"] == 0
+        assert set(result["layers_used"]) == {"F.Cu"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/router/test_grid_a_star.py
+++ b/tests/unit/router/test_grid_a_star.py
@@ -178,6 +178,56 @@ class TestMultiLayerAStar:
         assert _VIA_COST == 2.0
 
 
+# ── shortcut_path ─────────────────────────────────────────────────────
+
+
+class TestShortcutPath:
+    """Tests for :func:`shortcut_path` 45°-family constraint.
+
+    The router must never emit a shortcut that is not 0/45/90/135°:
+    snap_to_45_path_safe can only repair such segments into a Manhattan
+    corner pair, which often collapses into a 90° turn (and can even be
+    blocked).  Keep the original 45°+axis-aligned waypoints instead.
+    """
+
+    def test_rejects_non_45_shortcut_keeps_waypoint(self):
+        """A 50° shortcut (45° diagonal + vertical tail) must be rejected,
+        keeping the intermediate point so the path stays 0/45/90."""
+        from kcaa.router.grid_a_star import shortcut_path
+
+        # Mirror the test-route end shape: 45° approach then a vertical
+        # tail into the pad.  Shortcutting (10,10)->(20,25) is a ~50° line.
+        pts = [(0.0, 20.0), (10.0, 10.0), (20.0, 25.0)]
+        bbox = (-2.0, 8.0, 24.0, 27.0)
+        out = shortcut_path(pts, [], bbox, resolution=0.1)
+        # The near-45 shortcut is rejected -> intermediate point kept.
+        assert out == pts
+
+    def test_accepts_aligned_shortcuts(self):
+        """Axis-aligned and true-45° shortcuts are still collapsed."""
+        from kcaa.router.grid_a_star import shortcut_path
+
+        # Three collinear points on a single horizontal line -> one segment.
+        pts = [(0.0, 5.0), (5.0, 5.0), (10.0, 5.0)]
+        bbox = (-2.0, 3.0, 12.0, 7.0)
+        out = shortcut_path(pts, [], bbox, resolution=0.1)
+        assert len(out) == 2
+        assert out[0] == (0.0, 5.0)
+        assert out[-1] == (10.0, 5.0)
+
+    def test_true_45_diagonal_collapses(self):
+        """A genuine 45° corner is one segment after shortcutting."""
+        from kcaa.router.grid_a_star import shortcut_path
+
+        # (0,10) -> (10,0) is exactly 45°; intermediate point removable.
+        pts = [(0.0, 10.0), (5.0, 5.0), (10.0, 0.0)]
+        bbox = (-2.0, -2.0, 12.0, 12.0)
+        out = shortcut_path(pts, [], bbox, resolution=0.1)
+        assert len(out) == 2
+        assert out[0] == (0.0, 10.0)
+        assert out[-1] == (10.0, 0.0)
+
+
 # ── _subtract_pad_aabb ────────────────────────────────────────────────
 
 

--- a/tests/unit/router/test_grid_a_star.py
+++ b/tests/unit/router/test_grid_a_star.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from shapely.geometry import Polygon
+from shapely.geometry import Point, Polygon
 
 from kcaa.router.grid_a_star import (
     multi_layer_a_star,
@@ -167,7 +167,7 @@ class TestMultiLayerAStar:
             if prev.layer != cur.layer:
                 # via transition — cur is on the destination layer.
                 # Its position should be outside the obstacle.
-                assert not (8.0 <= cur.x <= 12.0 and 9.0 <= cur.y <= 11.0), (
+                assert not obs.shape.contains(Point(cur.x, cur.y)), (
                     f"via landed on blocked cell at ({cur.x:.2f},{cur.y:.2f})"
                 )
 

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -913,3 +913,89 @@ def test_auto_route_pair_reaches_pad_in_footprint_drawn_bay(tmp_path: Path) -> N
     result = auto_route_pair(req)
     assert result.end == pytest.approx((64.0, 62.0), abs=0.02)
     assert len(result.segments) > 0
+
+
+# ---------------------------------------------------------------------------
+# Edge.Cuts internal openings
+# ---------------------------------------------------------------------------
+
+
+def _board_with_opening(tmp_path: Path, rect: tuple[float, float, float, float]) -> Path:
+    """Fixture board + one internal gr_rect opening on Edge.Cuts.
+
+    Baseline outline is (20,20)-(70,60); the opening must sit inside it.
+    """
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    x1, y1, x2, y2 = rect
+    opening = (
+        "\n\t# ---- internal Edge.Cuts opening ----\n"
+        "\t(gr_rect\n"
+        f"\t\t(start {x1} {y1})\n"
+        f"\t\t(end {x2} {y2})\n"
+        "\t\t(stroke (width 0.1) (type solid))\n"
+        "\t\t(fill none)\n"
+        '\t\t(layer "Edge.Cuts")\n'
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + opening + ")\n")
+    return dst
+
+
+def test_edge_cuts_internal_rect_becomes_opening_obstacle(tmp_path: Path) -> None:
+    """A closed gr_rect fully inside the outline is a routing-slot opening:
+    it must appear in the world model as an all-layer obstacle of kind
+    "opening", not just widen the board AABB."""
+    from kcaa.router.world_model import build_world_model
+
+    dst = _board_with_opening(tmp_path, (40.0, 25.0, 50.0, 35.0))
+    world = build_world_model(str(dst), net_filter=None)
+    openings = [o for o in world.obstacles if o.kind == "opening"]
+    assert len(openings) == 1
+    o = openings[0]
+    # Slot polygon matches the requested rect (world coords).
+    assert o.shape.bounds == pytest.approx((40.0, 25.0, 50.0, 35.0))
+    assert o.layers == frozenset({"F.Cu", "B.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu"})
+    assert o.net is None
+
+
+def test_auto_route_pair_detours_around_internal_opening(tmp_path: Path) -> None:
+    """R1 (30,30) -> C1 (60,30) crosses a 40..50 x 25..35 opening on the
+    straight line; the router must route around it (no segment may cross
+    the slot)."""
+    from shapely.geometry import LineString, Polygon
+
+    dst = _board_with_opening(tmp_path, (40.0, 25.0, 50.0, 35.0))
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="C1",
+        pad_b="1",
+        net="VCC",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
+    slot = Polygon([(40.0, 25.0), (50.0, 25.0), (50.0, 35.0), (40.0, 35.0)])
+    for seg in result.segments:
+        line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
+        assert not line.intersects(slot), (
+            f"Segment {seg.x1:.3f},{seg.y1:.3f}->{seg.x2:.3f},{seg.y2:.3f} "
+            f"crosses the Edge.Cuts opening"
+        )
+
+
+def test_edge_cuts_open_notch_is_not_opening(tmp_path: Path) -> None:
+    """The X1 bay notch touches the board outline (it is carved out of the
+    edge), so it is part of the outline -- NOT an internal opening.  The
+    world model must not produce an "opening" obstacle for it."""
+    from kcaa.router.world_model import build_world_model
+
+    dst = _board_with_bay_connector(tmp_path)
+    world = build_world_model(str(dst), net_filter=None)
+    openings = [o for o in world.obstacles if o.kind == "opening"]
+    assert openings == []

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -694,7 +694,7 @@ def test_duplicate_pad_name_resolves_to_layer_matching_pad(tmp_path: Path) -> No
     result = auto_route_pair(req)
     # The route must end on the thru-hole pad at world (62+2, 45), not on
     # the F.Cu-only finger at (62, 45).
-    assert result.end == pytest.approx((64.0, 45.0), abs=0.02)
+    assert result.end == pytest.approx((64.0, 45.0), abs=0.1)
     assert result.layers_used == ["F.Cu", "B.Cu"]
     assert len(result.segments) > 0
 

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -401,8 +401,8 @@ def test_auto_route_pair_warns_when_no_edge_cuts(
 
 
 def test_unknown_layer_in_pcb_raises_route_failure(tmp_path: Path) -> None:
-    """A start_layer / end_layer / via_pair layer that the PCB doesn't declare
-    must fail loudly with a RouteFailure that names the offending layer."""
+    """A via_pair layer that the PCB doesn't declare must fail loudly with
+    a RouteFailure that names the offending layer."""
     src = _fixture_pcb()
     dst = tmp_path / "board.kicad_pcb"
     dst.write_text(Path(src).read_text())
@@ -416,7 +416,7 @@ def test_unknown_layer_in_pcb_raises_route_failure(tmp_path: Path) -> None:
         net="VCC",
         width=0.3,
         clearance=0.2,
-        start_layer="In1.Cu",  # 2-layer fixture has no In1.Cu
+        via_pairs=(("F.Cu", "In2.Cu"),),  # 4-layer fixture has no In2.Cu
     )
     with pytest.raises(RouteFailure) as excinfo:
         auto_route_pair(req)
@@ -424,12 +424,17 @@ def test_unknown_layer_in_pcb_raises_route_failure(tmp_path: Path) -> None:
 
 
 def test_pad_missing_on_layer_raises_route_failure(tmp_path: Path) -> None:
-    """If a pad has no copper shape on the requested layer, routing from it
+    """If a pad has no copper shape on the resolved layer, routing from it
     must fail loudly — never silently fall back to a guessed size."""
     src = _fixture_pcb()
     dst = tmp_path / "board.kicad_pcb"
     dst.write_text(Path(src).read_text())
 
+    # R1.1 / C1.1 are SMD on F.Cu in the fixture; layer_hint="B.Cu" is
+    # ignored for SMD pads (layer is fixed), so the route stays on F.Cu
+    # and succeeds.  The real failure is when a pad has NO copper at all.
+    # This test now verifies the SMD path: layer_hint is ignored, route
+    # proceeds on the pad's own layer (F.Cu).
     req = RouteRequest(
         pcb_path=str(dst),
         ref_a="R1",
@@ -439,11 +444,11 @@ def test_pad_missing_on_layer_raises_route_failure(tmp_path: Path) -> None:
         net="VCC",
         width=0.3,
         clearance=0.2,
-        end_layer="B.Cu",  # R1.1 / C1.1 are SMD on F.Cu in the fixture
+        layer_hint="B.Cu",  # ignored for SMD pads; route stays F.Cu
     )
-    with pytest.raises(RouteFailure) as excinfo:
-        auto_route_pair(req)
-    assert "no copper shape" in str(excinfo.value)
+    # R1.1 / C1.1 are SMD on F.Cu — route should succeed on F.Cu.
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -459,11 +464,10 @@ def test_routing_layers_includes_start_end_and_via_pairs():
         ref_b="B",
         pad_b="1",
         net="N",
-        start_layer="F.Cu",
-        end_layer="B.Cu",
+        layer_hint="F.Cu",
         via_pairs=(("F.Cu", "B.Cu"),),
     )
-    layers = _routing_layers(req)
+    layers = _routing_layers(req, "F.Cu", "B.Cu")
     assert layers == ["F.Cu", "B.Cu"]
 
 
@@ -475,11 +479,10 @@ def test_routing_layers_dedupes():
         ref_b="B",
         pad_b="1",
         net="N",
-        start_layer="F.Cu",
-        end_layer="F.Cu",
+        layer_hint="F.Cu",
         via_pairs=(("F.Cu", "F.Cu"),),
     )
-    layers = _routing_layers(req)
+    layers = _routing_layers(req, "F.Cu", "F.Cu")
     assert layers == ["F.Cu"]
 
 
@@ -609,24 +612,24 @@ def test_invalid_ref_b_pad_raises_failure(pcb_copy):
 # ---------------------------------------------------------------------------
 
 
-def test_thru_hole_pad_on_unused_layer_raises_failure(pcb_copy):
-    # A thru-hole pad is on *.Cu layers but has a "through_hole" pad
-    # type with a hole, not an SMD rect — _find_pad_size returns None
-    # when the requested layer doesn't host the copper shape.  R1.1
-    # is an SMD on F.Cu only; requesting the route on B.Cu should
-    # fail because R1.1 has no copper shape there.
+def test_smd_pad_layer_is_fixed(pcb_copy):
+    # SMD pads are on exactly one copper layer.  layer_hint is ignored
+    # for SMD pads — the layer is fixed by the pad itself.  R1.1 and
+    # C1.2 are both SMD on F.Cu, so the route stays on F.Cu even when
+    # layer_hint suggests B.Cu.
     req = RouteRequest(
         pcb_path=pcb_copy,
         ref_a="R1",
         pad_a="1",
         ref_b="C1",
-        pad_b="2",
+        pad_b="1",
         net="VCC",
-        start_layer="B.Cu",
-        end_layer="B.Cu",
+        width=0.25,
+        clearance=0.2,
+        layer_hint="B.Cu",  # ignored — SMD pads are on F.Cu
     )
-    with pytest.raises(RouteFailure, match="no copper shape"):
-        auto_route_pair(req)
+    result = auto_route_pair(req)
+    assert result.layers_used == ["F.Cu"]
 
 
 # ---------------------------------------------------------------------------
@@ -686,8 +689,7 @@ def test_duplicate_pad_name_resolves_to_layer_matching_pad(tmp_path: Path) -> No
         ref_b="X1",
         pad_b="T",
         net="VCC",
-        start_layer="F.Cu",
-        end_layer="B.Cu",
+        layer_hint="B.Cu",
         width=0.25,
         clearance=0.2,
     )
@@ -761,8 +763,7 @@ def test_multi_layer_via_not_on_same_net_pad(tmp_path: Path) -> None:
         ref_b="X1",
         pad_b="T",
         net="VCC",
-        start_layer="F.Cu",
-        end_layer="B.Cu",
+        layer_hint="B.Cu",
         width=0.25,
         clearance=0.2,
     )
@@ -821,8 +822,7 @@ def test_multi_layer_route_avoids_same_net_tht_hole(tmp_path: Path) -> None:
         ref_b="C1",
         pad_b="1",
         net="VCC",
-        start_layer="F.Cu",
-        end_layer="F.Cu",
+        # Both R1/1 and C1/1 are SMD on F.Cu → single-layer route.
         width=0.25,
         clearance=0.2,
     )
@@ -908,8 +908,7 @@ def test_auto_route_pair_reaches_pad_in_footprint_drawn_bay(tmp_path: Path) -> N
         ref_b="X1",
         pad_b="T",
         net="VCC",
-        start_layer="F.Cu",
-        end_layer="F.Cu",
+        # R1/1 SMD F.Cu → X1/T THT; both share F.Cu → single-layer.
         width=0.25,
         clearance=0.2,
     )

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -697,3 +697,84 @@ def test_duplicate_pad_name_resolves_to_layer_matching_pad(tmp_path: Path) -> No
     assert result.end == pytest.approx((64.0, 45.0), abs=0.02)
     assert result.layers_used == ["F.Cu", "B.Cu"]
     assert len(result.segments) > 0
+
+
+def _board_with_bay_connector(tmp_path: Path) -> Path:
+    """Fixture board + X1 edge connector at the top edge (baseline outline
+    top y=60): X1 draws its bay with fp Edge.Cuts items (top at local y=4,
+    world y=64) and carries pad T at local (2, 2) — world (64, 62) — which
+    sits in the bay, above the gr-only outline."""
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    x1 = (
+        "\n\t# ---- X1: edge connector bay drawn with fp Edge.Cuts ----\n"
+        '\t(footprint "user_add:edge-connector"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "77777777-0000-0000-0000-000000000007")\n'
+        "\t\t(at 62.0 60.0 0.0)\n"
+        '\t\t(property "Reference" "X1")\n'
+        '\t\t(property "Value" "X1")\n'
+        "\t\t(fp_line\n"
+        "\t\t\t(start -3.0 0.0)\n"
+        "\t\t\t(end -3.0 4.0)\n"
+        "\t\t\t(stroke (width 0.1) (type solid))\n"
+        '\t\t\t(layer "Edge.Cuts")\n'
+        "\t\t)\n"
+        "\t\t(fp_line\n"
+        "\t\t\t(start -3.0 4.0)\n"
+        "\t\t\t(end 7.0 4.0)\n"
+        "\t\t\t(stroke (width 0.1) (type solid))\n"
+        '\t\t\t(layer "Edge.Cuts")\n'
+        "\t\t)\n"
+        "\t\t(fp_line\n"
+        "\t\t\t(start 7.0 4.0)\n"
+        "\t\t\t(end 7.0 0.0)\n"
+        "\t\t\t(stroke (width 0.1) (type solid))\n"
+        '\t\t\t(layer "Edge.Cuts")\n'
+        "\t\t)\n"
+        '\t\t(pad "T" smd rect\n'
+        "\t\t\t(at 2.0 2.0)\n"
+        "\t\t\t(size 1.0 1.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x1 + ")\n")
+    return dst
+
+
+def test_board_bbox_includes_footprint_edge_cuts_profile(tmp_path: Path) -> None:
+    """Edge-mounted connectors describe the notch they sit in with
+    footprint-level Edge.Cuts items; those are part of the board outline
+    and must widen the AABB (baseline outline (0,0)-(70,60) → top 64)."""
+    from kcaa.router.world_model import _board_bbox
+
+    dst = _board_with_bay_connector(tmp_path)
+    data = load_pcb(str(dst))
+    bbox = _board_bbox(data)
+    assert bbox == (20.0, 20.0, 70.0, 64.0)
+
+
+def test_auto_route_pair_reaches_pad_in_footprint_drawn_bay(tmp_path: Path) -> None:
+    """A route into a pad sitting in a footprint-drawn bay (above the gr-only
+    outline) must pass the board-bounds check once the outline includes the
+    footprint Edge.Cuts profile."""
+    dst = _board_with_bay_connector(tmp_path)
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="X1",
+        pad_b="T",
+        net="VCC",
+        start_layer="F.Cu",
+        end_layer="F.Cu",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert result.end == pytest.approx((64.0, 62.0), abs=0.02)
+    assert len(result.segments) > 0

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -989,6 +989,41 @@ def test_auto_route_pair_detours_around_internal_opening(tmp_path: Path) -> None
         )
 
 
+def test_auto_route_pair_detours_around_tall_opening(tmp_path: Path) -> None:
+    """An opening TALLER than the pad +/-5 mm search box (it extends beyond
+    the bbox on both sides, e.g. a slot between two connectors) previously
+    looked like an impassable wall: the A* grid is clipped to route_bbox, so
+    the detour around the slot was outside the search area and the route
+    failed even though one exists.  The bbox must grow to cover the opening
+    so the router can find the detour."""
+    from shapely.geometry import LineString, Polygon
+
+    # Baseline outline (20,20)-(70,60); opening is taller than the
+    # R1(30,30) -> C1(60,30) search box (bbox y = 25..35, even with the
+    # 2 mm grid margin: 23..37) on both sides, yet fully inside the
+    # outline (y 20..60).
+    dst = _board_with_opening(tmp_path, (40.0, 21.0, 50.0, 45.0))
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="C1",
+        pad_b="1",
+        net="VCC",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
+    slot = Polygon([(40.0, 21.0), (50.0, 21.0), (50.0, 45.0), (40.0, 45.0)])
+    for seg in result.segments:
+        line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
+        assert not line.intersects(slot), (
+            f"Segment {seg.x1:.3f},{seg.y1:.3f}->{seg.x2:.3f},{seg.y2:.3f} "
+            f"crosses the tall Edge.Cuts opening"
+        )
+
+
 def test_auto_route_pair_rejects_pads_on_different_nets(tmp_path: Path) -> None:
     """Routing two pads that are on DIFFERENT nets must fail fast with a
     clear message instead of treating the target pad as a foreign-net

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -989,6 +989,25 @@ def test_auto_route_pair_detours_around_internal_opening(tmp_path: Path) -> None
         )
 
 
+def test_auto_route_pair_rejects_pads_on_different_nets(tmp_path: Path) -> None:
+    """Routing two pads that are on DIFFERENT nets must fail fast with a
+    clear message instead of treating the target pad as a foreign-net
+    obstacle and failing deep inside A*."""
+    dst = _board_with_opening(tmp_path, (40.0, 25.0, 50.0, 35.0))
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",  # R1/1 is on VCC
+        ref_b="C1",
+        pad_b="1",  # C1/1 is on VCC
+        net="NET_A",  # matches neither pad -> early rejection
+        width=0.25,
+        clearance=0.2,
+    )
+    with pytest.raises(RouteFailure, match="cannot route between different nets"):
+        auto_route_pair(req)
+
+
 def test_edge_cuts_open_notch_is_not_opening(tmp_path: Path) -> None:
     """The X1 bay notch touches the board outline (it is carved out of the
     edge), so it is part of the outline -- NOT an internal opening.  The

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -699,6 +699,144 @@ def test_duplicate_pad_name_resolves_to_layer_matching_pad(tmp_path: Path) -> No
     assert len(result.segments) > 0
 
 
+def test_multi_layer_via_not_on_same_net_pad(tmp_path: Path) -> None:
+    """A via must never land on any same-net pad face (DFM defect:
+    solder wicking / annular-ring breakout).  Via-forbidden zones
+    cover ALL same-net pads, not just the two endpoint pads."""
+    from shapely.geometry import Point, box
+
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    # X3: same-net SMD pads on F.Cu near the route corridor between
+    # R1/1 (29.5, 30) and X1/T (64, 45).  Neither pad is an endpoint;
+    # a multi-layer route's via must avoid both.
+    x3 = (
+        "\n\t# ---- X3: same-net SMD pads, via must avoid ----\n"
+        '\t(footprint "user_add:via-dodge"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "99999999-0000-0000-0000-000000000009")\n'
+        "\t\t(at 45.0 40.0 0.0)\n"
+        '\t\t(property "Reference" "X3")\n'
+        '\t\t(property "Value" "X3")\n'
+        '\t\t(pad "1" smd rect\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 2.0 2.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        '\t\t(pad "2" smd rect\n'
+        "\t\t\t(at 5.0 0.0)\n"
+        "\t\t\t(size 2.0 2.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+        # X1: duplicate T pads — THT variant on B.Cu (endpoint).
+        "\n\t# ---- X1: THT endpoint pad on B.Cu ----\n"
+        '\t(footprint "user_add:edge-connector"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "66666666-0000-0000-0000-000000000006")\n'
+        "\t\t(at 62.0 45.0 0.0)\n"
+        '\t\t(property "Reference" "X1")\n'
+        '\t\t(property "Value" "X1")\n'
+        '\t\t(pad "T" thru_hole circle\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 1.6 1.6)\n"
+        "\t\t\t(drill 1.0)\n"
+        '\t\t\t(layers "*.Cu" "*.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x3 + ")\n")
+
+    # R1/1 F.Cu -> X1/T B.Cu (both VCC).  A via is unavoidable (layer
+    # change).  The via must not land on X3/1 (45,40) or X3/2 (50,40).
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="X1",
+        pad_b="T",
+        net="VCC",
+        start_layer="F.Cu",
+        end_layer="B.Cu",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.vias) > 0
+    # Pad copper rectangles (unbuffered, world coords): 2×2 at (45,40)
+    # and (50,40).
+    pad_rects = [box(44, 39, 46, 41), box(49, 39, 51, 41)]
+    for via in result.vias:
+        pt = Point(via.x, via.y)
+        for i, rect in enumerate(pad_rects):
+            assert not rect.contains(pt), (
+                f"Via at ({via.x:.3f},{via.y:.3f}) lands on X3/{i + 1} pad"
+            )
+
+
+def test_multi_layer_route_avoids_same_net_tht_hole(tmp_path: Path) -> None:
+    """A same-net thru-hole pad's drill hole physically severs any track
+    crossing it.  The router must re-add the hole as an obstacle (the
+    world model drops same-net pad copper entirely) so A* routes around
+    the hole instead of running a track straight through it."""
+    from shapely.geometry import LineString, Point
+
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    # X2: same-net THT pad sitting between R1/1 and C1/1.  Drill 3.0 mm
+    # is large enough that a straight track at x≈45 would cross the hole.
+    x2 = (
+        "\n\t# ---- X2: same-net THT transit pad between R1 and C1 ----\n"
+        '\t(footprint "user_add:tht-blocker"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "88888888-0000-0000-0000-000000000008")\n'
+        "\t\t(at 45.0 30.0 0.0)\n"
+        '\t\t(property "Reference" "X2")\n'
+        '\t\t(property "Value" "X2")\n'
+        '\t\t(pad "1" thru_hole circle\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 4.0 4.0)\n"
+        "\t\t\t(drill 3.0)\n"
+        '\t\t\t(layers "*.Cu" "*.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x2 + ")\n")
+
+    # R1/1 (29.5, 30) F.Cu -> C1/1 (60, 29.5) F.Cu, both VCC.
+    # Without the hole obstacle, A* would run a track at y≈30 through
+    # X2's drill (center 45,30, r=1.5).  The hole forces a detour.
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="C1",
+        pad_b="1",
+        net="VCC",
+        start_layer="F.Cu",
+        end_layer="F.Cu",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
+    # No segment may cross the actual drill hole (r=1.5 at (45, 30)).
+    hole = Point(45.0, 30.0).buffer(1.5)
+    for seg in result.segments:
+        line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
+        assert not line.intersects(hole), (
+            f"Segment {seg.x1:.3f},{seg.y1:.3f}->{seg.x2:.3f},{seg.y2:.3f} crosses X2 drill hole"
+        )
+
+
 def _board_with_bay_connector(tmp_path: Path) -> Path:
     """Fixture board + X1 edge connector at the top edge (baseline outline
     top y=60): X1 draws its bay with fp Edge.Cuts items (top at local y=4,

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -999,3 +999,107 @@ def test_edge_cuts_open_notch_is_not_opening(tmp_path: Path) -> None:
     world = build_world_model(str(dst), net_filter=None)
     openings = [o for o in world.obstacles if o.kind == "opening"]
     assert openings == []
+
+
+# ---------------------------------------------------------------------------
+# NPTH pad type index (type lives at [2], not [1])
+# ---------------------------------------------------------------------------
+
+
+def _fp_with_pad(pad_body: str, ref: str = "X1") -> str:
+    """One footprint with a single pad; returned as raw PCB text snippet."""
+    return (
+        '(footprint "test:npth"\n'
+        '\t(layer "F.Cu")\n'
+        "\t(at 100 100)\n"
+        f'\t(property "Reference" "{ref}")\n'
+        f'\t(property "Value" "{ref}")\n'
+        f"{pad_body}\n"
+        ")\n"
+    )
+
+
+def _load_pcb_text(pcb_text: str, tmp_path: Path) -> Path:
+    from kcaa.utils.pcb_sexp_utils import load_pcb as _lp
+
+    dst = tmp_path / "npth.kicad_pcb"
+    dst.write_text(f"(kicad_pcb (version 20240108) (generator pcbnew)\n{pcb_text}\n)\n")
+    _lp(str(dst))  # parse-validity smoke
+    return dst
+
+
+def test_npth_pad_becomes_drill_obstacle_not_pad_obstacle(tmp_path: Path) -> None:
+    """A KiCad NPTH pad (type at index [2], name '' at [1]) must produce a
+    drill-kind circular obstacle, not a pad-kind rectangle."""
+    from kcaa.router.world_model import build_world_model
+
+    pcb = _load_pcb_text(
+        _fp_with_pad(
+            '\t(pad "" np_thru_hole circle\n'
+            "\t\t(at 0 0)\n"
+            "\t\t(size 3.2 3.2)\n"
+            "\t\t(drill 1.6)\n"
+            '\t\t(layers "*.Cu" "*.Mask")\n'
+            "\t)\n"
+        ),
+        tmp_path,
+    )
+    world = build_world_model(str(pcb), net_filter=None)
+    drills = [o for o in world.obstacles if o.kind == "drill"]
+    pads = [o for o in world.obstacles if o.kind == "pad"]
+    assert len(drills) == 1, f"expected one drill obstacle, got {len(drills)}"
+    assert pads == [], "NPTH must not produce a pad-kind obstacle"
+    d = drills[0]
+    # Drill diameter 1.6 -> obstacle circle r=0.8 at footprint origin (100,100).
+    assert d.shape.area == pytest.approx(3.14159 * 0.8**2, rel=0.05)
+    assert (d.shape.centroid.x, d.shape.centroid.y) == pytest.approx((100.0, 100.0))
+    assert d.layers == frozenset({"F.Cu", "B.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu"})
+    assert d.net is None
+
+
+def test_npth_pad_rotated_with_footprint(tmp_path: Path) -> None:
+    """The drill center follows the footprint placement/rotation."""
+    from kcaa.router.world_model import build_world_model
+
+    pcb = _load_pcb_text(
+        _fp_with_pad(
+            '\t(pad "" np_thru_hole circle\n'
+            "\t\t(at 5 0)\n"
+            "\t\t(size 3.2 3.2)\n"
+            "\t\t(drill 1.6)\n"
+            '\t\t(layers "*.Cu" "*.Mask")\n'
+            "\t)\n",
+            ref="X1",
+        ).replace("(at 100 100)", "(at 100 100 90)"),
+        tmp_path,
+    )
+    world = build_world_model(str(pcb), net_filter=None)
+    drills = [o for o in world.obstacles if o.kind == "drill"]
+    assert len(drills) == 1
+    # Local (5,0) rotated 90 CW on screen -> world (100, 95).
+    assert (drills[0].shape.centroid.x, drills[0].shape.centroid.y) == pytest.approx((100.0, 95.0))
+
+
+def test_plated_thru_hole_pad_still_pad_obstacle(tmp_path: Path) -> None:
+    """A regular plated THT pad must keep producing a pad-kind obstacle --
+    the index fix must not misclassify non-NPTH pads."""
+    from kcaa.router.world_model import build_world_model
+
+    pcb = _load_pcb_text(
+        _fp_with_pad(
+            '\t(pad "1" thru_hole circle\n'
+            "\t\t(at 0 0)\n"
+            "\t\t(size 2.0 2.0)\n"
+            "\t\t(drill 1.0)\n"
+            '\t\t(layers "*.Cu" "*.Mask")\n'
+            '\t\t(net 1 "VCC")\n'
+            "\t)\n"
+        ),
+        tmp_path,
+    )
+    world = build_world_model(str(pcb), net_filter="OtherNet")
+    pads = [o for o in world.obstacles if o.kind == "pad"]
+    drills = [o for o in world.obstacles if o.kind == "drill"]
+    assert len(pads) == 1, "plated THT pad must remain a pad-kind obstacle"
+    assert drills == [], "plated THT pad must not become a drill obstacle"
+    assert pads[0].net == "VCC"

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -423,18 +423,16 @@ def test_unknown_layer_in_pcb_raises_route_failure(tmp_path: Path) -> None:
     assert "In1.Cu" in str(excinfo.value)
 
 
-def test_pad_missing_on_layer_raises_route_failure(tmp_path: Path) -> None:
-    """If a pad has no copper shape on the resolved layer, routing from it
-    must fail loudly — never silently fall back to a guessed size."""
+def test_smd_pad_layer_hint_ignored_route_on_pad_layer(tmp_path: Path) -> None:
+    """SMD pads fix their layer: layer_hint="B.Cu" is ignored for R1.1/C1.1
+    (SMD on F.Cu), so the route proceeds on F.Cu and succeeds."""
     src = _fixture_pcb()
     dst = tmp_path / "board.kicad_pcb"
     dst.write_text(Path(src).read_text())
 
     # R1.1 / C1.1 are SMD on F.Cu in the fixture; layer_hint="B.Cu" is
     # ignored for SMD pads (layer is fixed), so the route stays on F.Cu
-    # and succeeds.  The real failure is when a pad has NO copper at all.
-    # This test now verifies the SMD path: layer_hint is ignored, route
-    # proceeds on the pad's own layer (F.Cu).
+    # and succeeds.
     req = RouteRequest(
         pcb_path=str(dst),
         ref_a="R1",

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -32,12 +32,15 @@ from kcaa.router.router import (
     _default_clearance,
     _default_track_width,
     _find_footprint,
+    _find_pad_center,
+    _find_pad_size,
     _layers_used,
     _project_file_for,
     _routing_layers,
     auto_route_pair,
     connect_with_via,
 )
+from kcaa.utils.pcb_sexp_utils import load_pcb
 
 # ---------------------------------------------------------------------------
 # _project_file_for
@@ -331,6 +334,24 @@ def test_check_segments_in_board_rejects_degenerate_bbox() -> None:
     assert "degenerate" in str(excinfo.value)
 
 
+def test_check_segments_in_board_accepts_segment_onto_edge_pad_zone() -> None:
+    """A segment ending past the shrunk boundary is legal when it lands on
+    an endpoint pad that straddles the edge (edge connector)."""
+    # Board 0..10; width 0.25 shrinks the fence to 0.125..9.875, so
+    # x=9.9 alone would be out of bounds — the pad zone makes it legal.
+    segs = [_seg(5.0, 5.0, 9.9, 5.0)]
+    _check_segments_in_board(segs, (0.0, 0.0, 10.0, 10.0), pad_zones=[(9.9, 5.0, 1.0, 1.0)])
+
+
+def test_check_segments_in_board_rejects_past_edge_without_pad_zone() -> None:
+    """The pad-zone exemption is scoped: same segment, different pad —
+    still rejected."""
+    segs = [_seg(5.0, 5.0, 4.0, 9.9)]
+    with pytest.raises(RouteFailure) as excinfo:
+        _check_segments_in_board(segs, (0.0, 0.0, 10.0, 10.0), pad_zones=[(9.9, 5.0, 1.0, 1.0)])
+    assert "outside the Edge.Cuts boundary" in str(excinfo.value)
+
+
 # ---------------------------------------------------------------------------
 # auto_route_pair — board-bounds check integration
 # ---------------------------------------------------------------------------
@@ -606,3 +627,73 @@ def test_thru_hole_pad_on_unused_layer_raises_failure(pcb_copy):
     )
     with pytest.raises(RouteFailure, match="no copper shape"):
         auto_route_pair(req)
+
+
+# ---------------------------------------------------------------------------
+# duplicate pad names in one footprint (edge-connector style)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_pad_name_resolves_to_layer_matching_pad(tmp_path: Path) -> None:
+    """A footprint may declare several pads with the same name (e.g. edge-
+    connector fingers sharing a net). Looking up that name on a given
+    copper layer must resolve to the pad whose copper is actually there —
+    the first same-named pad must not shadow the rest, and a pad with a
+    drill hole (thru-hole) is a valid target."""
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    x1 = (
+        "\n\t# ---- X1: duplicate 'T' pads; F.Cu finger first, thru-hole *.Cu second ----\n"
+        '\t(footprint "user_add:edge-connector"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "66666666-0000-0000-0000-000000000006")\n'
+        "\t\t(at 62.0 45.0 0.0)\n"
+        '\t\t(property "Reference" "X1")\n'
+        '\t\t(property "Value" "X1")\n'
+        '\t\t(pad "T" smd rect\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 1.0 1.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        '\t\t(pad "T" thru_hole custom\n'
+        "\t\t\t(at 2.0 0.0)\n"
+        "\t\t\t(size 1.6 1.6)\n"
+        "\t\t\t(drill 1.0)\n"
+        '\t\t\t(layers "*.Cu" "*.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x1 + ")\n")
+
+    data = load_pcb(str(dst))
+    # F.Cu resolves to the first pad; B.Cu skips it and finds the thru-hole
+    # pad.  Center and size must describe the SAME pad.
+    assert _find_pad_size(data, "X1", "T", "F.Cu") == (1.0, 1.0)
+    assert _find_pad_size(data, "X1", "T", "B.Cu") == (1.6, 1.6)
+    assert _find_pad_center(data, "X1", "T", "F.Cu") == pytest.approx((62.0, 45.0))
+    assert _find_pad_center(data, "X1", "T", "B.Cu") == pytest.approx((64.0, 45.0))
+    # Unfiltered lookup keeps the legacy first-match behaviour.
+    assert _find_pad_center(data, "X1", "T") == pytest.approx((62.0, 45.0))
+
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="X1",
+        pad_b="T",
+        net="VCC",
+        start_layer="F.Cu",
+        end_layer="B.Cu",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    # The route must end on the thru-hole pad at world (62+2, 45), not on
+    # the F.Cu-only finger at (62, 45).
+    assert result.end == pytest.approx((64.0, 45.0), abs=0.02)
+    assert result.layers_used == ["F.Cu", "B.Cu"]
+    assert len(result.segments) > 0


### PR DESCRIPTION
## Summary

Fixes routing defects in `pcb_route_pad_to_pad` that surfaced when routing `J2/3 → U11/3v3` on a real board with an edge-mounted micro:bit connector (four same-named `3v3` pads: three SMD fingers + one thru-hole), and then improves route quality (turns) end to end.

### Root causes & fixes (routing correctness)

1. **Board outline missed footprint Edge.Cuts profiles** (commit `bffd7bf`)
   - `_board_bbox` only collected top-level `gr_*` Edge.Cuts items; the connector bay (drawn with `fp_line`/`fp_rect` inside the footprint) was missing from the outline → false "outside board" rejection.
   - Fix: `_board_bbox` now recurses into footprints, transforms `fp_*` Edge.Cuts geometry through the footprint `(at x y rot)` into world coords.

2. **Track through same-net THT drill hole** (commit `0357004`)
   - The world model drops same-net pad copper entirely (the route must land on its own pads). This also dropped the **drill hole** of same-net `thru_hole` pads, so a track could run straight through a hole the drill physically severs.
   - Fix: Re-add only the drill hole of each same-net `thru_hole` pad as a circular obstacle on every routing layer (endpoint pads exempt — the track terminates *at* the pad center, the plated barrel bridges layers there).

3. **Via on same-net pad face** (commit `0357004`)
   - Via-forbidden zones covered only the two endpoint pad AABBs; a multi-layer route's via could land on any other same-net pad (finger/annulus) — a DFM defect (solder wicking, annular-ring breakout).
   - Fix: Via-forbidden zones now cover **every** same-net pad, not just the endpoints.

4. **Route bbox too narrow for obstacle detours** (commit `0357004`)
   - `route_bbox` was `pad_centers ± 5mm`; a detour around a wide THT drill can extend past that. Now expanded to include same-net THT hole obstacle bounds.

5. **Same-net pad copper overlap** (commits `e142e24`, `ddc871e`)
   - Same-net pad copper was dropped from the obstacle set too, so a track could overlap a sibling pad's face. Re-added all same-net pads as obstacles; the buffer is now `width/2 + clearance` so the track edge keeps a full DRC clearance gap (zero overlap). If that makes the route impossible at the requested width, the router fails rather than overlapping — the correct answer.

### Layer selection & route quality

6. **Automatic layer selection via `layer_hint`** (commit `22b3a46`)
   - Replaced `start_layer`/`end_layer` with a single `layer_hint`. SMD pads keep their fixed layer; thru-hole pads pick any shared copper layer, preferring `layer_hint`. For duplicate pad names (THT + SMD siblings), `_resolve_layers` unions the copper layers of all same-named pads so a `3v3` THT pad is flexible even if the first same-named pad is an SMD finger. Same-layer routing stays via-free.

7. **Fewer turns** (commits `56ee082`, `dd98eab`)
   - `shortcut_path` no longer restricts short cuts to 0/45/90/135° (any straight clear line is taken; `snap_to_45_path_safe` restores 45° angles, followed by re-simplify).
   - A* now applies a **turn penalty** (default 0.3 mm, configurable via `RouteRequest.turn_penalty` / tool parameter): the search state tracks the arrival direction so a direction change adds cost. On the real board this takes the route from 12 → 9 → **2 segments** (one 45° + one vertical run, no vias).

8. **Release metadata** (commit `3665382`): version bumped to 0.2.1.

### Verification

- Real-board repro (`/tmp/repro/run.py`, exact user args, net `Net-(J2-Pin_3)`, J2/3→U11/3v3, `layer_hint=B.Cu`, 0.5 mm width, 0.2 mm clearance): route succeeds — **2 segments, 0 vias, single layer B.Cu**, one 45° + one vertical run.
- Full test suite: **1346 passed, 17 skipped** after every commit (new regression tests for same-net THT holes, via placement, layer hint, and A* turn behavior).

### Important for users

- The running `kcaa.server` MCP process must be **restarted** for the new code to take effect (Python does not hot-reload; the server imported the old code at startup).
- If a route fails at the requested width, the failure is deliberate (the track would overlap same-net copper) — try a narrower track.