### PR TITLE
feat(plugin): per-project session persistence and follow project switches

### DIFF
--- a/kicad_plugin/__init__.py
+++ b/kicad_plugin/__init__.py
@@ -134,14 +134,7 @@ class KiCadAIPlugin(_ActionPluginBase):
             settings = PluginSettings.load()
             server_mgr = ServerManager(settings)
 
-            parent = None
-            if _IN_KICAD:
-                try:
-                    parent = _pcbnew.GetCurrentFrame()
-                except Exception as e:
-                    log.debug("Could not get KiCad parent frame: %s", e)
-
-            self._panel = AssistantPanel(parent, server_mgr=server_mgr, settings=settings)
+            self._panel = AssistantPanel(None, server_mgr=server_mgr, settings=settings)
             self._panel.Show()
             self._panel.Raise()
 

--- a/kicad_plugin/context_bridge.py
+++ b/kicad_plugin/context_bridge.py
@@ -7,9 +7,32 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+# KiCad window titles name project/board/schematic files, e.g.
+# "PCB Editor: /path/to/board.kicad_pcb [*]" or a .kicad_pro path.
+_TITLE_PROJECT_RE = re.compile(r"([^\s\[]+\.kicad_pro)\b")
+_TITLE_FRAME_RE = re.compile(r"([^\s\[]+\.kicad_(?:pcb|sch))\b")
+
+
+def project_path_from_title(title: str) -> str | None:
+    """Extract a ``.kicad_pro`` path from a KiCad window title, or None.
+
+    Editor windows title the active file (``.kicad_pcb`` / ``.kicad_sch``),
+    the project manager window may title the ``.kicad_pro`` itself.  When
+    only a board/schematic path is named, the sibling ``.kicad_pro`` is
+    derived and returned only if it actually exists.
+    """
+    for m in _TITLE_PROJECT_RE.finditer(title):
+        return os.path.abspath(m.group(1))
+    m = _TITLE_FRAME_RE.search(title)
+    if not m:
+        return None
+    pro = os.path.splitext(m.group(1))[0] + ".kicad_pro"
+    return os.path.abspath(pro) if os.path.exists(pro) else None
 
 
 def _try_import_pcbnew():

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -855,6 +855,15 @@ class LLMClient:
         """Clear conversation history."""
         self._history = []
 
+    def set_base_url(self, url: str | None) -> None:
+        """Set the MCP backend base URL after construction.
+
+        The URL is only known once the backend has finished starting, which
+        may happen after the client is created (e.g. on panel display before
+        the backend came up).
+        """
+        self._mcp_base_url = url
+
     def get_history(self) -> list[dict[str, Any]]:
         """Return a copy of the conversation history for session persistence."""
         return list(self._history)

--- a/kicad_plugin/session_store.py
+++ b/kicad_plugin/session_store.py
@@ -1,0 +1,217 @@
+"""Session persistence for the KiCad AI Assistant (schema v2).
+
+Schema history
+--------------
+v1 (original)::
+
+    {"version": 1, "title", "timestamp", "conv_entries", "llm_history"}
+
+v2 (project-scoped): adds ``project_path`` — the absolute path of the
+``.kicad_pro`` the session was created in, or ``None`` when no project was
+open at save time::
+
+    {"version": 2, "project_path", "title", "timestamp",
+     "conv_entries", "llm_history"}
+
+Project scoping rules
+---------------------
+- A v2 session is owned by exactly one project (``project_path``).
+- A v1 file (missing ``project_path``) is *legacy*: it must never be
+  auto-restored into a project, and is not offered in project-scoped lookups.
+  It stays loadable via the manual Load Session dialog in the UI.
+- ``current.json`` (symlink or plain-text fallback) points at the most
+  recently active session file regardless of project; the caller decides
+  whether the pointed session belongs to the open project.
+"""
+
+from __future__ import annotations
+
+import datetime
+import glob
+import json
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 2
+
+SESSIONS_DIRNAME = "kicad_ai_sessions"
+CURRENT_LINK_NAME = "current.json"
+SESSION_PREFIX = "session_"
+SESSION_SUFFIX = ".json"
+SESSION_GLOB = SESSION_PREFIX + "*" + SESSION_SUFFIX
+
+
+def sessions_dir(config_dir: str) -> str:
+    """Directory holding session files under the kcaa config dir."""
+    return os.path.join(config_dir, SESSIONS_DIRNAME)
+
+
+def current_link_path(config_dir: str) -> str:
+    """Path of the current.json pointer file."""
+    return os.path.join(sessions_dir(config_dir), CURRENT_LINK_NAME)
+
+
+def resolve_current_session(config_dir: str) -> str | None:
+    """Resolve current.json to a session file path, or None.
+
+    Handles both the symlink form and the plain-text fallback.  A dangling
+    symlink or a pointer to a missing file resolves to None.
+    """
+    link = current_link_path(config_dir)
+    if not os.path.exists(link):
+        return None
+    if os.path.islink(link):
+        target = os.readlink(link)
+        # readlink may return a relative path — resolve against the dir.
+        if not os.path.isabs(target):
+            target = os.path.join(sessions_dir(config_dir), target)
+        if os.path.isfile(target):
+            return target
+        return None
+    try:
+        with open(link, encoding="utf-8") as lf:
+            fname = lf.read().strip()
+        candidate = os.path.join(sessions_dir(config_dir), fname)
+        if os.path.isfile(candidate):
+            return candidate
+    except OSError:
+        pass
+    return None
+
+
+def load_session(path: str) -> tuple[dict | None, str | None]:
+    """Load a session file.
+
+    Returns (data, None) on success; (None, error) when the file is missing
+    or contains invalid JSON.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f), None
+    except (OSError, ValueError) as e:
+        return None, str(e)
+
+
+def session_project_path(session: dict | None) -> str | None:
+    """Project stamp of a session; None for legacy v1 files."""
+    if not session:
+        return None
+    return session.get("project_path")
+
+
+def is_project_session(session: dict | None, project_path: str | None) -> bool:
+    """True when *session* is v2-owned by exactly *project_path*.
+
+    Legacy v1 files (no project stamp) and a missing current project never
+    match, so they can never be auto-restored into a project.
+    """
+    return bool(project_path) and session_project_path(session) == project_path
+
+
+def list_session_files(config_dir: str) -> list[str]:
+    """All session files under the sessions dir, newest first."""
+    return sorted(
+        glob.glob(os.path.join(sessions_dir(config_dir), SESSION_GLOB)),
+        reverse=True,
+    )
+
+
+def list_project_sessions(config_dir: str, project_path: str | None) -> list[str]:
+    """Session files owned by *project_path*, newest first.
+
+    Legacy v1 sessions are never included.
+    """
+    if not project_path:
+        return []
+    return [
+        f
+        for f in list_session_files(config_dir)
+        if is_project_session(load_session(f)[0], project_path)
+    ]
+
+
+def list_loadable_sessions(config_dir: str, project_path: str | None) -> list[str]:
+    """Sessions offered in the Load dialog: current project's plus unowned.
+
+    Unowned = legacy v1 files (no project stamp) and v2 files saved with no
+    project open.  Other projects' sessions are hidden so a session can never
+    be picked into the wrong project.  Current project's sessions come first,
+    then unowned — each group newest first.
+    """
+    own = list_project_sessions(config_dir, project_path) if project_path else []
+    unowned = [
+        f for f in list_session_files(config_dir) if not session_project_path(load_session(f)[0])
+    ]
+    return own + unowned
+
+
+def session_title(conv_entries: list[dict]) -> str:
+    """First user message text (truncated), or the default title."""
+    return next((e["text"][:60] for e in conv_entries if e["type"] == "user"), "session")
+
+
+def make_payload(
+    conv_entries: list[dict],
+    llm_history: list,
+    project_path: str | None,
+) -> dict:
+    """Build the on-disk schema v2 payload for a session."""
+    return {
+        "version": SCHEMA_VERSION,
+        "project_path": project_path,
+        "title": session_title(conv_entries),
+        "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+        "conv_entries": conv_entries,
+        "llm_history": llm_history,
+    }
+
+
+def save_session(config_dir: str, filename: str, payload: dict) -> str | None:
+    """Write *payload* to sessions_dir/filename with owner-only perms.
+
+    Returns an error string on failure, None on success.
+    """
+    sessions = sessions_dir(config_dir)
+    try:
+        os.makedirs(sessions, exist_ok=True)
+    except OSError as e:
+        return str(e)
+    path = os.path.join(sessions, filename)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, default=str)
+    except OSError as e:
+        return str(e)
+    return None
+
+
+def update_current_link(config_dir: str, filename: str) -> None:
+    """Atomically point current.json at *filename* (basename).
+
+    Uses a symlink when possible (POSIX); falls back to a plain-text pointer
+    file when symlinks are unavailable (e.g. Windows without privilege).
+    """
+    link = current_link_path(config_dir)
+    tmp_link = link + ".tmp"
+    try:
+        os.symlink(filename, tmp_link)
+        os.replace(tmp_link, link)
+    except Exception:
+        try:
+            with open(link, "w", encoding="utf-8") as lf:
+                lf.write(filename)
+        except Exception as e:
+            log.debug("Could not write session file link: %s", e)
+
+
+def remove_current_link(config_dir: str) -> None:
+    """Remove current.json (both symlink and plain-text variants)."""
+    link = current_link_path(config_dir)
+    try:
+        if os.path.lexists(link):  # lexists catches dangling symlinks too
+            os.remove(link)
+    except OSError:
+        pass

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -155,6 +155,10 @@ if _WX_AVAILABLE:
             # switching projects can re-offer that project's saved sessions
             # (same flow as startup auto-restore). Started by _init_llm_client.
             self._active_project: str | None = None
+            # Project-switch confirmation: first differing reading is held
+            # here and only acted on when the next tick agrees.
+            self._watch_candidate: str | None = None
+            self._watch_candidate_seen: bool = False
             self._project_watch_timer = wx.Timer(self)
 
             self._build_ui()
@@ -2298,16 +2302,34 @@ if _WX_AVAILABLE:
             return True
 
         def _collect_active_project(self) -> str | None:
-            """Absolute path of the currently open .kicad_pro, or None."""
-            try:
-                from ..context_bridge import collect_context
+            """Absolute path of the currently open .kicad_pro, or None.
 
-                return collect_context().get("active_project")
+            Primary source: pcbnew.GetBoard() — only non-empty once a board
+            is loaded in the PCB Editor.  Fallback: KiCad top-level window
+            titles, which name the project/board/schematic path even while
+            GetBoard() is still settling (e.g. right after opening a project
+            or when only the project manager is open).
+            """
+            try:
+                from ..context_bridge import collect_context, project_path_from_title
+
+                proj = collect_context().get("active_project")
+                if proj:
+                    return proj
+                for w in wx.GetTopLevelWindows():
+                    title = w.GetTitle()
+                    if not title:
+                        continue
+                    p = project_path_from_title(title)
+                    if p:
+                        log.debug("project from window title %r -> %s", title, p)
+                        return p
             except Exception:
-                return None
+                log.debug("_collect_active_project failed", exc_info=True)
+            return None
 
         def _start_project_watch(self) -> None:
-            """Start polling for KiCad project switches (3 s interval).
+            """Start polling for KiCad project switches (1 s interval).
 
             The first snapshot is taken here — after auto-restore — so the
             watcher only reacts to *later* project changes, never to the
@@ -2316,34 +2338,56 @@ if _WX_AVAILABLE:
             if not self._project_watch_timer:
                 return
             self._active_project = self._collect_active_project()
-            self._project_watch_timer.Start(3000)
+            self._watch_candidate_seen = False
+            self._project_watch_timer.Start(
+                1000
+            )  # 1 s poll: project switch is noticed quickly once a board signal is available
 
         def _on_project_watch_tick(self, event) -> None:
-            """Offer the new project's sessions when the open project changes.
+            """Close this panel when the open KiCad project changes.
 
-            Same rule as startup auto-restore: if current.json already points
-            at a session of the newly opened project, the conversation is the
-            right one and nothing happens.  Only when current.json is null,
-            stale (still pointing at another project), or legacy do we offer
-            the new project's saved sessions.  Switching to no project, or to
-            a project without saved sessions, leaves things untouched.
+            The panel binds to the project that was active at startup; when
+            the project switches (or the board/project is closed), this
+            instance is stale.  Tear it down — including its MCP server —
+            instead of lingering; the panel opened in the new project
+            auto-restores the right session on first display.
+
+            The project signal flaps during project load (GetBoard() stays
+            empty until the board is up, and the window-title fallback is
+            equally transient), so a switch is only acted on after two
+            consecutive identical readings.
             """
             if self._busy:
                 return
             project = self._collect_active_project()
             if project == self._active_project:
+                self._watch_candidate_seen = False
                 return
+            if not self._watch_candidate_seen:
+                # First differing reading: remember it and wait for a second
+                # identical one before acting.
+                self._watch_candidate_seen = True
+                self._watch_candidate = project
+                return
+            if project != self._watch_candidate:
+                # Still flapping between values (project loading in
+                # background): re-arm with the latest reading.
+                self._watch_candidate = project
+                return
+            log.info(
+                "Project switch confirmed: %s -> %s; switching session",
+                self._active_project,
+                project,
+            )
             self._active_project = project
-            if not self._active_project:
-                return
-            from .. import session_store as _sstore
-
-            path = _sstore.resolve_current_session(self._settings.config_dir)
-            if path:
-                data, err = _sstore.load_session(path)
-                if data and _sstore.is_project_session(data, project):
-                    return  # Conversation already belongs to this project.
-            self._prompt_project_session_choice(self._active_project)
+            self._watch_candidate_seen = False
+            # Keep this panel open and re-run the startup restore flow for
+            # the new project: matching current.json is restored in place,
+            # otherwise the new project's sessions are offered.  Never
+            # Destroy() the window — on a top-level wx.Frame that behaves as
+            # a forced Close and cascaded into closing KiCad's project
+            # windows.
+            self._autoload_session()
 
         def _prompt_project_session_choice(self, project_path: str | None) -> None:
             """Offer the open project's saved sessions after a skip.
@@ -2360,6 +2404,7 @@ if _WX_AVAILABLE:
             if not project_path:
                 return
             candidates = _sstore.list_project_sessions(self._settings.config_dir, project_path)
+            log.info("Session picker for %s: %d candidate(s)", project_path, len(candidates))
             if not candidates:
                 return
             if len(candidates) == 1:
@@ -2407,27 +2452,38 @@ if _WX_AVAILABLE:
                 self._llm_client.reset()
 
         def _on_close(self, event) -> None:
-            if event.CanVeto():
-                # User closed the plugin panel – hide it so the backend stays
-                # warm and KiCad is unaffected. The suicide watchdog timer
-                # (_on_suicide_check) will force-close us when KiCad itself
-                # exits, triggering the real teardown path below.
-                event.Veto()
-                self.Hide()
-                return
-            # Force-close (e.g. from _on_suicide_check when KiCad has exited)
-            # – tear down completely. No final save needed: every user
-            # message, AI reply and cancellation is persisted immediately
-            # where it happens.
+            """Panel close (user clicks X, or watchdog force-close): tear down
+            completely.
+
+            Every user message, AI reply and cancellation is persisted as it
+            happens, so closing loses nothing — the next open restores the
+            session from disk.  The panel is never merely hidden: a hidden
+            panel would keep its timers and MCP server running in the
+            background.  Either the panel stays usable (project switch keeps
+            it open and swaps the session) or it is destroyed — no
+            half-alive state.
+            """
+            if self._busy and self._cancel_event is not None:
+                # An in-flight turn ends with the panel: ask it to stop
+                # writing before we tear down.
+                self._cancel_event.set()
             self._server_mgr.stop()
             self.Destroy()
 
         def _on_suicide_check(self, event) -> None:
-            """Periodically check if KiCad is gone. If we are the only
-            visible top-level wx window left, KiCad's main window must
-            have been closed without sending us EVT_CLOSE — so close
-            ourselves now."""
-            others = [w for w in wx.GetTopLevelWindows() if w is not self and w.IsShown()]
+            """Periodically check if KiCad is gone.
+
+            If the only visible top-level wx windows left are our own plugin
+            panels — including any other AssistantPanel instances (a second
+            panel must not count as a reason to stay alive) — KiCad's own
+            windows are all gone, so close ourselves.  Any non-panel window
+            (project manager, editors, dialogs) keeps us alive.
+            """
+            others = [
+                w
+                for w in wx.GetTopLevelWindows()
+                if not isinstance(w, AssistantPanel) and w.IsShown()
+            ]
             if not others:
                 self.Close(force=True)
 

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -91,6 +91,9 @@ if _WX_AVAILABLE:
             self._server_mgr = server_mgr
             self._settings = settings
             self._llm_client: Any | None = None
+            # True once the MCP backend reported a successful start; the LLM
+            # client is only created when this and panel display both hold.
+            self._server_ready: bool = False
             self._busy = False
             # threading.Event for cancelling an in-progress LLM turn
             self._cancel_event: threading.Event | None = None
@@ -148,6 +151,11 @@ if _WX_AVAILABLE:
             # glitch on Windows), reset _page_loading so renders are not
             # permanently blocked.
             self._page_watchdog = wx.Timer(self)
+            # Project-scoped session watch: tracks the open KiCad project so
+            # switching projects can re-offer that project's saved sessions
+            # (same flow as startup auto-restore). Started by _init_llm_client.
+            self._active_project: str | None = None
+            self._project_watch_timer = wx.Timer(self)
 
             self._build_ui()
             self._start_server()
@@ -396,6 +404,9 @@ if _WX_AVAILABLE:
                 style=wx.BU_EXACTFIT | wx.BORDER_NONE,
             )
             self._send_btn.SetToolTip("Send message (Enter)")
+            # Backend not ready until _on_server_started(True); the button is
+            # enabled there, not clickable while the backend is down.
+            self._send_btn.Disable()
             side_vbox.Add(self._send_btn, 0, wx.ALIGN_CENTER_HORIZONTAL)
 
             hbox.Add(side_vbox, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
@@ -483,6 +494,8 @@ if _WX_AVAILABLE:
             # glitch on Windows), reset _page_loading so renders are not
             # permanently blocked.
             self.Bind(wx.EVT_TIMER, self._on_page_watchdog, self._page_watchdog)
+            self.Bind(wx.EVT_TIMER, self._on_project_watch_tick, self._project_watch_timer)
+            self.Bind(wx.EVT_SHOW, self._on_panel_show)
 
         # ------------------------------------------------------------------ #
         # Server lifecycle
@@ -501,14 +514,21 @@ if _WX_AVAILABLE:
                 if ok:
                     self._set_status("✅ Backend ready", self._C_OK)
                     self.GetMenuBar().Enable(self._menu_autoroute_id, True)
-                    self._init_llm_client()
                     self._check_kicad_ipc_environment()
                     self._auto_save_pcb_on_open()
+                    self._server_ready = True
+                    # The client captures the backend base URL at
+                    # construction; if it was created before the backend was
+                    # up (panel shown early), inject the URL now.
+                    if self._llm_client is not None:
+                        self._llm_client.set_base_url(self._server_mgr.base_url)
                 else:
+                    self._server_ready = False
                     self._set_status(
                         "❌ Backend failed to start — use Server → Restart Backend to retry",
                         self._C_ERR,
                     )
+                self._sync_send_button_state()
                 self.Layout()
             except Exception as e:
                 import traceback
@@ -521,10 +541,24 @@ if _WX_AVAILABLE:
 
                 self._llm_client = LLMClient(self._settings, self._server_mgr.base_url)
                 self._autoload_session()
+                self._start_project_watch()
             except Exception as e:
                 import traceback
 
                 log.error("_init_llm_client failed: %s\n%s", e, traceback.format_exc())
+
+        def _on_panel_show(self, event) -> None:
+            """Initialise the LLM client (and restore the session) on display.
+
+            Deferred from plugin registration so restore/prompt only happens
+            while the user looks at the panel.  The backend base URL is
+            injected later by _on_server_started once the backend is up, so
+            an early panel display is safe.  An already-initialised client
+            (e.g. after a backend Restart) is left untouched.
+            """
+            if event.IsShown() and self._llm_client is None:
+                self._init_llm_client()
+            event.Skip()
 
         # ------------------------------------------------------------------ #
         # KiCad IPC API status check
@@ -678,6 +712,9 @@ if _WX_AVAILABLE:
                     self._llm_client is not None,
                 )
                 return
+            if not self._server_ready:
+                log.debug("_on_send: skipped (backend not ready)")
+                return
             text = self._input.GetValue().strip()
             images = self._encode_attached_images()
             pdfs = [p for p, t in self._attached_files if t == "pdf"]
@@ -723,12 +760,13 @@ if _WX_AVAILABLE:
             self._attached_files.clear()
             self._refresh_attachments_bar()
             self._follow_output_to_bottom = True
-            # Create the session file on the very first message so current.json
-            # is established before the AI responds.
-            if self._current_session_file is None:
-                err = self._save_session_to_disk()
-                if err:
-                    log.warning("Could not create session file: %s", err)
+            # Persist on every user message: creates the file on the first
+            # message (so current.json exists before the AI responds) and makes
+            # the session durable immediately (also upgrading legacy v1 files
+            # to v2, since the user has now modified the session).
+            err = self._save_session_to_disk()
+            if err:
+                log.warning("Could not save session: %s", err)
             self._render_conversation(force_scroll_to_bottom=True)
             self._busy = True
             self._cancel_event = threading.Event()
@@ -961,6 +999,13 @@ if _WX_AVAILABLE:
             else:
                 self._send_btn.SetBitmap(self._make_send_bitmap(bg=bg))
                 self._send_btn.SetToolTip("Send message (Enter)")
+
+        def _sync_send_button_state(self) -> None:
+            """Enable the send button unless the backend is not ready.
+
+            A busy button is the Stop button and must stay clickable.
+            """
+            self._send_btn.Enable(self._server_ready or self._busy)
 
         def _on_send_btn(self, event) -> None:
             """Handle send/stop button click depending on current state."""
@@ -1374,6 +1419,12 @@ if _WX_AVAILABLE:
             if self._tool_calls_made:
                 self._auto_refresh(ctx)
             self._follow_output_to_bottom = False
+            # Persist the completed turn so disk always holds the full
+            # conversation, including the streamed AI reply. On-exit autosave
+            # then only refreshes — no data depends on it.
+            err = self._save_session_to_disk()
+            if err:
+                log.warning("Could not save session after reply: %s", err)
 
         def _on_stream_flush(self, event) -> None:
             """Drain the streaming buffer into the pending AI text (main thread, timer-driven)."""
@@ -1591,6 +1642,11 @@ if _WX_AVAILABLE:
             self._busy = False
             self._cancel_event = None
             self._toggle_send_stop(busy=False)
+            # Persist what has been finalised so far — the turn was cancelled
+            # mid-flight and on-exit autosave is best-effort only.
+            err = self._save_session_to_disk()
+            if err:
+                log.warning("Could not save session after stop: %s", err)
 
         def _on_restart(self, event) -> None:
             if self._busy:
@@ -1601,6 +1657,9 @@ if _WX_AVAILABLE:
                 )
                 return
             self._set_status("⏳ Restarting backend…", self._C_WARN)
+            # Messages are blocked while the backend is down.
+            self._server_ready = False
+            self._sync_send_button_state()
             self._conv_entries.append(
                 {
                     "type": "status",
@@ -1626,6 +1685,9 @@ if _WX_AVAILABLE:
                     }
                 )
                 self._render_conversation()
+                # Rebuild the LLM client: the backend may have come back on a
+                # new port, so the old client's base URL is stale.  Session
+                # restore here is lossless — disk holds every completed turn.
                 self._init_llm_client()
                 self._on_server_started(True)
             else:
@@ -2084,9 +2146,6 @@ if _WX_AVAILABLE:
         # Session persistence
         # ------------------------------------------------------------------ #
 
-        def _sessions_dir(self) -> str:
-            return os.path.join(self._settings.config_dir, "kicad_ai_sessions")
-
         def _on_new_session(self, event) -> None:
             """Save the current session (if non-empty) then clear to start a new one."""
             if self._busy:
@@ -2115,7 +2174,9 @@ if _WX_AVAILABLE:
                 self._llm_client.reset()
 
             # Remove current.json so a blank close won't restore the old session.
-            self._remove_current_link()
+            from .. import session_store as _sstore
+
+            _sstore.remove_current_link(self._settings.config_dir)
 
             self._set_status(
                 "✅ New session started" + (" (previous session saved)" if has_content else ""),
@@ -2123,17 +2184,12 @@ if _WX_AVAILABLE:
             )
             self.Layout()
 
-        def _remove_current_link(self) -> None:
-            """Remove current.json (both symlink and plain-text variants)."""
-            link = os.path.join(self._sessions_dir(), "current.json")
-            try:
-                if os.path.lexists(link):  # lexists catches dangling symlinks too
-                    os.remove(link)
-            except OSError as e:
-                log.warning("Could not remove current.json: %s", e)
-
         def _save_session_to_disk(self) -> str | None:
             """Write current conv_entries + history to disk and update current.json.
+
+            Sessions are stamped with the currently open KiCad project
+            (schema v2), so a session never silently leaks into a different
+            project.  The stamp reflects the project active at save time.
 
             If ``_current_session_file`` is already set the existing file is
             overwritten; otherwise a new timestamped file is created and
@@ -2141,65 +2197,31 @@ if _WX_AVAILABLE:
 
             Returns an error string on failure, None on success.
             """
-            import datetime
-            import json as _json
+            from .. import session_store as _sstore
 
-            sessions_dir = self._sessions_dir()
-            try:
-                os.makedirs(sessions_dir, exist_ok=True)
-            except OSError as e:
-                return str(e)
-
-            title = next(
-                (e["text"][:60] for e in self._conv_entries if e["type"] == "user"),
-                "session",
-            )
             if self._current_session_file:
                 filename = self._current_session_file
             else:
                 ts = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
                 filename = f"session_{ts}.json"
                 self._current_session_file = filename
-            path = os.path.join(sessions_dir, filename)
-            data = {
-                "version": 1,
-                "title": title,
-                "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
-                "conv_entries": self._conv_entries,
-                "llm_history": (
+            payload = _sstore.make_payload(
+                self._conv_entries,
+                (
                     _strip_images_from_history(self._llm_client.get_history())
                     if self._llm_client
                     else []
                 ),
-            }
-            try:
-                fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    _json.dump(data, f, indent=2, default=str)
-            except OSError as e:
-                return str(e)
-
-            self._update_current_link(filename)
+                self._collect_active_project(),
+            )
+            err = _sstore.save_session(self._settings.config_dir, filename, payload)
+            if err:
+                return err
+            _sstore.update_current_link(self._settings.config_dir, filename)
             return None
 
-        def _update_current_link(self, filename: str) -> None:
-            """Atomically update current.json to point at *filename* (basename)."""
-            sessions_dir = self._sessions_dir()
-            link = os.path.join(sessions_dir, "current.json")
-            tmp_link = link + ".tmp"
-            try:
-                os.symlink(filename, tmp_link)
-                os.replace(tmp_link, link)
-            except Exception:
-                try:
-                    with open(link, "w", encoding="utf-8") as lf:
-                        lf.write(filename)
-                except Exception as e:
-                    log.debug("Could not write session file link: %s", e)
-
         def _on_load_session(self, event) -> None:
-            import glob
-            import json as _json
+            from .. import session_store as _sstore
 
             if self._busy:
                 wx.MessageBox(
@@ -2209,28 +2231,28 @@ if _WX_AVAILABLE:
                 )
                 return
 
-            sessions_dir = self._sessions_dir()
-            files = sorted(
-                glob.glob(os.path.join(sessions_dir, "session_*.json")),
-                reverse=True,
+            files = _sstore.list_loadable_sessions(
+                self._settings.config_dir, self._collect_active_project()
             )
             if not files:
                 wx.MessageBox(
-                    "No saved sessions found.", "Load Session", wx.OK | wx.ICON_INFORMATION
+                    "No saved sessions found for the current project.",
+                    "Load Session",
+                    wx.OK | wx.ICON_INFORMATION,
                 )
                 return
 
             # Build display labels
             labels = []
             for f in files:
-                try:
-                    with open(f, encoding="utf-8") as fh:
-                        d = _json.load(fh)
-                    ts = d.get("timestamp", "")[:19].replace("T", " ")
-                    title = d.get("title", "")[:50]
-                    labels.append(f"{ts}  —  {title}")
-                except Exception:
+                d, _ = _sstore.load_session(f)
+                if d is None:
                     labels.append(os.path.basename(f))
+                    continue
+                ts = d.get("timestamp", "")[:19].replace("T", " ")
+                title = d.get("title", "")[:50]
+                suffix = "" if d.get("project_path") else "  [no project]"
+                labels.append(f"{ts}  —  {title}{suffix}")
 
             dlg = wx.SingleChoiceDialog(
                 self,
@@ -2243,14 +2265,21 @@ if _WX_AVAILABLE:
                 return
             idx = dlg.GetSelection()
             dlg.Destroy()
+            if 0 <= idx < len(files):
+                self._restore_session_file(files[idx])
 
-            chosen = files[idx]
-            try:
-                with open(chosen, encoding="utf-8") as fh:
-                    data = _json.load(fh)
-            except (OSError, _json.JSONDecodeError) as e:
-                wx.MessageBox(f"Could not load session:\n{e}", "Error", wx.OK | wx.ICON_ERROR)
-                return
+        def _restore_session_file(self, path: str) -> bool:
+            """Load a saved session file into the panel and point current.json at it.
+
+            Returns True on success; shows an error dialog and returns False
+            when the file cannot be loaded.
+            """
+            from .. import session_store as _sstore
+
+            data, err = _sstore.load_session(path)
+            if data is None:
+                wx.MessageBox(f"Could not load session:\n{err}", "Error", wx.OK | wx.ICON_ERROR)
+                return False
 
             # Restore state
             self._stream_timer.Stop()
@@ -2260,11 +2289,106 @@ if _WX_AVAILABLE:
             if self._llm_client:
                 self._llm_client.set_history(data.get("llm_history", []))
             # Track which file is now active; point current.json at it.
-            self._current_session_file = os.path.basename(chosen)
-            self._update_current_link(self._current_session_file)
+            self._current_session_file = os.path.basename(path)
+            _sstore.update_current_link(self._settings.config_dir, self._current_session_file)
+
             self._render_conversation(force_scroll_to_bottom=True)
             self._set_status("✅ Session restored", self._C_OK)
             self.Layout()
+            return True
+
+        def _collect_active_project(self) -> str | None:
+            """Absolute path of the currently open .kicad_pro, or None."""
+            try:
+                from ..context_bridge import collect_context
+
+                return collect_context().get("active_project")
+            except Exception:
+                return None
+
+        def _start_project_watch(self) -> None:
+            """Start polling for KiCad project switches (3 s interval).
+
+            The first snapshot is taken here — after auto-restore — so the
+            watcher only reacts to *later* project changes, never to the
+            project already active at startup.
+            """
+            if not self._project_watch_timer:
+                return
+            self._active_project = self._collect_active_project()
+            self._project_watch_timer.Start(3000)
+
+        def _on_project_watch_tick(self, event) -> None:
+            """Offer the new project's sessions when the open project changes.
+
+            Same rule as startup auto-restore: if current.json already points
+            at a session of the newly opened project, the conversation is the
+            right one and nothing happens.  Only when current.json is null,
+            stale (still pointing at another project), or legacy do we offer
+            the new project's saved sessions.  Switching to no project, or to
+            a project without saved sessions, leaves things untouched.
+            """
+            if self._busy:
+                return
+            project = self._collect_active_project()
+            if project == self._active_project:
+                return
+            self._active_project = project
+            if not self._active_project:
+                return
+            from .. import session_store as _sstore
+
+            path = _sstore.resolve_current_session(self._settings.config_dir)
+            if path:
+                data, err = _sstore.load_session(path)
+                if data and _sstore.is_project_session(data, project):
+                    return  # Conversation already belongs to this project.
+            self._prompt_project_session_choice(self._active_project)
+
+        def _prompt_project_session_choice(self, project_path: str | None) -> None:
+            """Offer the open project's saved sessions after a skip.
+
+            Invoked when current.json cannot be auto-restored for the open
+            project — callers (auto-restore, project switch) check that first.
+            Candidates are the sessions stamped with *project_path*; a single
+            candidate is restored directly (a one-option dialog adds no
+            information), and the user may cancel a multi-candidate picker to
+            start blank.
+            """
+            from .. import session_store as _sstore
+
+            if not project_path:
+                return
+            candidates = _sstore.list_project_sessions(self._settings.config_dir, project_path)
+            if not candidates:
+                return
+            if len(candidates) == 1:
+                self._restore_session_file(candidates[0])
+                return
+
+            labels = []
+            for f in candidates:
+                d, _ = _sstore.load_session(f)
+                if d is None:
+                    labels.append(os.path.basename(f))
+                    continue
+                ts = d.get("timestamp", "")[:19].replace("T", " ")
+                title = d.get("title", "")[:50]
+                labels.append(f"{ts}  —  {title}")
+
+            dlg = wx.SingleChoiceDialog(
+                self,
+                "Saved sessions for this project found — restore one?",
+                "Restore Session",
+                labels,
+            )
+            if dlg.ShowModal() != wx.ID_OK:
+                dlg.Destroy()
+                return
+            idx = dlg.GetSelection()
+            dlg.Destroy()
+            if 0 <= idx < len(candidates):
+                self._restore_session_file(candidates[idx])
 
         def _on_clear(self, event) -> None:
             if self._busy:
@@ -2292,8 +2416,9 @@ if _WX_AVAILABLE:
                 self.Hide()
                 return
             # Force-close (e.g. from _on_suicide_check when KiCad has exited)
-            # – tear down completely.
-            self._autosave_session()
+            # – tear down completely. No final save needed: every user
+            # message, AI reply and cancellation is persisted immediately
+            # where it happens.
             self._server_mgr.stop()
             self.Destroy()
 
@@ -2309,68 +2434,49 @@ if _WX_AVAILABLE:
         def _on_destroy(self, event) -> None:
             """Called when the wx window is actually destroyed (e.g. KiCad shutdown)."""
             if event.GetEventObject() is self:
-                self._autosave_session()
+                if self._project_watch_timer is not None:
+                    self._project_watch_timer.Stop()
                 self._server_mgr.stop()
             event.Skip()
 
         # ------------------------------------------------------------------ #
-        # Auto-save / auto-load
+        # Auto-load
         # ------------------------------------------------------------------ #
-
-        def _autosave_session(self) -> None:
-            """Save a timestamped session file on every close.
-
-            Also atomically updates the ``current.json`` symlink in the sessions
-            directory so the next startup can load it directly without globbing.
-            """
-            # Only save if there is real conversational content — skip sessions
-            # that only contain status/warning notices.
-            if not any(e["type"] in ("user", "ai") for e in self._conv_entries):
-                return
-            err = self._save_session_to_disk()
-            if err:
-                log.warning("Auto-save failed: %s", err)
 
         def _autoload_session(self) -> None:
             """Restore the session pointed to by ``current.json`` on startup.
 
+            Project-aware since schema v2: a session is auto-restored only
+            when it belongs to the currently open KiCad project.  Legacy v1
+            sessions (no project stamp) and sessions saved in other projects
+            are skipped; if the open project has sessions of its own, the
+            user is asked to pick one.
+
             Only follows current.json — no glob fallback. This ensures "New
             Session" (which removes current.json) always starts blank.
+
+            Runs when the LLM client is initialised — on first panel display, or
+            after a manual backend Restart.  Since every turn is persisted as
+            it completes (send/reply/stop), the disk snapshot is always the
+            newest completed state, and restoring it is lossless.
             """
-            import json as _json
+            from .. import session_store as _sstore
 
-            sessions_dir = self._sessions_dir()
-            link = os.path.join(sessions_dir, "current.json")
-            path: str | None = None
-
-            if os.path.exists(link):
-                # Resolve: may be a real symlink or the plain-text fallback.
-                if os.path.islink(link):
-                    target = os.readlink(link)
-                    # readlink may return a relative path — resolve against dir.
-                    if not os.path.isabs(target):
-                        target = os.path.join(sessions_dir, target)
-                    if os.path.isfile(target):
-                        path = target
-                else:
-                    # Plain-text pointer written by the symlink fallback.
-                    try:
-                        with open(link, encoding="utf-8") as lf:
-                            fname = lf.read().strip()
-                        candidate = os.path.join(sessions_dir, fname)
-                        if os.path.isfile(candidate):
-                            path = candidate
-                    except OSError:
-                        pass
-
+            path = _sstore.resolve_current_session(self._settings.config_dir)
             if path is None:
                 return  # No current.json and no sessions dir — blank start.
 
-            try:
-                with open(path, encoding="utf-8") as f:
-                    data = _json.load(f)
-            except (OSError, _json.JSONDecodeError) as e:
-                log.warning("Auto-load failed: %s", e)
+            data, err = _sstore.load_session(path)
+            if data is None:
+                log.warning("Auto-load failed: %s (%s)", path, err)
+                return
+
+            current_project = self._collect_active_project()
+
+            # Legacy v1 sessions and sessions of other projects must not leak
+            # into the open project — skip and offer project sessions instead.
+            if not _sstore.is_project_session(data, current_project):
+                self._prompt_project_session_choice(current_project)
                 return
 
             conv = data.get("conv_entries", [])

--- a/tests/unit/plugin/test_context_bridge.py
+++ b/tests/unit/plugin/test_context_bridge.py
@@ -3,7 +3,11 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from kicad_plugin.context_bridge import collect_context, context_to_system_prompt_block
+from kicad_plugin.context_bridge import (
+    collect_context,
+    context_to_system_prompt_block,
+    project_path_from_title,
+)
 
 
 class TestCollectContextNoPcbnew:
@@ -167,3 +171,35 @@ class TestContextToSystemPromptBlock:
         }
         block = context_to_system_prompt_block(ctx)
         assert "Active PCB: /" not in block  # Should show "(none)" not a path
+
+
+class TestProjectPathFromTitle:
+    def test_pcb_editor_title_derives_existing_project(self, tmp_path):
+        pcb = tmp_path / "board.kicad_pcb"
+        pro = pcb.with_suffix(".kicad_pro")
+        pcb.write_text("(kicad_pcb)")
+        pro.write_text("(kicad_project)")
+        assert project_path_from_title(f"PCB Editor: {pcb}") == os.path.abspath(str(pro))
+
+    def test_schematic_editor_title_derives_project(self, tmp_path):
+        sch = tmp_path / "board.kicad_sch"
+        sch.with_suffix(".kicad_pro").write_text("(kicad_project)")
+        sch.write_text("(kicad_sch)")
+        assert project_path_from_title(f"Eeschema: {sch}") == os.path.abspath(
+            str(sch.with_suffix(".kicad_pro"))
+        )
+
+    def test_project_title_direct(self, tmp_path):
+        pro = tmp_path / "proj.kicad_pro"
+        pro.write_text("(kicad_project)")
+        assert project_path_from_title(f"KiCad - {pro}") == os.path.abspath(str(pro))
+
+    def test_derived_project_missing_returns_none(self, tmp_path):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        # No sibling .kicad_pro — derivation fails and returns None.
+        assert project_path_from_title(f"PCB Editor: {pcb}") is None
+
+    def test_unrelated_title_returns_none(self):
+        assert project_path_from_title("Settings Dialog") is None
+        assert project_path_from_title("") is None

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -90,6 +90,21 @@ def _tool(tool_call_id="tc1", content="result"):
 # ---------------------------------------------------------------------------
 
 
+class TestSetBaseUrl:
+    def test_updates_url_after_construction(self):
+        client = _make_client()
+        assert client._mcp_base_url == "http://127.0.0.1:9999"
+        client.set_base_url("http://127.0.0.1:5555")
+        assert client._mcp_base_url == "http://127.0.0.1:5555"
+
+    def test_none_then_real_url(self):
+        client = _make_client()
+        # Client constructed before the backend is up sees base URL None.
+        client.set_base_url(None)
+        client.set_base_url("http://127.0.0.1:1234")
+        assert client._mcp_base_url == "http://127.0.0.1:1234"
+
+
 class TestDedupToolCalls:
     def test_no_change_when_no_tool_calls(self):
         client = _make_client()

--- a/tests/unit/plugin/test_session_store.py
+++ b/tests/unit/plugin/test_session_store.py
@@ -1,0 +1,242 @@
+"""Tests for session_store: schema v2 project scoping and v1 legacy support.
+
+Defends the contract that drives session auto-restore:
+
+- v1 files (no ``project_path``) are legacy and never project-matched, so
+  they can never be auto-restored into a project;
+- v2 files match only the project they were stamped with;
+- ``current.json`` is followed only when it points to a session of the open
+  project, and project-scoped lookups never leak other projects' sessions;
+- existing files (v1 and v2) remain readable/writable — no data loss upgrade.
+"""
+
+import json
+import os
+
+from kicad_plugin import session_store as sstore
+
+PROJECT_A = "/home/user/projects/alpha/alpha.kicad_pro"
+PROJECT_B = "/home/user/projects/beta/beta.kicad_pro"
+
+
+def _write_v1_session(config_dir: str, filename: str) -> str:
+    """Write a legacy v1 session file exactly as the old plugin did."""
+    sessions = sstore.sessions_dir(config_dir)
+    os.makedirs(sessions, exist_ok=True)
+    data = {
+        "version": 1,
+        "title": "legacy",
+        "timestamp": "2026-08-01T10:00:00",
+        "conv_entries": [{"type": "user", "text": "legacy question"}],
+        "llm_history": [],
+    }
+    path = os.path.join(sessions, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return path
+
+
+def _write_v2_session(config_dir: str, filename: str, project_path: str, title: str = "v2") -> str:
+    """Write a v2 session file stamped with *project_path*."""
+    payload = sstore.make_payload([{"type": "user", "text": title}], [], project_path)
+    sessions = sstore.sessions_dir(config_dir)
+    os.makedirs(sessions, exist_ok=True)
+    path = os.path.join(sessions, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    return path
+
+
+class TestSchemaV2:
+    def test_make_payload_stamps_project(self):
+        payload = sstore.make_payload(
+            [{"type": "user", "text": "hello"}], [{"role": "user"}], PROJECT_A
+        )
+        assert payload["version"] == 2
+        assert payload["project_path"] == PROJECT_A
+        assert payload["title"] == "hello"
+        assert "timestamp" in payload
+        assert payload["conv_entries"] == [{"type": "user", "text": "hello"}]
+        assert payload["llm_history"] == [{"role": "user"}]
+
+    def test_make_payload_defaults(self):
+        payload = sstore.make_payload([{"type": "ai", "text": "hi"}], [], None)
+        assert payload["version"] == 2
+        assert payload["project_path"] is None
+        assert payload["title"] == "session"
+
+    def test_title_uses_first_user_message(self):
+        payload = sstore.make_payload(
+            [
+                {"type": "status", "text": "notice"},
+                {"type": "user", "text": "  " * 30 + "real question"},
+            ],
+            [],
+            PROJECT_A,
+        )
+        assert payload["title"] == ("  " * 30 + "real question")[:60]
+
+
+class TestProjectMatching:
+    def test_v2_session_matches_own_project(self):
+        assert sstore.is_project_session({"project_path": PROJECT_A}, PROJECT_A)
+
+    def test_v2_session_rejects_other_project(self):
+        assert not sstore.is_project_session({"project_path": PROJECT_A}, PROJECT_B)
+
+    def test_v1_legacy_session_never_matches(self):
+        # v1 payloads have no project_path key at all.
+        assert not sstore.is_project_session({"version": 1, "conv_entries": []}, PROJECT_A)
+
+    def test_session_with_none_project_never_matches(self):
+        assert not sstore.is_project_session({"project_path": None}, PROJECT_A)
+
+    def test_no_open_project_never_matches(self):
+        assert not sstore.is_project_session({"project_path": PROJECT_A}, None)
+
+    def test_none_data_never_matches(self):
+        assert not sstore.is_project_session(None, PROJECT_A)
+
+
+class TestCurrentLink:
+    def test_resolve_plain_text_pointer(self, tmp_path):
+        _write_v1_session(str(tmp_path), "session_old.json")
+        link = sstore.current_link_path(str(tmp_path))
+        with open(link, "w", encoding="utf-8") as f:
+            f.write("session_old.json")
+        resolved = sstore.resolve_current_session(str(tmp_path))
+        assert resolved == os.path.join(str(tmp_path), "kicad_ai_sessions", "session_old.json")
+
+    def test_resolve_symlink_form(self, tmp_path):
+        path = _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        sstore.update_current_link(str(tmp_path), "session_a.json")
+        assert sstore.resolve_current_session(str(tmp_path)) == path
+
+    def test_resolve_missing_returns_none(self, tmp_path):
+        assert sstore.resolve_current_session(str(tmp_path)) is None
+
+    def test_resolve_dangling_symlink_returns_none(self, tmp_path):
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        os.symlink("session_ghost.json", os.path.join(sessions, "current.json"))
+        assert sstore.resolve_current_session(str(tmp_path)) is None
+
+    def test_remove_current_link(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        sstore.update_current_link(str(tmp_path), "session_a.json")
+        assert sstore.resolve_current_session(str(tmp_path)) is not None
+        sstore.remove_current_link(str(tmp_path))
+        assert sstore.resolve_current_session(str(tmp_path)) is None
+
+    def test_remove_current_link_missing_is_noop(self, tmp_path):
+        sstore.remove_current_link(str(tmp_path))  # must not raise
+
+
+class TestProjectSessions:
+    def test_lists_only_matching_project(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A, title="a1")
+        _write_v2_session(str(tmp_path), "session_2.json", PROJECT_B, title="b1")
+        _write_v1_session(str(tmp_path), "session_3.json")
+        found = sstore.list_project_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == ["session_1.json"]
+
+    def test_newest_first_ordering(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A)
+        _write_v2_session(str(tmp_path), "session_2.json", PROJECT_A)
+        found = sstore.list_project_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == [
+            "session_2.json",
+            "session_1.json",
+        ]
+
+    def test_legacy_sessions_excluded(self, tmp_path):
+        _write_v1_session(str(tmp_path), "session_1.json")
+        assert sstore.list_project_sessions(str(tmp_path), PROJECT_A) == []
+
+    def test_none_project_returns_empty(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A)
+        assert sstore.list_project_sessions(str(tmp_path), None) == []
+
+    def test_corrupt_file_is_skipped_not_crash(self, tmp_path):
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        with open(os.path.join(sessions, "session_bad.json"), "w") as f:
+            f.write("{not json")
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A)
+        found = sstore.list_project_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == ["session_1.json"]
+
+
+class TestLoadableSessions:
+    def test_own_project_sessions_plus_unowned(self, tmp_path):
+        own = _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A, title="own1")
+        _write_v2_session(str(tmp_path), "session_2.json", PROJECT_B, title="other")
+        legacy = _write_v1_session(str(tmp_path), "session_3.json")
+        found = sstore.list_loadable_sessions(str(tmp_path), PROJECT_A)
+        assert found == [own, legacy]
+
+    def test_unowned_v2_without_project_included(self, tmp_path):
+        unowned = sstore.make_payload([{"type": "user", "text": "no proj"}], [], None)
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        unowned_path = os.path.join(sessions, "session_x.json")
+        with open(unowned_path, "w", encoding="utf-8") as f:
+            json.dump(unowned, f)
+        _write_v2_session(str(tmp_path), "session_own.json", PROJECT_A)
+        found = sstore.list_loadable_sessions(str(tmp_path), PROJECT_A)
+        assert found == [
+            os.path.join(sessions, "session_own.json"),
+            unowned_path,
+        ]
+
+    def test_none_project_returns_only_unowned(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        _write_v1_session(str(tmp_path), "session_legacy.json")
+        found = sstore.list_loadable_sessions(str(tmp_path), None)
+        assert [os.path.basename(f) for f in found] == ["session_legacy.json"]
+
+    def test_empty_dir(self, tmp_path):
+        assert sstore.list_loadable_sessions(str(tmp_path), PROJECT_A) == []
+
+    def test_other_projects_excluded(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        _write_v2_session(str(tmp_path), "session_b.json", PROJECT_B)
+        found = sstore.list_loadable_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == ["session_a.json"]
+
+
+class TestRoundTrip:
+    def test_save_then_load_v2(self, tmp_path):
+        payload = sstore.make_payload(
+            [{"type": "user", "text": "q"}], [{"role": "user"}], PROJECT_A
+        )
+        err = sstore.save_session(str(tmp_path), "session_x.json", payload)
+        assert err is None
+
+        path = os.path.join(sstore.sessions_dir(str(tmp_path)), "session_x.json")
+        assert os.path.isfile(path)
+        if os.name != "nt":
+            assert os.stat(path).st_mode & 0o777 == 0o600
+
+        data, err2 = sstore.load_session(path)
+        assert err2 is None
+        assert data is not None
+        assert data["version"] == 2
+        assert data["project_path"] == PROJECT_A
+        assert data["conv_entries"] == [{"type": "user", "text": "q"}]
+
+    def test_load_missing_file(self, tmp_path):
+        data, err = sstore.load_session(
+            os.path.join(sstore.sessions_dir(str(tmp_path)), "session_none.json")
+        )
+        assert data is None
+        assert err is not None
+
+    def test_load_corrupt_file(self, tmp_path):
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        with open(os.path.join(sessions, "session_bad.json"), "w") as f:
+            f.write("{not json")
+        data, err = sstore.load_session(os.path.join(sessions, "session_bad.json"))
+        assert data is None
+        assert err is not None


### PR DESCRIPTION
Closes #83

## Summary

Sessions are now stored **per project** and the panel follows KiCad project switches instead of lingering or stacking windows.

- `kicad_plugin/session_store.py` (new): schema-v2 session files stamped with the owning `.kicad_pro`; `current.json` points at the session for the currently open project
- `ui/panel.py`:
  - auto-restore moved to first panel display (`IsShown`), decoupled from backend server readiness
  - a 1 s poll (two-tick confirmation) of the GetBoard-derived project path detects project switches; on a confirmed switch the panel re-runs the startup restore flow **in place** for the new project
  - closing the panel (user X or watchdog) fully tears down timers and the MCP server — no hidden windows with background tasks; the suicide watchdog only force-closes when no non-plugin top-level window remains
  - send/stop/reply persist every message as it happens (no autosave timer)
- `llm_client.py`: `set_base_url()` so the client can be created before the backend is ready and pointed at the actual port afterwards (fixes `None/mcp` URL error)
- `context_bridge.py`: window-title project path fallback for `_collect_active_project`

Removed dead/ineffective approaches: `pcbnew.GetCurrentFrame()` (does not exist in this environment), EVT_DESTROY binding, frame-id polling, and the `Run()` leftover-panel sweep (isinstance cannot match a reloaded class).

## Verification

- `pytest tests/unit/plugin/test_context_bridge.py tests/unit/plugin/test_session_store.py tests/unit/plugin/test_llm_client.py -q --no-cov` — 107 passed
- ruff check / ruff format / bandit — clean