### PR TITLE
chore: release develop to main

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,6 +1,8 @@
 name: Build KiCad Plugin ZIP
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/docs/issue_backlog.md
+++ b/docs/issue_backlog.md
@@ -1,0 +1,200 @@
+# Issue Backlog
+
+Known issues discovered during review but not fixed in the originating PR.
+Each entry records the evidence, the impact, and the proposed fix so the work
+can be picked up independently.
+
+## NPTH pad type index bug in world_model
+
+**Status:** fixed for circular NPTH on `fix/duplicate-pad-routing`
+(commit after `77e8301`); oval/slot drill support remains open (see
+sub-entry below)
+
+### Symptom
+
+`kcaa/router/world_model.py` uses the wrong index when checking whether a pad
+node is a non-plated through-hole (NPTH) pad:
+
+- `_pad_obstacle` checks `pad_node[1] == "np_thru_hole"` to decide whether to
+  skip the pad
+- `_npth_obstacle` checks `pad_node[1] != "np_thru_hole"` to decide whether to
+  skip the hole
+
+### Evidence
+
+Pad node structure (confirmed from real KiCad files, e.g.
+`/home/user1/pcb/ninja-keyboard/ninja-keyboard.kicad_pcb`, 309 NPTH pads):
+
+```
+['pad', '', 'np_thru_hole', 'circle', [at ...], [size ...], [drill ...], [layers '*.Cu' '*.Mask']]
+    [0]   [1]      [2]          [3]
+   token  name    type        shape
+```
+
+- Pad **name** is at `[1]` (empty string for NPTH), pad **type** is at `[2]`.
+- All 309 ninja-keyboard NPTH pads have the same layout; `sub[2] ==
+  'np_thru_hole'` matched all 309, `sub[1]` matched none.
+- Behavioral check: `_npth_obstacle` created 0/309 obstacles on
+  ninja-keyboard; world model reported 0 `drill`-kind obstacles for a board
+  with 309 NPTH holes.
+
+### Impact
+
+- `_npth_obstacle` always returns `None`: NPTH drill holes are never
+  registered as obstacles.
+- `_pad_obstacle` never skips NPTH pads: they are treated as ordinary plated
+  pads. In practice the KiCad-written `layers "*.Cu" "*.Mask"` makes them
+  rectangular pad-kind obstacles across all copper layers, so holes are
+  still roughly blocked — but as axis-aligned rectangles from `size`, not as
+  circular drill obstacles.
+- Legacy/hand-written files without a `layers` node (e.g. the fixture in
+  `tests/unit/tools/fixtures/test_group_placement.kicad_pcb`) produce **no**
+  obstacle at all for NPTH holes — tracks could cross them.
+- Side effect: `pad-kind` count inflates (~309 on ninja-keyboard) and
+  clearance semantics use the rectangular pad envelope rather than the
+  drilled circle.
+
+### Fix
+
+In `_pad_obstacle` and `_npth_obstacle`, read the type from `pad_node[2]`
+with `str()` conversion (the values are `sexpdata.Symbol`, which does not
+compare equal to `str`):
+
+```python
+pad_type = str(pad_node[2]) if len(pad_node) > 2 else ""
+```
+
+Also note the equivalent check at `router.py` (~line 1634,
+`sub[2] == "np_thru_hole"`) already uses the correct index.
+
+### Validation
+
+- Unit: fixture with NPTH pads (`test_group_placement.kicad_pcb`) should
+  yield `drill`-kind obstacles for its two NPTH holes.
+- Real board: ninja-keyboard world model should report ~309 `drill`-kind
+  obstacles instead of 0.
+---
+
+## Edge.Cuts internal openings are not routing obstacles
+
+**Status:** fixed on `fix/duplicate-pad-routing` (commit after `de8ff31`);
+implemented as `_edge_cuts_openings` + `opening`-kind world-model obstacles
+(see below for the original analysis)
+
+### Symptom
+
+`kcaa/router/world_model.py` only uses Edge.Cuts for two things:
+
+- `_board_bbox` — the AABB of all Edge.Cuts items (outer envelope),
+- `router._check_segments_in_board` — verifies segments stay inside that
+  AABB rectangle.
+
+Neither models **internal openings**: closed Edge.Cuts loops fully inside
+the board (cutouts, routing slots, mounting windows). The router treats
+the board as a solid rectangle and can place tracks across a physical
+void — a real fabrication defect.
+
+### Evidence
+
+Real board `/home/user1/pcb/ninja-keyboard/ninja-keyboard.kicad_pcb`:
+
+- 76 Edge.Cuts items total; **61 internal `fp_rect` openings** (3.4 x 3.0 mm,
+  fully inside the board AABB, e.g. SL61 at x[430.6, 434.0] y[251.0, 254.0])
+  plus 7 `gr_circle` items.
+- `world_model` builds **0** obstacles from any of them; only the outer
+  AABB `(158.475, 139.475, 444.225, 256.725)` is used for the board fence.
+- A* would happily route across any of those 61 holes.
+
+### Impact
+
+Tracks routed across a cutout are floating copper — electrically valid,
+fabrication-invalid (the copper has no substrate, and the DRC clearance
+rules around the cutout edge are not honored). KiCad will flag it in DRC,
+but the router should avoid producing it.
+
+### Fix (proposed)
+
+In `world_model.py`:
+
+1. Collect all Edge.Cuts graphics (board-level `gr_*` and footprint-level
+   `fp_*`, transformed into world coordinates like `_board_bbox` does) as
+   shapely linework.
+2. `unary_union` the linework, `polygonize` it, take the outer face (the
+   one with maximum area), and read its `interiors` — each interior ring
+   is a closed opening loop.
+3. Add one obstacle per opening: polygon = the ring, layers = ALL copper
+   layers (a cutout severs every layer), kind = `"opening"`, net = None.
+
+The router's existing `_inflate_obstacles` (width/2 + clearance) then
+applies automatically — tracks keep full clearance from the opening edge.
+
+Open loops (notches open to the board edge, like the micro:bit card bay)
+are NOT openings — they stay part of the outline AABB, and the
+`_check_segments_in_board` fence still applies.
+
+### Validation
+
+- Unit: fixture board with an internal rectangle + circle opening →
+  `world_model` yields `opening`-kind obstacles at the right position;
+  route that would cross the opening detours around it.
+- Real board: ninja-keyboard world model reports 61+ `opening` obstacles
+  (one per internal fp_rect); regression-check matrix-bit-card J2/3 ->
+  U11/3v3 route is still produced (bay is an open notch, not an opening).
+
+## NPTH oval/slot drill shapes are not supported
+
+**Status:** open (discovered while fixing the NPTH index bug)
+
+### Symptom
+
+`_npth_obstacle` only reads a single drill value:
+
+```python
+drill = float(drill_sub[1])
+```
+
+A KiCad oval drill node is `(drill oval <width> <length>)` — `drill_sub[1]`
+is the `Symbol('oval')` tag, so `float()` raises `TypeError` and the
+function returns `None`. Oval/slot NPTH holes are silently dropped from the
+world model.
+
+### Evidence
+
+Real KiCad file `/home/user1/pcb/ninja-keyboard/.history/ninja-keyboard.kicad_pcb`:
+
+```
+(pad "MP" thru_hole rect (at 7.5 -3.1 180) (size 3 2.5)
+    (drill oval 2.5 2) (layers "*.Cu" "*.Mask") ...)
+```
+
+Multiple `(drill oval w l)` nodes exist in the file history. The router
+would generate no obstacle for any of them. (The current
+`ninja-keyboard.kicad_pcb` uses 309 circular NPTH drills only.)
+
+### Unresolved question
+
+KiCad's oval-drill semantics for `(drill oval w l)` is not confirmed from
+primary source at write time:
+- Is `l` the total slot length (outer ends) or the center-to-center
+  distance of the two end circles?
+- Does the slot's major axis follow the pad's own `at` rotation, the
+  footprint rotation, or neither (fixed along one axis)?
+
+The pad examples show mixed data (`(size 3 2.5)` with `(drill oval 2.5 2)`;
+`(size 1 1.6)` with `(drill oval 0.6 1.2)`) — size and drill axes do not
+obviously align, so the axis rule needs verification before implementing.
+
+### Fix (proposed)
+
+Shape the obstacle as a stadium/capsule: `LineString` between the two end
+circle centers, buffered by `width / 2` (shapely:
+`LineString([(-d, 0), (d, 0)]).buffer(w / 2, cap_style="round")`), where
+`d` depends on the resolved `l` semantics. Rotate by the pad's own `at`
+rotation plus the footprint rotation (verify which KiCad actually applies).
+
+### Validation
+
+- Unit: NPTH oval pad node -> obstacle shape whose bounding box matches
+  the resolved slot extent.
+- Real board: ninja-keyboard history file with `(drill oval ...)` pads
+  yields `drill`-kind obstacles.

--- a/docs/pcb-routing.md
+++ b/docs/pcb-routing.md
@@ -26,12 +26,22 @@ to the board on the same layer as the source pad.  Obstacles include:
 * Existing tracks of *other* nets.
 * Keepout zones on the active layer.
 
+Only copper on the requested routing layer blocks a single-layer route;
+copper on other layers is a parallel plane and is ignored.  The board
+bounds check exempts the two endpoint pads' rectangles: a pad whose
+copper straddles the board edge (edge-mounted connectors) is a legal
+terminus, even though the track must otherwise stay inside the
+Edge.Cuts outline.  The outline includes Edge.Cuts profiles drawn
+*inside* footprints — an edge-mounted connector (e.g. a card bay)
+describes the notch it sits in with its own Edge.Cuts items, and that
+region is real board area, so tracks may run into it.
+
 ## Multi-layer routing (via insertion)
 
-If the source pad is on a different layer from the destination pad,
-the router will insert through-hole vias at every layer transition.
-You must supply the destination layer and the set of via pairs the
-router is allowed to use:
+If the source and destination pads are on different copper layers (e.g.
+an SMD pad on F.Cu and an SMD pad on In1.Cu), the router inserts vias to
+reach the destination.  Specify the via layer pairs the router is
+allowed to use:
 
 ```python
 await pcb_route_pad_to_pad(
@@ -39,14 +49,14 @@ await pcb_route_pad_to_pad(
     ref_a="R1", pad_a="2",
     ref_b="U1", pad_b="5",
     net="VCC",
-    layer="F.Cu",                # start layer
-    target_layer="In1.Cu",        # end layer
     via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
 )
 ```
 
-If `target_layer` is supplied and differs from `layer` and
-`via_pairs` is omitted, the router defaults to a single F<->B pair.
+Layer selection is automatic: SMD/connect pads use their fixed layer;
+thru-hole pads (`*.Cu`) pick a shared copper layer, preferring
+`layer_hint` when it is valid.  When both pads are thru-hole and share
+a layer, the route stays on a single layer (no vias).
 
 ### Response shape
 
@@ -131,10 +141,40 @@ for the human-readable summary.
 
 | Failure | Meaning |
 | --- | --- |
-| `RouteFailure: Pad <ref>/<pad> not found` | Pad name is wrong or pad is on a different layer than requested. |
-| `RouteFailure: Pad <ref>/<pad> has no copper shape on layer '<layer>'` | The destination pad does not have a copper shape on the requested `end_layer`. |
+| `RouteFailure: Pad <ref>/<pad> not found` | No pad with that name exists on the footprint.  A pad that exists but has no copper on the requested layer fails with the layer-naming error below instead. |
+| `RouteFailure: Pad <ref>/<pad> has no copper shape on layer '<layer>'` | The pad exists, but no same-named pad has a copper shape on the requested layer. |
 | `RouteFailure: No obstacle-avoiding path from <a> to <b> across layers [...]` | No combination of exit points / via transitions yields a clear path.  Check obstacles and via pairs. |
 | `RouteFailure: Via at (x, y) would extend outside the board` | At least one via pad does not fit inside the Edge.Cuts board outline.  Move the route or shrink the board. |
 
 The tool returns `{"error": "..."}` on any of the above; the board
 file is **not** modified on failure.
+
+A footprint may declare several pads with the same name — edge-connector
+fingers sharing a net, e.g. a micro:bit edge connector exposing several
+`3v3` pads (SMD fingers plus one thru-hole pad).  The router resolves
+the pad by the requested layer: routing to `U11/3v3` on `B.Cu` targets
+the same-named pad whose copper is actually on `B.Cu` (typically the
+thru-hole pad), not merely the first occurrence in the footprint.  A
+thru-hole pad's center is a valid track terminus — the plated barrel
+carries the connection.
+
+### Same-net pad copper and drill holes
+
+The world model drops same-net pad copper entirely (the route must be
+able to land on its own endpoint pads).  The router re-adds every
+same-net pad as a transit obstacle on the copper layers it covers so
+the track never overlaps other same-net pad copper — it terminates on
+the endpoint pad only and connects to other same-net pads by separate
+tracks later.  Buffer is ``width/2 + clearance``: the track edge must
+keep a full clearance gap from the pad copper, same as for any other
+obstacle.  If this makes the route impossible at the requested width,
+that is the correct answer — try a narrower track.  The two endpoint
+pads are exempt on their own terminal layers so the track can
+start/end at their centres; a same-net thru-hole pad's drill hole is
+covered by its pad-copper obstacle (non-endpoint pads), so a track
+never crosses a hole the drill physically severs.
+
+Vias must never land on any same-net pad face (a DFM defect: solder
+wicking, annular-ring breakout).  Via-forbidden zones cover **every**
+same-net pad, not just the two endpoint pads — a multi-layer route's
+vias are kept off all same-net fingers and annuli.

--- a/kcaa/router/grid_a_star.py
+++ b/kcaa/router/grid_a_star.py
@@ -56,6 +56,14 @@ _DIRECTIONS = [
 _CARD_COST = 1.0
 _DIAG_COST = math.sqrt(2.0)
 
+# Turn penalty (mm-equivalent) added when the path changes direction.
+# 0.3 mm ≈ 3 cells at 0.1 mm resolution — discourages zigzag without
+# blocking legitimate detours.  Set to 0 to disable (pure shortest path).
+_TURN_PENALTY = 0.3
+
+# Number of movement directions (8-directional grid).
+_N_DIRS = 8
+
 # Default via cost (mm added to the path for each via transition).
 _VIA_COST = 2.0
 
@@ -231,7 +239,9 @@ def _octile_dist(gx: int, gy: int, ex: int, ey: int) -> float:
     """Octile distance heuristic (admissible for 8-direction movement)."""
     dx = abs(gx - ex)
     dy = abs(gy - ey)
-    return _CARD_COST * abs(dx - dy) + (_DIAG_COST - _CARD_COST) * min(dx, dy)
+    if dx > dy:
+        return _DIAG_COST * dy + (dx - dy)
+    return _DIAG_COST * dx + (dy - dx)
 
 
 def grid_a_star(
@@ -243,6 +253,7 @@ def grid_a_star(
     via_from: dict[int, set[int]] | None = None,
     via_cost: float = _VIA_COST,
     via_forbidden_zones: list | None = None,
+    turn_penalty: float = _TURN_PENALTY,
 ) -> AStarResult:
     """Run A* on one or more walkability grids.
 
@@ -265,6 +276,8 @@ def grid_a_star(
         via_cost: Distance-equivalent cost per via transition (mm).
         via_forbidden_zones: Optional list of ``shapely`` Polygon objects
             where vias are forbidden (e.g. start/end pad AABBs).
+        turn_penalty: Distance-equivalent cost added when the path
+            changes direction.  0 disables (pure shortest path).
 
     Returns:
         :class:`AStarResult` with ``path`` as ``list[(x, y, layer_idx)]``,
@@ -288,13 +301,21 @@ def grid_a_star(
     if not grids[end_layer_idx].is_free(ex, ey):
         return AStarResult(path=None)
 
-    def _encode(gx: int, gy: int, li: int) -> int:
-        return (gy * W + gx) * n_layers + li
+    # State encoding: (cell, layer, arrival_direction).
+    # arrival_direction is 0-7 (index into _DIRECTIONS) or _N_DIRS for
+    # the start node (no previous move).  This lets A* distinguish
+    # reaching a cell from different directions and apply a turn penalty
+    # when the direction changes.
+    _NO_DIR = _N_DIRS  # sentinel for "no previous direction"
 
-    start_id = _encode(sx, sy, start_layer_idx)
-    end_id = _encode(ex, ey, end_layer_idx)
+    def _encode(gx: int, gy: int, li: int, di: int) -> int:
+        return ((gy * W + gx) * n_layers + li) * (_N_DIRS + 1) + di
 
-    g_score = {start_id: 0.0}
+    # The goal is any state at (ex, ey, end_layer) regardless of direction.
+    # We check for the cell-level match inside the loop.
+    start_id = _encode(sx, sy, start_layer_idx, _NO_DIR)
+
+    g_score: dict[int, float] = {start_id: 0.0}
     parent: dict[int, int | None] = {start_id: None}
     open_heap = [(_octile_dist(sx, sy, ex, ey), start_id)]
     closed: set[int] = set()
@@ -307,45 +328,55 @@ def grid_a_star(
         closed.add(cur_id)
         visited += 1
 
-        if cur_id == end_id:
-            path: list[tuple[float, float, int]] = []
-            nid = cur_id
-            while nid is not None:
-                li = nid % n_layers
-                rest = nid // n_layers
-                gy_p = rest // W
-                gx_p = rest % W
-                wx, wy = ref.to_world(gx_p, gy_p)
-                path.append((wx, wy, li))
-                nid = parent[nid]
-            path.reverse()
-
-            # Compute length from world-coordinate distance (ignore
-            # layer — via cost is already baked into g_score).
-            total_len = 0.0
-            for i in range(1, len(path)):
-                px, py, _ = path[i - 1]
-                cx, cy, _ = path[i]
-                total_len += math.hypot(cx - px, cy - py)
-            return AStarResult(path=path, cells_visited=visited, path_length_mm=total_len)
-
-        li = cur_id % n_layers
-        rest = cur_id // n_layers
-        cy = rest // W
-        cx = rest % W
+        # Decode state.
+        di = cur_id % (_N_DIRS + 1)
+        rest = cur_id // (_N_DIRS + 1)
+        li = rest % n_layers
+        rest2 = rest // n_layers
+        cy = rest2 // W
+        cx = rest2 % W
         cur_g = g_score[cur_id]
         cur_grid = grids[li]
 
+        # Goal check: any direction at the target cell on the target layer.
+        if cx == ex and cy == ey and li == end_layer_idx:
+            path: list[tuple[float, float, int]] = []
+            nid: int | None = cur_id
+            while nid is not None:
+                rest_n = nid // (_N_DIRS + 1)
+                li_n = rest_n % n_layers
+                rest2_n = rest_n // n_layers
+                gy_p = rest2_n // W
+                gx_p = rest2_n % W
+                wx, wy = ref.to_world(gx_p, gy_p)
+                path.append((wx, wy, li_n))
+                nid = parent[nid]
+            path.reverse()
+
+            total_len = 0.0
+            for i in range(1, len(path)):
+                px, py, _ = path[i - 1]
+                cx_p, cy_p, _ = path[i]
+                total_len += math.hypot(cx_p - px, cy_p - py)
+            return AStarResult(path=path, cells_visited=visited, path_length_mm=total_len)
+
         # ---- Same-layer 8-dir moves ----
-        for dx, dy, is_diag in _DIRECTIONS:
+        for dir_idx, (dx, dy, is_diag) in enumerate(_DIRECTIONS):
             nx, ny = cx + dx, cy + dy
             if not cur_grid.is_free(nx, ny):
                 continue
-            nid = _encode(nx, ny, li)
+            nid = _encode(nx, ny, li, dir_idx)
             if nid in closed:
                 continue
             step = _DIAG_COST if is_diag else _CARD_COST
-            tentative = cur_g + step
+            # Turn penalty: if this move's direction differs from the
+            # arrival direction (and we have a previous direction), add
+            # the penalty.  45° changes (cardinal→diagonal) cost the
+            # same as 90° changes — both are one turn.
+            tp = 0.0
+            if turn_penalty > 0 and di != _NO_DIR and di != dir_idx:
+                tp = turn_penalty
+            tentative = cur_g + step + tp
             if tentative < g_score.get(nid, float("inf")):
                 g_score[nid] = tentative
                 heapq.heappush(
@@ -364,7 +395,8 @@ def grid_a_star(
                     wx, wy = ref.to_world(cx, cy)
                     if any(z.contains(Point(wx, wy)) for z in via_forbidden_zones):
                         continue
-                nid = _encode(cx, cy, tgt_li)
+                # Via resets direction (layer change is not a "turn").
+                nid = _encode(cx, cy, tgt_li, _NO_DIR)
                 if nid in closed:
                     continue
                 tentative = cur_g + via_cost
@@ -422,6 +454,7 @@ def hierarchical_a_star(
     end_world: tuple[float, float],
     fine_resolution: float = GRID_RESOLUTION,
     route_bbox: tuple[float, float, float, float] | None = None,
+    turn_penalty: float = _TURN_PENALTY,
 ) -> AStarResult:
     """Run hierarchical A* with auto-detection of single-pass vs two-pass.
 
@@ -457,11 +490,11 @@ def hierarchical_a_star(
 
     if fine_cells < _SINGLE_PASS_THRESHOLD:
         grid = build_grid_map(obstacles, bbox, resolution=fine_resolution)
-        return grid_a_star([grid], start_world, end_world)
+        return grid_a_star([grid], start_world, end_world, turn_penalty=turn_penalty)
 
     coarse_res = fine_resolution * COARSE_FACTOR
     coarse_grid = build_grid_map(obstacles, bbox, resolution=coarse_res)
-    coarse_result = grid_a_star([coarse_grid], start_world, end_world)
+    coarse_result = grid_a_star([coarse_grid], start_world, end_world, turn_penalty=turn_penalty)
     if coarse_result.path is None:
         return AStarResult(path=None, cells_visited=coarse_result.cells_visited)
 
@@ -477,7 +510,7 @@ def hierarchical_a_star(
     )
 
     fine_grid = build_grid_map(obstacles, band, resolution=fine_resolution)
-    result = grid_a_star([fine_grid], start_world, end_world)
+    result = grid_a_star([fine_grid], start_world, end_world, turn_penalty=turn_penalty)
     if result.path is not None:
         result.cells_visited += coarse_result.cells_visited
     else:
@@ -535,6 +568,7 @@ def multi_layer_a_star(
     fine_resolution: float = GRID_RESOLUTION,
     via_cost: float = _VIA_COST,
     via_forbidden_zones: list | None = None,
+    turn_penalty: float = _TURN_PENALTY,
 ) -> MultiLayerAStarResult:
     """Run A* across multiple copper layers.
 
@@ -583,6 +617,7 @@ def multi_layer_a_star(
         via_from=via_from or None,
         via_cost=via_cost,
         via_forbidden_zones=via_forbidden_zones,
+        turn_penalty=turn_penalty,
     )
     if result.path is None:
         return MultiLayerAStarResult(path=None, cells_visited=result.cells_visited)
@@ -683,6 +718,13 @@ def _grid_line_clear(
     return True
 
 
+def _is_45_family(x0: float, y0: float, x1: float, y1: float) -> bool:
+    """True when the segment (x0,y0)-(x1,y1) is axis-aligned or a 45° diagonal."""
+    dx = abs(x1 - x0)
+    dy = abs(y1 - y0)
+    return abs(dx) < 1e-6 or abs(dy) < 1e-6 or abs(dx - dy) < 1e-6
+
+
 def shortcut_path(
     pts: list[tuple[float, float]],
     obstacles: list,
@@ -693,16 +735,11 @@ def shortcut_path(
 
     Builds a walkability grid once, then for each point tries to skip
     as many subsequent points as possible while keeping the line clear.
-    Only 0°/45°/90°/135° shortcuts are accepted.
-
-    Args:
-        pts: Ordered ``(x, y)`` points (after collinear simplification).
-        obstacles: Inflated obstacle list (Polygon objects).
-        bbox: ``(min_x, min_y, max_x, max_y)`` of the route area.
-        resolution: Grid cell size in mm.
-
-    Returns:
-        Simplified polyline with redundant points removed.
+    Only 0°/45°/90°/135° shortcuts are accepted.  A shortcut that would
+    skip a direction change all the way through (producing a near-45°
+    long diagonal) is REJECTED: snapping that back to the 45° family
+    later would have to force a Manhattan corner (often a 90° turn), so
+    it is better to keep the original 45°+axis-aligned waypoints.
     """
     if len(pts) <= 2:
         return list(pts)
@@ -713,10 +750,13 @@ def shortcut_path(
     while i < len(pts) - 1:
         best_next = i + 1
         for k in range(len(pts) - 1, i, -1):
-            dx = pts[k][0] - result[-1][0]
-            dy = pts[k][1] - result[-1][1]
-            if abs(dx) > 1e-9 and abs(dy) > 1e-9 and abs(abs(dx) - abs(dy)) > 1e-9:
-                continue  # not 0/45/90/135°
+            if not _is_45_family(
+                result[-1][0],
+                result[-1][1],
+                pts[k][0],
+                pts[k][1],
+            ):
+                continue
             if _grid_line_clear(
                 grid,
                 result[-1][0],

--- a/kcaa/router/router.py
+++ b/kcaa/router/router.py
@@ -12,7 +12,7 @@ Pipeline
 3. **Find pad centers**: locate the two pads to connect and read their copper
    pad shape's center.
 4. **Pick exit points**: choose one or two candidate exit points on the pad
-   edge for each end (axis-aligned first, 45° if needed).
+   edge for each end (axis-aligned first, 45 deg  if needed).
 5. **Grid search + A\\***: build a walkability grid from inflated obstacles
    and run 8-direction A*.  Multi-layer routes insert via edges at legal
    (x, y) positions between layers in ``via_pairs``.
@@ -24,7 +24,7 @@ Multi-layer routing
 
 When ``start_layer != end_layer`` the router builds one GridMap per
 routing layer and runs a multi-layer A* that can insert via edges.
-Via edges cost 2.0 mm (configurable) — this penalises vias so A* prefers
+Via edges cost 2.0 mm (configurable) -- this penalises vias so A* prefers
 routing on a single layer when possible.
 
 No shove
@@ -44,6 +44,7 @@ import logging
 import math
 import os
 
+from shapely.geometry import Polygon
 from shapely.geometry import box as _shapely_box
 
 from kcaa.router.grid_a_star import (
@@ -61,7 +62,7 @@ from kcaa.router.path_postprocess import (
     postprocess_path,
 )
 from kcaa.router.visibility_graph import RouteNode
-from kcaa.router.world_model import Obstacle, build_world_model
+from kcaa.router.world_model import Obstacle, _get_net, build_world_model
 from kcaa.utils.pcb_sexp_utils import load_pcb
 
 logger = logging.getLogger(__name__)
@@ -112,30 +113,39 @@ class RouteRequest:
     The pads may live on different copper layers; in that case the router
     will insert one or more vias to switch layers.
 
+    Layer selection is automatic: the router inspects each pad's type and
+    copper layers.  For SMD/connect pads the layer is fixed by the pad
+    itself.  For thru-hole pads (``*.Cu``) the router picks the best
+    shared copper layer, preferring ``layer_hint`` when it is valid.
+
     Attributes:
         pcb_path: Absolute path to the ``.kicad_pcb`` file.
         ref_a / pad_a: Reference designator and pad number for one end.
         ref_b / pad_b: Reference designator and pad number for the other end.
         net: Net name shared by both pads.
-        start_layer: Copper layer the pad-A copper shape is on.
-        end_layer: Copper layer the pad-B copper shape is on.
+        layer_hint: Preferred copper layer for thru-hole pads.  When
+            ``None`` (default) the router picks the best layer
+            automatically.  Ignored for SMD pads whose layer is fixed.
         via_pairs: Allowed (top, bottom) layer pairs that may carry a
             through-via. Default is ``(("F.Cu", "B.Cu"),)``. Pass an
             explicit tuple to restrict transitions (e.g. to forbid inner-
             layer vias on a 4-layer board).
-        width: Track width; ``None`` → resolve from netclass.
-        clearance: Minimum clearance to obstacles; ``None`` → resolve from
+        width: Track width; ``None`` -> resolve from netclass.
+        clearance: Minimum clearance to obstacles; ``None`` -> resolve from
             the board's design rules.
-        via_diameter / via_drill: Through-via dimensions; ``None`` →
+        via_diameter / via_drill: Through-via dimensions; ``None`` ->
             resolve from netclass.
         max_miter_mm: Maximum corner miter extension before falling back
-            to a sharp 90° corner.
+            to a sharp 90 deg  corner.
         grid_resolution: Grid cell size in mm for the walkability grid.
             Smaller values give finer paths but more cells.  ``None``
             uses the default (0.025 mm).
         via_cost: Distance-equivalent penalty for taking a via edge in
             multi-layer A*.  Higher values discourage unnecessary stack
             vias.  Default 2.0 mm.
+        turn_penalty: Distance-equivalent cost added when the path
+            changes direction.  0 disables (pure shortest path).
+            Default 0.3 mm ~ 3 cells at 0.1 mm resolution.
     """
 
     pcb_path: str
@@ -144,16 +154,16 @@ class RouteRequest:
     ref_b: str
     pad_b: str
     net: str
-    start_layer: str = "F.Cu"
-    end_layer: str = "F.Cu"
+    layer_hint: str | None = None
     via_pairs: tuple[tuple[str, str], ...] = (("F.Cu", "B.Cu"),)
     width: float | None = None  # if None, use DRC default for the net
     clearance: float | None = None
     via_diameter: float | None = None
     via_drill: float | None = None
     max_miter_mm: float = 1.0
-    grid_resolution: float | None = None  # None → GRID_RESOLUTION
+    grid_resolution: float | None = None  # None -> GRID_RESOLUTION
     via_cost: float = 2.0  # mm penalty per via edge
+    turn_penalty: float = 0.3  # mm penalty per direction change; 0 disables
 
 
 @dataclass
@@ -186,8 +196,11 @@ class RouteResult:
 
 def auto_route_pair(req: RouteRequest) -> RouteResult:
     """Connect pad ``req.pad_a`` on ``req.ref_a`` to pad ``req.pad_b`` on
-    ``req.ref_b`` on the same net ``req.net`` and same layer ``req.start_layer``
-    (and ``req.end_layer`` for the destination pad).
+    ``req.ref_b`` on the same net ``req.net``.
+
+    Layers are auto-resolved from pad types: SMD pads use their fixed
+    layer; thru-hole pads use a shared copper layer (preferring
+    ``req.layer_hint``).
 
     Returns:
         A :class:`RouteResult` containing the segments and (optionally) vias.
@@ -197,18 +210,8 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     """
     data = load_pcb(req.pcb_path)
 
-    # Validate requested layers against the PCB early. The visibility graph
-    # query below assumes both layers exist; checking later would produce
-    # a less informative error path.
+    # Validate via_pairs against the PCB layers early.
     pcb_layers = _pcb_layer_names(data)
-    for layer in (req.start_layer, req.end_layer):
-        if layer not in pcb_layers:
-            raise RouteFailure(
-                f"Layer {layer!r} is not present in PCB {req.pcb_path}; "
-                f"PCB layers are {pcb_layers}."
-            )
-    # via_pairs must reference layers that exist too — otherwise A* would
-    # never use those edges and the user might not notice.
     for top, bot in req.via_pairs:
         if top not in pcb_layers:
             raise RouteFailure(
@@ -219,6 +222,15 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             raise RouteFailure(
                 f"via_pairs contains bottom layer {bot!r} which is not in PCB "
                 f"{req.pcb_path}; PCB layers are {pcb_layers}."
+            )
+
+    # Auto-resolve start/end layers from pad types + layer_hint.
+    start_layer, end_layer = _resolve_layers(data, req)
+    for layer in (start_layer, end_layer):
+        if layer not in pcb_layers:
+            raise RouteFailure(
+                f"Layer {layer!r} is not present in PCB {req.pcb_path}; "
+                f"PCB layers are {pcb_layers}."
             )
 
     # DRC defaults from the .kicad_pro / board file. Fail loudly if the
@@ -248,29 +260,55 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     if via_drill is None:
         via_drill = _resolve_via_drill(req.pcb_path, net=req.net)
 
-    # Pad center coordinates.
-    pad_a_xy = _find_pad_center(data, req.ref_a, req.pad_a)
-    pad_b_xy = _find_pad_center(data, req.ref_b, req.pad_b)
+    # Pad center coordinates. The layer keeps center and size on the SAME
+    # pad when a footprint declares several pads with one name.
+    pad_a_xy = _find_pad_center(data, req.ref_a, req.pad_a, start_layer)
+    pad_b_xy = _find_pad_center(data, req.ref_b, req.pad_b, end_layer)
     if pad_a_xy is None:
-        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
-    if pad_b_xy is None:
-        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
-
-    # Validate pads exist on the requested copper layers before doing
-    # anything else (gives a clear error, not a confusing A* failure).
-    if _find_pad_size(data, req.ref_a, req.pad_a, req.start_layer) is None:
+        if _find_pad_center(data, req.ref_a, req.pad_a) is None:
+            raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
         raise RouteFailure(
             f"Pad {req.ref_a}/{req.pad_a} has no copper shape on layer "
-            f"{req.start_layer!r}; cannot route from there."
+            f"{start_layer!r}; cannot route from there."
         )
-    if _find_pad_size(data, req.ref_b, req.pad_b, req.end_layer) is None:
+    if pad_b_xy is None:
+        if _find_pad_center(data, req.ref_b, req.pad_b) is None:
+            raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
         raise RouteFailure(
             f"Pad {req.ref_b}/{req.pad_b} has no copper shape on layer "
-            f"{req.end_layer!r}; cannot route to there."
+            f"{end_layer!r}; cannot route to there."
         )
 
+    # Validate pads exist on the resolved copper layers before doing
+    # anything else (gives a clear error, not a confusing A* failure).
+    if _find_pad_size(data, req.ref_a, req.pad_a, start_layer) is None:
+        raise RouteFailure(
+            f"Pad {req.ref_a}/{req.pad_a} has no copper shape on layer "
+            f"{start_layer!r}; cannot route from there."
+        )
+    if _find_pad_size(data, req.ref_b, req.pad_b, end_layer) is None:
+        raise RouteFailure(
+            f"Pad {req.ref_b}/{req.pad_b} has no copper shape on layer "
+            f"{end_layer!r}; cannot route to there."
+        )
+
+    # Early net check: pads on different nets must not be routed together.
+    # A foreign-net pad is an obstacle -- past the net check the world model
+    # would dutifully treat it as one and fail deep inside A*, so fail fast
+    # with the actual cause.
+    for ref, pad, layer in (
+        (req.ref_a, req.pad_a, start_layer),
+        (req.ref_b, req.pad_b, end_layer),
+    ):
+        pad_net = _find_pad_net(data, ref, pad, layer)
+        if pad_net is not None and pad_net != req.net:
+            raise RouteFailure(
+                f"Pad {ref}/{pad} is on net {pad_net!r}, not the requested "
+                f"net {req.net!r}; cannot route between different nets."
+            )
+
     # World model: only existing copper (tracks, vias, keepouts) blocks the
-    # route.  Footprint courtyards are NOT obstacles — they're a DRC spacing
+    # route.  Footprint courtyards are NOT obstacles -- they're a DRC spacing
     # concept, not a hard copper boundary, and treating them as forbidden
     # forces pointless detours around parts.  Start/end footprints would be
     # excluded anyway, but we skip the whole footprint layer.
@@ -284,13 +322,13 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     buffered = _inflate_obstacles(model.obstacles, width / 2.0 + clearance)
 
     # Group inflated obstacles by layer for multi-layer routing.
-    routing_layers = _routing_layers(req)
+    routing_layers = _routing_layers(req, start_layer, end_layer)
     obstacles_by_layer: dict[str, list] = {}
     for rl in routing_layers:
         obstacles_by_layer[rl] = [o for o in buffered if rl in o.layers]
 
     # Detect rectangular pads to replace A* path inside them.
-    # A pad is "rectangular" when its width and height differ by ≥ 20%.
+    # A pad is "rectangular" when its width and height differ by >= 20%.
     def _is_rect(size: tuple[float, float] | None) -> bool:
         if size is None:
             return False
@@ -298,13 +336,13 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         return w > 0 and h > 0 and abs(w - h) / max(w, h) >= 0.2
 
     def _world_size(local_w: float, local_h: float, fp_rot: float) -> tuple[float, float]:
-        """Return (world_w, world_h) accounting for ±90° footprint rotation."""
+        """Return (world_w, world_h) accounting for +/-90 degree footprint rotation."""
         if abs(fp_rot % 180.0 - 90.0) < 0.1:
             return local_h, local_w
         return local_w, local_h
 
-    pad_a_size = _find_pad_size(data, req.ref_a, req.pad_a, req.start_layer)
-    pad_b_size = _find_pad_size(data, req.ref_b, req.pad_b, req.end_layer)
+    pad_a_size = _find_pad_size(data, req.ref_a, req.pad_a, start_layer)
+    pad_b_size = _find_pad_size(data, req.ref_b, req.pad_b, end_layer)
     pad_a_world_size = (
         _world_size(pad_a_size[0], pad_a_size[1], _fp_rotation(data, req.ref_a))
         if pad_a_size
@@ -321,28 +359,97 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     # For multi-layer routing, clear the start/end pad areas from the
     # obstacle grid so A* can start from / end at the pad centres.
     # Existing copper (e.g. a track from another net) may occupy the pad.
-    if req.start_layer != req.end_layer:
+    if start_layer != end_layer:
         if pad_a_world_size is not None:
-            obstacles_by_layer[req.start_layer] = _subtract_pad_aabb(
-                obstacles_by_layer[req.start_layer],
+            obstacles_by_layer[start_layer] = _subtract_pad_aabb(
+                obstacles_by_layer[start_layer],
                 pad_a_xy,
                 pad_a_world_size,
             )
         if pad_b_world_size is not None:
-            obstacles_by_layer[req.end_layer] = _subtract_pad_aabb(
-                obstacles_by_layer[req.end_layer],
+            obstacles_by_layer[end_layer] = _subtract_pad_aabb(
+                obstacles_by_layer[end_layer],
                 pad_b_xy,
                 pad_b_world_size,
             )
 
-    # Route from pad center to pad center.  A* on the grid naturally
-    # produces 0/45/90° segments.
+    # The world model drops same-net pad copper entirely (the route must
+    # land on its own endpoint pads).  Re-add every same-net pad as a
+    # transit obstacle on the copper layers it covers so the track never
+    # overlaps other same-net pad copper -- it terminates on the endpoint
+    # pad only and connects to other same-net pads by separate tracks
+    # later.  Buffer by ``width / 2 + clearance``: the track edge must
+    # keep a clearance gap from the pad copper, same as for any other
+    # obstacle.  If this makes the route impossible at the requested
+    # width, that is the correct answer -- the user should try a
+    # narrower track.  The two endpoint pads are exempt on their own
+    # terminal layers so the track can start/end at their centres.
+    pad_half = width / 2.0 + clearance
+    _sn_shapes: list = []
+    for poly, players, _ref, _pname, center in _same_net_pad_polygons(data, req.net):
+        is_end = (abs(center[0] - pad_a_xy[0]) < 1e-6 and abs(center[1] - pad_a_xy[1]) < 1e-6) or (
+            abs(center[0] - pad_b_xy[0]) < 1e-6 and abs(center[1] - pad_b_xy[1]) < 1e-6
+        )
+        buf = poly.buffer(pad_half)
+        if buf.is_empty or not buf.is_valid:
+            continue
+        _sn_shapes.append(buf)
+        for layer in players:
+            if layer not in obstacles_by_layer:
+                continue
+            if is_end and layer in (start_layer, end_layer):
+                continue
+            obstacles_by_layer[layer].append(
+                Obstacle(
+                    shape=buf,
+                    layers=frozenset({layer}),
+                    net=req.net,
+                    kind="pad",
+                )
+            )
+
+    # Route bounding box must cover the endpoint pads and every same-net
+    # pad obstacle: a detour around a wide pad cluster can extend past
+    # the +/-5 mm endpoint margin.
+    _hb = [s.bounds for s in _sn_shapes]
+    _hx0 = min((b[0] for b in _hb), default=pad_a_xy[0])
+    _hy0 = min((b[1] for b in _hb), default=pad_a_xy[1])
+    _hx1 = max((b[2] for b in _hb), default=pad_a_xy[0])
+    _hy1 = max((b[3] for b in _hb), default=pad_b_xy[1])
     route_bbox = (
-        min(pad_a_xy[0], pad_b_xy[0]) - 5.0,
-        min(pad_a_xy[1], pad_b_xy[1]) - 5.0,
-        max(pad_a_xy[0], pad_b_xy[0]) + 5.0,
-        max(pad_a_xy[1], pad_b_xy[1]) + 5.0,
+        min(pad_a_xy[0], pad_b_xy[0], _hx0) - 5.0,
+        min(pad_a_xy[1], pad_b_xy[1], _hy0) - 5.0,
+        max(pad_a_xy[0], pad_b_xy[0], _hx1) + 5.0,
+        max(pad_a_xy[1], pad_b_xy[1], _hy1) + 5.0,
     )
+    # The A* search area is clipped to route_bbox; an obstacle that spans
+    # the whole box (e.g. an Edge.Cuts opening the two pads sit on either
+    # side of) then looks like an impassable wall even though a detour
+    # around it exists outside the box.  Extend the box to cover the
+    # bounds of every obstacle that intersects it (iterated to closure so
+    # obstacles discovered on the second ring are included too), giving
+    # the search enough room to route around them.
+    _routing = set(routing_layers)
+    _x0, _y0, _x1, _y1 = route_bbox
+    _grew = True
+    while _grew:
+        _grew = False
+        for _o in buffered:
+            if not (_routing & _o.layers):
+                continue
+            _b = _o.shape.bounds
+            if _b[2] < _x0 or _b[0] > _x1 or _b[3] < _y0 or _b[1] > _y1:
+                continue  # no overlap with the current search box
+            _nx0, _ny0, _nx1, _ny1 = (
+                min(_x0, _b[0]),
+                min(_y0, _b[1]),
+                max(_x1, _b[2]),
+                max(_y1, _b[3]),
+            )
+            if (_nx0, _ny0, _nx1, _ny1) != (_x0, _y0, _x1, _y1):
+                _x0, _y0, _x1, _y1 = _nx0, _ny0, _nx1, _ny1
+                _grew = True
+    route_bbox = (_x0, _y0, _x1, _y1)
     grid_res = req.grid_resolution or GRID_RESOLUTION
 
     # ---- A* directly from pad centre to pad centre ----
@@ -350,7 +457,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
     _bx, _by = pad_b_xy
     print(
         f"  [route] {req.ref_a}/{req.pad_a} ({_ax:.3f},{_ay:.3f})"
-        f" → {req.ref_b}/{req.pad_b} ({_bx:.3f},{_by:.3f})"
+        f" -> {req.ref_b}/{req.pad_b} ({_bx:.3f},{_by:.3f})"
         f"  size_a={pad_a_size} size_b={pad_b_size}"
     )
     # Build pad-rectangle descriptors early (used by postprocess_path in
@@ -381,46 +488,37 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
                 )
             )
 
-    if req.start_layer != req.end_layer:
-        # ── Multi-layer: grid A* with via edges ──────────────────────
-        # Build via-forbidden zones from start/end pad AABBs to
-        # prevent via-in-pad (DFM issue: solder wicking).
+    if start_layer != end_layer:
+        # -- Multi-layer: grid A* with via edges ----------------------
+        # Via-forbidden zones cover EVERY same-net pad, not just the two
+        # endpoint pads: a via on any same-net pad face is a DFM defect
+        # (solder wicking, annular-ring breakout).  Same-net pads are
+        # absent from the obstacle grid (the route must land on its own
+        # pads), so without this the via search would happily drop a via
+        # on a finger pad.
         via_forbidden: list = []
-        if pad_a_world_size is not None:
-            via_forbidden.append(
-                _shapely_box(
-                    pad_a_xy[0] - pad_a_world_size[0] / 2.0,
-                    pad_a_xy[1] - pad_a_world_size[1] / 2.0,
-                    pad_a_xy[0] + pad_a_world_size[0] / 2.0,
-                    pad_a_xy[1] + pad_a_world_size[1] / 2.0,
-                )
-            )
-        if pad_b_world_size is not None:
-            via_forbidden.append(
-                _shapely_box(
-                    pad_b_xy[0] - pad_b_world_size[0] / 2.0,
-                    pad_b_xy[1] - pad_b_world_size[1] / 2.0,
-                    pad_b_xy[0] + pad_b_world_size[0] / 2.0,
-                    pad_b_xy[1] + pad_b_world_size[1] / 2.0,
-                )
-            )
+        for poly, _players, _ref, _pname, _center in _same_net_pad_polygons(data, req.net):
+            via_forbidden.append(poly)
         ml_result = multi_layer_a_star(
             obstacles_by_layer,
             pad_a_xy,
             pad_b_xy,
-            req.start_layer,
-            req.end_layer,
+            start_layer,
+            end_layer,
             req.via_pairs,
             route_bbox,
             grid_res,
             via_cost=req.via_cost,
             via_forbidden_zones=via_forbidden or None,
+            turn_penalty=req.turn_penalty,
         )
         if ml_result.path is None:
+            # Dump the failure state so the blockage can be inspected.
+            _dump_viz("fail-multi-astar", [], _pad_viz, buffered, route_bbox)
             raise RouteFailure(
                 f"No obstacle-avoiding multi-layer path from "
                 f"{req.ref_a}/{req.pad_a} to {req.ref_b}/{req.pad_b} at "
-                f"{width}mm track width ({req.start_layer} → {req.end_layer})."
+                f"{width}mm track width ({start_layer} -> {end_layer})."
             )
         print(
             f"  [route] multi-layer A*: {len(ml_result.path)} pts"
@@ -463,7 +561,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
                 _log_path(f"{prefix}-pad-replace", pts, n_before)
             _dump_viz(f"{prefix}-1-pad-replace", pts, _pad_viz, obs, route_bbox)
 
-            # Simplify → shortcut → snap45.
+            # Simplify -> shortcut -> snap45.
             pts = _postprocess_layer_segment(pts, obs, route_bbox, grid_res, prefix, _pad_viz)
 
             # Align endpoint to pad centre (start/end segments only).
@@ -499,19 +597,28 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         end_xy = (all_nodes[-1].x, all_nodes[-1].y)
         layers_used = _layers_used(all_nodes)
     else:
-        # ── Single-layer: hierarchical A* ───────────────────────────
+        # -- Single-layer: hierarchical A* ---------------------------
+        # Only copper on the routing layer can block the track; other
+        # layers are parallel physical planes and must not poison the
+        # grid (the multi-layer branch groups by layer for the same
+        # reason).
+        layer_obstacles = obstacles_by_layer[start_layer]
         result = hierarchical_a_star(
-            buffered,
+            layer_obstacles,
             pad_a_xy,
             pad_b_xy,
             fine_resolution=grid_res,
             route_bbox=route_bbox,
+            turn_penalty=req.turn_penalty,
         )
         if result.path is None:
+            # Dump the failure state so the blockage can be inspected
+            # (same viz format as the success stages).
+            _dump_viz("fail-astar", [], _pad_viz, layer_obstacles, route_bbox)
             raise RouteFailure(
                 f"No obstacle-avoiding path from {req.ref_a}/{req.pad_a} to "
                 f"{req.ref_b}/{req.pad_b} at {req.width or 0.5}mm "
-                f"track width on layer {req.start_layer}."
+                f"track width on layer {start_layer}."
             )
         print(f"  [route] A*: {len(result.path)} pts  cells_visited={result.cells_visited}")
 
@@ -520,7 +627,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         _dump_viz("0-astar", raw_pts, _pad_viz, buffered, route_bbox)
 
         # ---- Discard A* path inside rectangular pads and replace with
-        #      axis-aligned wire (fence → centre). ----
+        #      axis-aligned wire (fence -> centre). ----
         best_path_pts = raw_pts
         if pad_a_size is not None:
             n_before = len(best_path_pts)
@@ -534,7 +641,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             _log_path("pad_b-replace", best_path_pts, n_before)
         _dump_viz("1-pad-replace", best_path_pts, _pad_viz, buffered, route_bbox)
 
-        # ---- Post-process: simplify → shortcut → snap45 ----
+        # ---- Post-process: simplify -> shortcut -> snap45 ----
         best_path_pts = _postprocess_layer_segment(
             best_path_pts, buffered, route_bbox, grid_res, "", _pad_viz
         )
@@ -553,7 +660,7 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
         _log_path("align-endpoints", best_path_pts)
         _dump_viz("6-align-endpoints", best_path_pts, _pad_viz, buffered, route_bbox)
 
-        path_nodes = path_to_nodes(best_path_pts, req.start_layer)
+        path_nodes = path_to_nodes(best_path_pts, start_layer)
         segs, vias = postprocess_path(
             path_nodes,
             width=width,
@@ -585,7 +692,14 @@ def auto_route_pair(req: RouteRequest) -> RouteResult:
             req.pcb_path,
         )
     else:
-        _check_segments_in_board(segs, model.board_bbox)
+        # Endpoint pads may straddle the board edge (edge connectors);
+        # their copper is a legal terminus, so exempt those rectangles
+        # from the board fence.
+        pad_zones: list[tuple[float, float, float, float]] = []
+        for pxy, psize in ((pad_a_xy, pad_a_world_size), (pad_b_xy, pad_b_world_size)):
+            if psize is not None:
+                pad_zones.append((pxy[0], pxy[1], psize[0] / 2.0, psize[1] / 2.0))
+        _check_segments_in_board(segs, model.board_bbox, pad_zones=pad_zones or None)
         if vias:
             _check_vias_in_board(vias, model.board_bbox)
 
@@ -609,7 +723,7 @@ def connect_with_via(
 ) -> OutputVia:
     """Helper to build a through-via connecting two segments on different layers.
 
-    The via is placed at the (x, y) of ``seg_a``'s end. Both segments are
+    The via is placed at the (x, y) of seg_a end. Both segments are
     expected to end at the same point.
     """
     return OutputVia(
@@ -652,7 +766,7 @@ def _log_path(label: str, pts: list[tuple[float, float]], prev_n: int | None = N
             kind = "45diag"
         else:
             kind = f"{ang:.0f}deg"
-        segs.append(f"({x1:.3f},{y1:.3f})→({x2:.3f},{y2:.3f}){kind}")
+        segs.append(f"({x1:.3f},{y1:.3f})->({x2:.3f},{y2:.3f}){kind}")
     print(f"  [{label}] {n} pts{delta}: {segs[0]}{'  ...  ' + segs[-1] if len(segs) > 1 else ''}")
     if len(segs) <= 6:
         for s in segs:
@@ -672,7 +786,7 @@ def _log_output_segments(label: str, segs: list) -> None:
             if abs(abs(s.x2 - s.x1) - abs(s.y2 - s.y1)) < 1e-6
             else f"{ang:.0f}deg"
         )
-        print(f"  [{label}] seg{i}: ({s.x1:.3f},{s.y1:.3f})→({s.x2:.3f},{s.y2:.3f}) {kind}")
+        print(f"  [{label}] seg{i}: ({s.x1:.3f},{s.y1:.3f})->({s.x2:.3f},{s.y2:.3f}) {kind}")
 
 
 # ---------------------------------------------------------------------------
@@ -843,7 +957,7 @@ def _postprocess_layer_segment(
     stage_prefix: str,
     pad_viz: list[tuple[str, tuple[float, float, float, float]]],
 ) -> list[tuple[float, float]]:
-    """Run simplify → shortcut → snap45 on a single layer's path points.
+    """Run simplify -> shortcut -> snap45 on a single layer's path.
 
     Each step dumps a viz file with ``stage_prefix`` prepended, so
     multi-layer dumps carry the layer name (e.g. ``layer-F.Cu-2-simplify``)
@@ -858,10 +972,14 @@ def _postprocess_layer_segment(
     pts = shortcut_path(pts, obstacles, route_bbox, resolution=grid_res)
     _log_path(f"{stage_prefix}shortcut", pts)
     _dump_viz(f"{stage_prefix}3-shortcut", pts, pad_viz, obstacles, route_bbox)
-
     pts = snap_to_45_path_safe(pts, obstacles, route_bbox, resolution=grid_res)
     _log_path(f"{stage_prefix}snap45", pts)
     _dump_viz(f"{stage_prefix}4-snap45", pts, pad_viz, obstacles, route_bbox)
+
+    # Re-simplify: snap45 may create new collinear points.
+    pts = simplify_path(pts)
+    _log_path(f"{stage_prefix}resimplify", pts)
+    _dump_viz(f"{stage_prefix}5-resimplify", pts, pad_viz, obstacles, route_bbox)
 
     return pts
 
@@ -875,7 +993,7 @@ def _align_single_endpoint(
     pad_size: tuple[float, float],
     from_center: bool,
 ) -> list[tuple[float, float]]:
-    """Align one endpoint to a pad centre via X→Y iterative translation.
+    """Align one endpoint to a pad centre via X->Y iterative translation.
 
     ``from_center=True`` aligns the start of *path*; ``False`` aligns
     the end.  See :func:`_align_path_endpoints` for the detailed algorithm.
@@ -885,7 +1003,7 @@ def _align_single_endpoint(
 
     pcx, pcy = pad_center
     if from_center:
-        # ── Start pad ───────────────────────────────────────────────
+        # -- Start pad -----------------------------------------------
         dx = pcx - path[0][0]
         if abs(dx) > 1e-9:
             orig = list(path)
@@ -912,7 +1030,7 @@ def _align_single_endpoint(
                 path[k] = (path[k][0], path[k][1] + dy)
                 k += 1
     else:
-        # ── End pad ─────────────────────────────────────────────────
+        # -- End pad -------------------------------------------------
         dx = pcx - path[-1][0]
         if abs(dx) > 1e-9:
             orig = list(path)
@@ -952,7 +1070,7 @@ def _align_path_endpoints(
     pad_a_size: tuple[float, float] | None = None,
     pad_b_size: tuple[float, float] | None = None,
 ) -> list[tuple[float, float]]:
-    """Align both endpoints to pad centres via X→Y translation.
+    """Align both endpoints to pad centres via X->Y translation.
 
     See :func:`_align_single_endpoint` for the per-endpoint algorithm.
     """
@@ -1009,7 +1127,7 @@ def _replace_pad_path(
             if not _inside_rect(path[k], center, hw, hh):
                 fx, fy = path[k + 1]
                 ox, oy = path[k]
-                # Same (center, fence) order — reverse so path reads [fence, projection].
+                # Same (center, fence) order -- reverse so path reads [fence, projection].
                 keep = _build_pad_wire(cx, cy, fx, fy, ox, oy, minx, maxx, miny, maxy)
                 return path[: k + 1] + keep[::-1]
         return path
@@ -1037,7 +1155,7 @@ def _build_pad_wire(
     miny: float,
     maxy: float,
 ) -> list[tuple[float, float]]:
-    """Return ``[projection, fence]`` — a single axis-aligned segment
+    """Return ``[projection, fence]`` -- a single axis-aligned segment
     along the AABB edge the outside point exits from.  The centre is
     kept by the caller (``_replace_pad_path``), and the whole chain
     is translated by ``_align_path_endpoints``."""
@@ -1055,10 +1173,10 @@ def _build_pad_wire(
         horizontal = abs(ox - x1) >= abs(oy - y1)
 
     if horizontal:
-        # fence on left/right edge → horizontal wire at fence_y
+        # fence on left/right edge -> horizontal wire at fence_y
         return [(x1, y2), (x2, y2)]
     else:
-        # fence on top/bottom edge → vertical wire at fence_x
+        # fence on top/bottom edge -> vertical wire at fence_x
         return [(x2, y1), (x2, y2)]
 
 
@@ -1070,6 +1188,7 @@ def _build_pad_wire(
 def _check_segments_in_board(
     segs: list[OutputSegment],
     board_bbox: tuple[float, float, float, float],
+    pad_zones: list[tuple[float, float, float, float]] | None = None,
 ) -> None:
     """Raise :class:`RouteFailure` if any segment leaves the Edge.Cuts AABB.
 
@@ -1080,10 +1199,17 @@ def _check_segments_in_board(
     copper would still touch but not cross the edge); a track whose
     centerline is on the wrong side of the shrunk boundary fails.
 
+    ``pad_zones`` relaxes the fence around the route's endpoint pads:
+    footprints mounted on the board edge (edge connectors) legitimately
+    straddle the outline, so copper running onto those pads must not be
+    rejected. Each zone is ``(cx, cy, half_w, half_h)`` in world coords
+    and is unioned into the region a segment's copper may occupy.
+
     Args:
         segs: The segments produced by :func:`postprocess`.
         board_bbox: ``(minx, miny, maxx, maxy)`` from
             :func:`kcaa.router.world_model._board_bbox`.
+        pad_zones: Optional endpoint-pad rectangles to exempt.
 
     Raises:
         RouteFailure: The first segment that would leave the board.
@@ -1107,7 +1233,7 @@ def _check_segments_in_board(
                 f"Track width {seg.width} mm is wider than the board "
                 f"(shrunk bbox {shrunk_bbox} is degenerate)."
             )
-        board_poly = Polygon(
+        allowed = Polygon(
             [
                 (shrunk_bbox[0], shrunk_bbox[1]),
                 (shrunk_bbox[2], shrunk_bbox[1]),
@@ -1115,8 +1241,20 @@ def _check_segments_in_board(
                 (shrunk_bbox[0], shrunk_bbox[3]),
             ]
         )
+        if pad_zones:
+            for cx, cy, hw, hh in pad_zones:
+                allowed = allowed.union(
+                    Polygon(
+                        [
+                            (cx - hw, cy - hh),
+                            (cx + hw, cy - hh),
+                            (cx + hw, cy + hh),
+                            (cx - hw, cy + hh),
+                        ]
+                    )
+                )
         line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
-        if not board_poly.covers(line):
+        if not allowed.covers(line):
             raise RouteFailure(
                 f"Segment {i} from ({seg.x1:.3f},{seg.y1:.3f}) to "
                 f"({seg.x2:.3f},{seg.y2:.3f}) would extend outside the "
@@ -1163,7 +1301,11 @@ def _check_vias_in_board(
 # ---------------------------------------------------------------------------
 
 
-def _routing_layers(req: RouteRequest) -> list[str]:
+def _routing_layers(
+    req: RouteRequest,
+    start_layer: str,
+    end_layer: str,
+) -> list[str]:
     """Return the ordered list of layers the router must consider.
 
     Includes ``start_layer`` and ``end_layer`` and every layer referenced
@@ -1171,7 +1313,7 @@ def _routing_layers(req: RouteRequest) -> list[str]:
     """
     seen: set[str] = set()
     out: list[str] = []
-    for layer in (req.start_layer, req.end_layer):
+    for layer in (start_layer, end_layer):
         if layer not in seen:
             out.append(layer)
             seen.add(layer)
@@ -1220,12 +1362,47 @@ def _pcb_layer_names(data: list) -> list[str]:
     return []
 
 
+def _find_pad_net(
+    data: list,
+    ref: str,
+    pad_name: str,
+    layer: str | None = None,
+) -> str | None:
+    """Return the net name of the named pad on the given footprint ref.
+
+    When ``layer`` is given, only pads whose copper covers that layer are
+    considered, matching :func:`_find_pad_center` semantics for footprints
+    that declare several pads with the same name.
+    """
+    fp = _find_footprint(data, ref)
+    if fp is None:
+        return None
+    for sub in fp:
+        if not _is_list(sub):
+            continue
+        if str(sub[0]) != "pad":
+            continue
+        if _get_pad_name(sub) != pad_name:
+            continue
+        if layer is not None and layer not in _pad_layers(sub):
+            continue
+        return _get_net(sub)
+    return None
+
+
 def _find_pad_center(
     data: list,
     ref: str,
     pad_name: str,
+    layer: str | None = None,
 ) -> tuple[float, float] | None:
-    """Return the (x, y) center of the named pad on the given footprint ref."""
+    """Return the (x, y) center of the named pad on the given footprint ref.
+
+    When ``layer`` is given, only pads whose copper covers that layer are
+    considered -- a footprint may declare several pads with the same name
+    (e.g. edge-connector fingers sharing a net), and the center must match
+    the pad whose shape :func:`_find_pad_size` would return.
+    """
     fp = _find_footprint(data, ref)
     if fp is None:
         return None
@@ -1238,6 +1415,8 @@ def _find_pad_center(
         name = _get_pad_name(sub)
         if name != pad_name:
             continue
+        if layer is not None and layer not in _pad_layers(sub):
+            continue
         # Pad ``at`` is in footprint-local coords.
         at = _get_sub(sub, "at")
         if at is None or len(at) < 3:
@@ -1246,7 +1425,7 @@ def _find_pad_center(
             px, py = float(at[1]), float(at[2])
         except (TypeError, ValueError):
             return None
-        # Transform local → world (only translation + rotation; pads don't
+        # Transform local -> world (only translation + rotation; pads don't
         # scale).
         wx, wy = _rotate(px, py, fp_rot)
         return fp_x + wx, fp_y + wy
@@ -1261,8 +1440,9 @@ def _find_pad_size(
 ) -> tuple[float, float] | None:
     """Return the (w, h) of the pad shape, for the requested copper layer.
 
-    Returns ``None`` if the pad is not on ``layer`` or not SMD (e.g. thru-hole
-    pads are circular and need a different exit strategy).
+    A footprint may declare several pads with the same name (e.g. edge-
+    connector fingers sharing a net). Returns the first pad whose copper
+    covers ``layer``, and ``None`` only if no same-named pad is on it.
     """
     fp = _find_footprint(data, ref)
     if fp is None:
@@ -1275,14 +1455,15 @@ def _find_pad_size(
         if _get_pad_name(sub) != pad_name:
             continue
         if layer not in _pad_layers(sub):
-            return None
+            # Another pad with this name may carry the requested layer.
+            continue
         size_sub = _get_sub(sub, "size")
         if size_sub is None or len(size_sub) < 3:
-            return None
+            continue
         try:
             return float(size_sub[1]), float(size_sub[2])
         except (TypeError, ValueError):
-            return None
+            continue
     return None
 
 
@@ -1319,6 +1500,38 @@ def _get_pad_name(pad_node: list) -> str:
     return ""
 
 
+def _pad_type(pad_node: list) -> str:
+    """Return the pad type: ``thru_hole``, ``smd``, or ``connect``."""
+    if len(pad_node) > 2:
+        return str(pad_node[2])
+    return ""
+
+
+def _find_pad_node(
+    data: list,
+    ref: str,
+    pad_name: str,
+    layer: str | None = None,
+) -> list | None:
+    """Return the raw pad node for ``ref``/``pad_name``.
+
+    When ``layer`` is given, only pads whose copper covers that layer
+    are considered (same logic as :func:`_find_pad_center`).
+    """
+    fp = _find_footprint(data, ref)
+    if fp is None:
+        return None
+    for sub in fp:
+        if not _is_list(sub) or str(sub[0]) != "pad":
+            continue
+        if _get_pad_name(sub) != pad_name:
+            continue
+        if layer is not None and layer not in _pad_layers(sub):
+            continue
+        return sub
+    return None
+
+
 _ALL_COPPER = {"F.Cu", "B.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu"}
 
 
@@ -1336,6 +1549,203 @@ def _pad_layers(pad_node: list) -> list[str]:
     return layers
 
 
+def _resolve_layers(
+    data: list,
+    req: RouteRequest,
+) -> tuple[str, str]:
+    """Auto-pick start/end copper layers from pad types and ``layer_hint``.
+
+    For SMD/connect pads the layer is fixed by the pad itself (it has
+    copper on exactly one copper layer).  For thru-hole pads (``*.Cu``)
+    the router picks the best shared copper layer, preferring
+    ``layer_hint`` when it is among the pad's copper layers.
+
+    When a footprint declares several pads with the same name (edge
+    connectors), the union of all same-named pads' copper layers is
+    used -- a THT pad named ``3v3`` makes the pad flexible across all
+    copper layers even if the first same-named pad is SMD.
+
+    Returns ``(start_layer, end_layer)``.
+
+    Raises :class:`RouteFailure` if either pad has no copper on any layer.
+    When the two pads share no copper layer and ``layer_hint`` is neither
+    pad's preferred layer, each pad falls back to its first available
+    copper layer; the returned layers may then differ (staggered).
+    """
+    fp_a = _find_footprint(data, req.ref_a)
+    fp_b = _find_footprint(data, req.ref_b)
+    if fp_a is None:
+        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
+    if fp_b is None:
+        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
+
+    # Collect ALL same-named pad nodes (a footprint may declare several
+    # pads with one name -- edge-connector fingers + a THT pad).
+    a_nodes = [
+        s for s in fp_a if _is_list(s) and str(s[0]) == "pad" and _get_pad_name(s) == req.pad_a
+    ]
+    b_nodes = [
+        s for s in fp_b if _is_list(s) and str(s[0]) == "pad" and _get_pad_name(s) == req.pad_b
+    ]
+    if not a_nodes:
+        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} not found")
+    if not b_nodes:
+        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} not found")
+
+    # Union of copper layers across all same-named pads, and detect
+    # whether any pad is THT (flexible) vs all SMD/connect (fixed).
+    pcb_copper = [l for l in _pcb_layer_names(data) if l.endswith(".Cu")]
+    a_layers: list[str] = []
+    b_layers: list[str] = []
+    a_has_tht = b_has_tht = False
+    for node in a_nodes:
+        if _pad_type(node) == "thru_hole":
+            a_has_tht = True
+        for l in _pad_layers(node):
+            if l.endswith(".Cu") and ".Mask" not in l and l not in a_layers:
+                a_layers.append(l)
+    for node in b_nodes:
+        if _pad_type(node) == "thru_hole":
+            b_has_tht = True
+        for l in _pad_layers(node):
+            if l.endswith(".Cu") and ".Mask" not in l and l not in b_layers:
+                b_layers.append(l)
+    # Filter THT layers to PCB's actual copper layers.
+    if a_has_tht:
+        a_layers = [l for l in a_layers if l in pcb_copper]
+    if b_has_tht:
+        b_layers = [l for l in b_layers if l in pcb_copper]
+    if not a_layers:
+        raise RouteFailure(f"Pad {req.ref_a}/{req.pad_a} has no copper layer")
+    if not b_layers:
+        raise RouteFailure(f"Pad {req.ref_b}/{req.pad_b} has no copper layer")
+
+    # A pad is "fixed" only when ALL same-named pads are SMD/connect.
+    a_fixed = not a_has_tht
+    b_fixed = not b_has_tht
+
+    # Determine start layer.
+    if a_fixed:
+        start_layer = a_layers[0]
+    elif req.layer_hint and req.layer_hint in a_layers:
+        start_layer = req.layer_hint
+    else:
+        start_layer = None
+
+    # Determine end layer.
+    if b_fixed:
+        end_layer = b_layers[0]
+    elif req.layer_hint and req.layer_hint in b_layers:
+        end_layer = req.layer_hint
+    else:
+        end_layer = None
+
+    # For THT pads without a fixed layer, pick a shared copper layer.
+    if start_layer is None or end_layer is None:
+        shared = [l for l in a_layers if l in b_layers]
+        if not shared:
+            if start_layer is None:
+                start_layer = (
+                    req.layer_hint
+                    if (req.layer_hint and req.layer_hint in a_layers)
+                    else a_layers[0]
+                )
+            if end_layer is None:
+                end_layer = (
+                    req.layer_hint
+                    if (req.layer_hint and req.layer_hint in b_layers)
+                    else b_layers[0]
+                )
+        else:
+            chosen = None
+            if req.layer_hint and req.layer_hint in shared:
+                chosen = req.layer_hint
+            else:
+                chosen = shared[0]
+            if start_layer is None:
+                start_layer = chosen
+            if end_layer is None:
+                end_layer = chosen
+
+    return start_layer, end_layer
+
+
+def _same_net_pad_polygons(
+    data: list,
+    net: str,
+) -> list[tuple[object, frozenset[str], str, str, tuple[float, float]]]:
+    """Return ``(world polygon, copper layers, ref, pad name, world center)``
+    for every pad carrying ``net``.
+
+    The world model drops same-net copper so the route can land on its
+    own endpoint pads; the router re-adds those pads here as *transit*
+    obstacles -- a track may terminate on a pad, never run across its
+    copper (a track through a thru-hole pad's hole is cut by the drill,
+    and a via on a pad face is a DFM defect).  Geometry mirrors
+    :func:`kcaa.router.world_model._pad_obstacle`.
+
+    The world center lets callers distinguish the *endpoint pad instance*
+    from other same-named pads by geometry -- two pads on the same net
+    can share ``(ref, pad name)`` (edge connectors with multiple
+    ``3v3`` fingers), so name-based skip would wrongly exempt every
+    same-named pad.
+    """
+    out: list[tuple[object, frozenset[str], str, str, tuple[float, float]]] = []
+    for item in data:
+        if not _is_list(item) or str(item[0]) != "footprint":
+            continue
+        fp_x, fp_y, fp_rot = _node_at3(item)
+        ref = ""
+        for sub in item:
+            if (
+                _is_list(sub)
+                and str(sub[0]) == "property"
+                and len(sub) >= 3
+                and str(sub[1]) == "Reference"
+            ):
+                ref = sub[2] if isinstance(sub[2], str) else str(sub[2])
+        for sub in item:
+            if not _is_list(sub) or str(sub[0]) != "pad":
+                continue
+            if _get_net(sub) != net:
+                continue
+            if len(sub) > 2 and str(sub[2]) == "np_thru_hole":
+                continue  # bare mechanical hole -- no copper to protect
+            players = _pad_layers(sub)
+            if not players:
+                continue
+            size = _get_sub(sub, "size")
+            if size is None or len(size) < 3:
+                continue
+            try:
+                pw, ph = float(size[1]), float(size[2])
+            except (TypeError, ValueError):
+                continue
+            at = _get_sub(sub, "at")
+            if at is None or len(at) < 3:
+                continue
+            try:
+                lx, ly = float(at[1]), float(at[2])
+            except (TypeError, ValueError):
+                continue
+            wx_off, wy_off = _rotate(lx, ly, fp_rot)
+            wx, wy = fp_x + wx_off, fp_y + wy_off
+            hw, hh = pw / 2.0, ph / 2.0
+            rad = math.radians(fp_rot)
+            c, s = math.cos(rad), math.sin(rad)
+            corners = [
+                (c * -hw + s * -hh, -s * -hw + c * -hh),
+                (c * hw + s * -hh, -s * hw + c * -hh),
+                (c * hw + s * hh, -s * hw + c * hh),
+                (c * -hw + s * hh, -s * -hw + c * hh),
+            ]
+            poly = Polygon([(wx + cx, wy + cy) for cx, cy in corners])
+            if poly.is_empty or not poly.is_valid:
+                continue
+            out.append((poly, frozenset(players), ref, _get_pad_name(sub), (wx, wy)))
+    return out
+
+
 # ---------------------------------------------------------------------------
 # DRC defaults (lightweight: read the netclass table from the .kicad_pro)
 # ---------------------------------------------------------------------------
@@ -1349,7 +1759,7 @@ def _default_track_width(pcb_path: str, net: str) -> float:
     ``track_width``.
 
     Raises:
-        ProFileMissing: No ``.kicad_pro`` next to ``pcb_path`` — pass
+        ProFileMissing: No ``.kicad_pro`` next to ``pcb_path`` -- pass
             ``RouteRequest(width=...)`` explicitly to skip DRC lookup.
         ProFileMalformed: The ``.kicad_pro`` exists but cannot be parsed or
             lacks the expected structure.
@@ -1383,7 +1793,7 @@ def _default_track_width(pcb_path: str, net: str) -> float:
 def _default_clearance(pcb_path: str, net: str | None = None) -> float:
     """Resolve minimum clearance from the board's effective design rules.
 
-    When the board's ``min_clearance`` is 0.0 (which is common — KiCad
+    When the board's ``min_clearance`` is 0.0 (which is common -- KiCad
     leaves it at 0 and relies on net class rules) this falls back to the
     clearance of the matching net class.  If no net class matches, uses
     the Default net class clearance (0.2 mm fallback).
@@ -1578,9 +1988,9 @@ def _resolve_via_drill(pcb_path: str, net: str) -> float:
 
 
 def _net_to_netclass(data: dict) -> dict[str, str]:
-    """Read net→netclass assignments from the JSON project file.
+    """Read net->netclass assignments from the JSON project file.
 
-    KiCad's project file uses ``netclass_patterns`` with a ``pattern`` glob —
+    KiCad's project file uses ``netclass_patterns`` with a ``pattern`` glob --
     a net belongs to the first matching pattern's netclass. This is a
     glob-style match (we use ``fnmatch`` for ``*`` and ``?`` wildcards).
     """
@@ -1609,7 +2019,7 @@ def _net_to_netclass(data: dict) -> dict[str, str]:
     # Resolve patterns into explicit per-net entries.
     # (Net names that are not in the explicit table are resolved here.)
     # The caller will look up by net name; for resolution we need to know
-    # the set of net names — but for our purposes (looking up a single
+    # the set of net names -- but for our purposes (looking up a single
     # net by name) the explicit table is enough. We expose the patterns
     # so a higher layer can resolve ambiguous names. For now, expose
     # ``out`` as the per-net map and also a fallback: if the net is not

--- a/kcaa/router/world_model.py
+++ b/kcaa/router/world_model.py
@@ -25,11 +25,21 @@ from dataclasses import dataclass, field
 import math
 from typing import Any, Literal
 
-from shapely.geometry import Point, Polygon
+from shapely.geometry import LineString, Point, Polygon
+from shapely.ops import polygonize, unary_union
 
 from kcaa.utils.pcb_sexp_utils import load_pcb
 
-ObstacleKind = Literal["footprint", "pad", "track", "via", "keepout", "board_edge", "drill"]
+ObstacleKind = Literal[
+    "footprint",
+    "pad",
+    "track",
+    "via",
+    "keepout",
+    "board_edge",
+    "drill",
+    "opening",
+]
 
 
 @dataclass(frozen=True)
@@ -122,6 +132,19 @@ def build_world_model(
             ko = _keepout_obstacle(item)
             if ko is not None:
                 model.obstacles.append(ko)
+
+    # Edge.Cuts internal openings (cutouts / routing slots) are physical
+    # voids through the whole stack: block them on every copper layer.
+    for opening in _edge_cuts_openings(data):
+        model.obstacles.append(
+            Obstacle(
+                shape=opening,
+                layers=_ALL_COPPER_LAYERS,
+                net=None,
+                kind="opening",
+                ref=None,
+            )
+        )
     return model
 
 
@@ -336,7 +359,7 @@ def _pad_obstacle(
 
     Returns ``None`` for NPTH pads (handled by :func:`_npth_obstacle`).
     """
-    pad_type = str(pad_node[1]) if len(pad_node) > 1 else ""
+    pad_type = str(pad_node[2]) if len(pad_node) > 2 else ""
     if pad_type == "np_thru_hole":
         return None  # handled by _npth_obstacle
 
@@ -418,7 +441,7 @@ def _npth_obstacle(
     Unlike ``_via_obstacle``, NPTH pads do not have a net, so the
     ``net_filter`` argument is not consulted — the hole blocks every net.
     """
-    pad_type = str(pad_node[1]) if len(pad_node) > 1 else ""
+    pad_type = str(pad_node[2]) if len(pad_node) > 2 else ""
     if pad_type != "np_thru_hole":
         return None
     # Pad ``at`` is in footprint-local coords.
@@ -478,29 +501,292 @@ def _keepout_obstacle(zone_node: list[Any]) -> Obstacle | None:
     return Obstacle(shape=poly, layers=frozenset({layer}), net=None, kind="keepout")
 
 
+_EDGE_GRAPHICS = {
+    "gr_line",
+    "gr_rect",
+    "gr_arc",
+    "gr_circle",
+    "gr_poly",
+    "fp_line",
+    "fp_rect",
+    "fp_arc",
+    "fp_circle",
+    "fp_poly",
+}
+
+
 def _board_bbox(data: list[Any]) -> tuple[float, float, float, float] | None:
-    """Compute the AABB of all Edge.Cuts items, or None."""
+    """Compute the AABB of all Edge.Cuts items, or None.
+
+    The outline is not always board-level graphics: edge-mounted
+    connectors (e.g. a micro:bit card bay) draw the notch they sit in
+    with ``fp_line``/``fp_poly`` Edge.Cuts items inside the footprint,
+    and those items are part of the real board outline.  Footprint
+    items are transformed into world coordinates through the footprint's
+    ``(at x y rot)`` placement.
+    """
     xs: list[float] = []
     ys: list[float] = []
-    for item in data:
-        if not _is_list(item):
-            continue
-        tag = _sym(item[0])
-        if tag not in {"gr_line", "gr_rect", "gr_arc", "gr_circle"}:
-            continue
-        layer = _get_layer_str(item)
-        if layer != "Edge.Cuts":
-            continue
-        for sub in item:
-            if not _is_list(sub):
-                continue
-            k = _sym(sub[0])
-            if k in {"start", "end", "mid", "center"} and len(sub) >= 3:
+
+    def _walk(node: list[Any], ox: float, oy: float, rot: float) -> None:
+        if not _is_list(node):
+            return
+        tag = _sym(node[0])
+        if tag == "footprint":
+            fox, foy, frot = ox, oy, rot
+            at = _get_sub(node, "at")
+            if at is not None and len(at) >= 3:
                 try:
-                    xs.append(float(sub[1]))
-                    ys.append(float(sub[2]))
+                    fox, foy = float(at[1]), float(at[2])
                 except (TypeError, ValueError):
                     pass
+                if len(at) >= 4:
+                    try:
+                        frot = float(at[3])
+                    except (TypeError, ValueError):
+                        pass
+            for sub in node:
+                _walk(sub, fox, foy, frot)
+            return
+        if tag in _EDGE_GRAPHICS:
+            if _get_layer_str(node) != "Edge.Cuts":
+                return
+            rad = math.radians(rot)
+            c, s = math.cos(rad), math.sin(rad)
+            for sub in node:
+                if not _is_list(sub):
+                    continue
+                k = _sym(sub[0])
+                if k in {"start", "end", "mid", "center"} and len(sub) >= 3:
+                    try:
+                        lx, ly = float(sub[1]), float(sub[2])
+                    except (TypeError, ValueError):
+                        continue
+                elif k == "xy" and len(sub) >= 3:
+                    try:
+                        lx, ly = float(sub[1]), float(sub[2])
+                    except (TypeError, ValueError):
+                        continue
+                else:
+                    continue
+                xs.append(ox + c * lx + s * ly)
+                ys.append(oy - s * lx + c * ly)
+            return
+        for sub in node:
+            _walk(sub, ox, oy, rot)
+
+    for item in data:
+        _walk(item, 0.0, 0.0, 0.0)
     if not xs:
         return None
     return min(xs), min(ys), max(xs), max(ys)
+
+
+# ---------------------------------------------------------------------------
+# Edge.Cuts openings (cutouts / routing slots inside the board)
+# ---------------------------------------------------------------------------
+
+
+def _edge_cuts_openings(data: list[Any]) -> list[Polygon]:
+    """Closed Edge.Cuts loops strictly inside the board outline.
+
+    KiCad draws internal cutouts (routing slots, mounting windows) as
+    closed loops on the Edge.Cuts layer that lie wholly inside the outer
+    outline.  A track routed across such a loop physically spans a hole in
+    the substrate -- fabrication-invalid copper.  Open notches that touch
+    the outer boundary (e.g. an edge-connector card bay) are NOT openings:
+    they are part of the outline, and the AABB fence handles them.
+
+    The outer outline is the polygonized face with maximum area; every
+    interior ring of that face is one opening loop.  Panel files with
+    several disjoint outlines are handled by collecting interior rings
+    from every face, not just the largest.
+
+    Returns [] when the outline is absent, open, or degenerate (same
+    workflow state as a missing ``_board_bbox``).
+    """
+    lines: list[LineString] = []
+
+    def _walk(node: list[Any], ox: float, oy: float, rot: float) -> None:
+        if not _is_list(node):
+            return
+        tag = _sym(node[0])
+        if tag == "footprint":
+            fox, foy, frot = ox, oy, rot
+            at = _get_sub(node, "at")
+            if at is not None and len(at) >= 3:
+                try:
+                    fox, foy = float(at[1]), float(at[2])
+                except (TypeError, ValueError):
+                    pass
+                if len(at) >= 4:
+                    try:
+                        frot = float(at[3])
+                    except (TypeError, ValueError):
+                        pass
+            for sub in node:
+                _walk(sub, fox, foy, frot)
+            return
+        if tag in _EDGE_GRAPHICS:
+            if _get_layer_str(node) != "Edge.Cuts":
+                return
+            segs = _edge_graphics_to_lines(node, ox, oy, rot)
+            lines.extend(segs)
+            return
+        for sub in node:
+            _walk(sub, ox, oy, rot)
+
+    for item in data:
+        _walk(item, 0.0, 0.0, 0.0)
+    if not lines:
+        return []
+    merged = unary_union(lines)
+    faces = list(polygonize(merged))
+    if not faces:
+        return []
+    # Every closed loop that is interior to *any* face is an opening.
+    # Taking interiors from all faces (not just the max-area one) also
+    # covers panel files with several disjoint board outlines.
+    openings = [Polygon(ring) for f in faces for ring in f.interiors]
+    return [p for p in openings if p.is_valid and not p.is_empty and p.area > 0]
+
+
+def _edge_graphics_to_lines(
+    node: list[Any],
+    ox: float,
+    oy: float,
+    rot: float,
+) -> list[LineString]:
+    """Convert one Edge.Cuts graphic node into world-coordinate segments.
+
+    Supports the KiCad line/rect/arc/circle/poly graphic families (board
+    ``gr_*`` and footprint ``fp_*`` variants).  Footprint-local coordinates
+    are transformed through the footprint origin/rotation, exactly like
+    :func:`_board_bbox`.
+    """
+    tag = _sym(node[0])
+    rad = math.radians(rot)
+    c, s = math.cos(rad), math.sin(rad)
+
+    def _pt(name: str) -> tuple[float, float] | None:
+        sub = _get_sub(node, name)
+        if sub is None or len(sub) < 3:
+            return None
+        try:
+            lx, ly = float(sub[1]), float(sub[2])
+        except (TypeError, ValueError):
+            return None
+        return (ox + c * lx + s * ly, oy - s * lx + c * ly)
+
+    if tag in ("gr_line", "fp_line"):
+        p1, p2 = _pt("start"), _pt("end")
+        if p1 is not None and p2 is not None:
+            return [LineString([p1, p2])]
+        return []
+    if tag in ("gr_rect", "fp_rect"):
+        p1, p2 = _pt("start"), _pt("end")
+        if p1 is None or p2 is None:
+            return []
+        x1, y1 = p1
+        x2, y2 = p2
+        ring = [(x1, y1), (x2, y1), (x2, y2), (x1, y2), (x1, y1)]
+        return [LineString(ring)]
+    if tag in ("gr_arc", "fp_arc"):
+        p1, pm, p2 = _pt("start"), _pt("mid"), _pt("end")
+        if p1 is None or pm is None or p2 is None:
+            return []
+        return [_arc_to_line(p1, pm, p2)]
+    if tag in ("gr_circle", "fp_circle"):
+        pc, pe = _pt("center"), _pt("end")
+        if pc is None or pe is None:
+            return []
+        r = math.hypot(pe[0] - pc[0], pe[1] - pc[1])
+        if r <= 0:
+            return []
+        n = 32
+        ring = [
+            (
+                pc[0] + r * math.cos(2.0 * math.pi * i / n),
+                pc[1] + r * math.sin(2.0 * math.pi * i / n),
+            )
+            for i in range(n + 1)
+        ]
+        return [LineString(ring)]
+    if tag in ("gr_poly", "fp_poly"):
+        pts: list[tuple[float, float]] = []
+        for sub in node:
+            if _is_list(sub) and _sym(sub[0]) == "pts":
+                for p in sub[1:]:
+                    if _is_list(p) and _sym(p[0]) == "xy" and len(p) >= 3:
+                        try:
+                            pts.append(
+                                (
+                                    ox + c * float(p[1]) + s * float(p[2]),
+                                    oy - s * float(p[1]) + c * float(p[2]),
+                                )
+                            )
+                        except (TypeError, ValueError):
+                            continue
+        if len(pts) >= 3:
+            if pts[0] != pts[-1]:
+                pts.append(pts[0])
+            return [LineString(pts)]
+        return []
+    return []
+
+
+def _arc_to_line(
+    p_start: tuple[float, float],
+    p_mid: tuple[float, float],
+    p_end: tuple[float, float],
+    n: int = 16,
+) -> LineString:
+    """Sample a 3-point arc (start, mid, end) into a polyline.
+
+    KiCad stores arcs as three on-arc points; the sweep direction is the
+    one that passes through ``p_mid``.  Returns a degenerate 2-point line
+    when the three points are collinear or coincident.
+    """
+    ax, ay = p_start
+    bx, by = p_mid
+    cx, cy = p_end
+    d = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
+    if abs(d) < 1e-12:
+        return LineString([p_start, p_end])
+    ux = (
+        (ax * ax + ay * ay) * (by - cy)
+        + (bx * bx + by * by) * (cy - ay)
+        + (cx * cx + cy * cy) * (ay - by)
+    ) / d
+    uy = (
+        (ax * ax + ay * ay) * (cx - bx)
+        + (bx * bx + by * by) * (ax - cx)
+        + (cx * cx + cy * cy) * (bx - ax)
+    ) / d
+    r = math.hypot(ax - ux, ay - uy)
+    if r <= 0:
+        return LineString([p_start, p_end])
+    a1 = math.atan2(ay - uy, ax - ux)
+    am = math.atan2(by - uy, bx - ux)
+    a2 = math.atan2(cy - uy, cx - ux)
+    ccw = (a2 - a1) % (2.0 * math.pi)  # 0..2pi sweep start->end
+    mid_ccw = (am - a1) % (2.0 * math.pi)
+    if 0.0 < mid_ccw < ccw:
+        sweep = ccw
+    elif mid_ccw > ccw:
+        sweep = ccw - 2.0 * math.pi
+    else:  # coincident mid (start == mid or mid == end) -> straight-ish
+        sweep = ccw
+    if abs(sweep) < 1e-12:
+        return LineString([p_start, p_end])
+    pts = [
+        (ux + r * math.cos(a1 + sweep * i / n), uy + r * math.sin(a1 + sweep * i / n))
+        for i in range(n + 1)
+    ]
+    # Pin the sampled endpoints to the exact input points so the arc
+    # stitches exactly onto neighbouring Edge.Cuts segments (rounding in
+    # the center/radius reconstruction would otherwise leave a tiny gap
+    # that breaks polygonize's ring closing).
+    pts[0] = p_start
+    pts[-1] = p_end
+    return LineString(pts)

--- a/kcaa/tools/pcb_query_tools.py
+++ b/kcaa/tools/pcb_query_tools.py
@@ -24,7 +24,7 @@ from kcaa.tools.pcb_placement_helpers import (
     _get_board_bounds_or_fallback,
     _get_fp_pads_world,
 )
-from kcaa.utils.pcb_board_utils import get_fp_courtyard_bbox
+from kcaa.utils.pcb_board_utils import get_fp_courtyard_bbox, get_fp_edge_cuts_items
 from kcaa.utils.pcb_footprint_utils import (
     _sym,
     find_footprint,
@@ -265,7 +265,10 @@ def register_pcb_query_tools(mcp: FastMCP) -> None:
             dict with reference, value, x/y/rotation (world, mm/deg CW+),
             layer, properties (dict of all property name→value), pads
             (list of {number, type, shape, local_x, local_y,
-             local_w, local_h, world_w, world_h, net_name}).
+             local_w, local_h, world_w, world_h, net_name}),
+             edge_cuts (list of fp_line/fp_rect/fp_arc/fp_circle/fp_curve
+             items on the footprint's Edge.Cuts layer, in footprint-local
+             mm; transform to world coordinates the same way as pads).
              ``world_w``/``world_h`` account for pad rotation (KiCad 10
              stores pad rotation as absolute board-space CW+).
         """
@@ -337,6 +340,7 @@ def register_pcb_query_tools(mcp: FastMCP) -> None:
             "layer": layer,
             "properties": props,
             "pads": pads,
+            "edge_cuts": get_fp_edge_cuts_items(fp),
         }
 
     @mcp.tool()

--- a/kcaa/tools/pcb_routing_tools.py
+++ b/kcaa/tools/pcb_routing_tools.py
@@ -43,17 +43,17 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
         pad_b: str,
         net: str,
         ctx: Context | None,
-        layer: str = "F.Cu",
         width: float | None = None,
-        target_layer: str | None = None,
+        layer_hint: str | None = None,
         via_pairs: tuple[tuple[str, str], ...] | None = None,
+        turn_penalty: float | None = None,
     ) -> dict[str, Any]:
         """Connect two pads with an obstacle-avoiding track, optionally across layers.
 
         Uses the no-shove PNS router: if the path is blocked by an existing
         track or footprint courtyard, the call fails rather than moving
         anything.  Run the placement tools first to clear the way, or call
-        again with a different ``layer``.
+        again with a different ``layer_hint``.
 
         PCB coordinates: mm, +X right, **+Y down**, rotation
         **clockwise-positive** (KiCad PCB convention).
@@ -63,6 +63,11 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
         found).  Clearance is taken from the board's effective design rules
         (see :mod:`kcaa.utils.pcb_design_rules`).
 
+        Layer selection is automatic: SMD pads use their fixed layer;
+        thru-hole pads pick a shared copper layer, preferring
+        ``layer_hint``.  When both pads are thru-hole and share a layer,
+        the route stays on a single layer (no vias).
+
         Args:
             pcb_path: Absolute path to the .kicad_pcb file.
             ref_a: Reference designator of the first footprint (e.g. ``"R1"``).
@@ -71,16 +76,18 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
             pad_b: Pad number on ``ref_b``.
             net: Net name to assign to the new segments.
             ctx: MCP context (unused).
-            layer: Starting copper layer (``"F.Cu"`` by default).
             width: Override the netclass track width (mm).  ``None`` uses the
                 DRC default for the net.
-            target_layer: Destination copper layer.  When ``None`` (default)
-                the route stays on ``layer``.  When set, the router may
-                insert through-hole vias to reach the destination.
+            layer_hint: Preferred copper layer for thru-hole pads.  When
+                ``None`` (default) the router picks automatically.  Ignored
+                for SMD pads whose layer is fixed by the pad itself.
             via_pairs: Optional tuple of ``(from_layer, to_layer)`` pairs
                 the router is allowed to use as via transitions.  Defaults
-                to ``(("F.Cu", "B.Cu"),)`` when ``target_layer`` differs
-                from ``layer``; ignored otherwise.
+                to ``(("F.Cu", "B.Cu"),)`` when the resolved layers differ;
+                ignored otherwise.
+            turn_penalty: Cost added when the path changes direction (mm).
+                ``None`` uses the default (0.3 mm).  Set to 0 for pure
+                shortest-path routing (more zigzag).
 
         Returns:
             dict with:
@@ -96,9 +103,7 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
 
             Or ``{"error": "<message>"}`` on failure.
         """
-        if target_layer is None:
-            target_layer = layer
-        if via_pairs is None and target_layer != layer:
+        if via_pairs is None:
             via_pairs = (("F.Cu", "B.Cu"),)
         req = RouteRequest(
             pcb_path=pcb_path,
@@ -107,10 +112,10 @@ def register_pcb_routing_tools(mcp: FastMCP) -> None:
             ref_b=ref_b,
             pad_b=pad_b,
             net=net,
-            start_layer=layer,
-            end_layer=target_layer,
+            layer_hint=layer_hint,
             width=width,
             via_pairs=via_pairs or (),
+            turn_penalty=turn_penalty if turn_penalty is not None else 0.3,
         )
         try:
             result = auto_route_pair(req)

--- a/kcaa/utils/pcb_board_utils.py
+++ b/kcaa/utils/pcb_board_utils.py
@@ -415,3 +415,105 @@ def get_fp_courtyard_bbox(
         "width": round(max_x - min_x, 6),
         "height": round(max_y - min_y, 6),
     }
+
+
+# ---------------------------------------------------------------------------
+# Footprint Edge.Cuts graphic items
+# ---------------------------------------------------------------------------
+
+
+def get_fp_edge_cuts_items(fp_node: list[Any]) -> list[dict[str, Any]]:
+    """Return all ``fp_*`` graphic items on Edge.Cuts inside a footprint.
+
+    Scans the footprint's content items for ``fp_line``/``fp_rect``/
+    ``fp_arc``/``fp_circle``/``fp_curve`` whose layer is ``Edge.Cuts`` (or
+    the legacy ``Edge_Cuts`` spelling) and returns their geometry in
+    **footprint-local coordinates** (mm, same frame as pads' ``local_x``/
+    ``local_y``).  Transform to board world coordinates the same way as pads:
+    ``world = fp.(x,y) + rotation(local)`` (clockwise-positive, +Y down).
+
+    Additional keys depend on the item type, mirroring
+    :func:`get_edge_cuts_items`:
+
+    - ``fp_line`` / ``fp_rect``: ``x1``, ``y1``, ``x2``, ``y2``, ``width``
+    - ``fp_arc``: ``start_x``, ``start_y``, ``mid_x``, ``mid_y``,
+      ``end_x``, ``end_y``, ``width``
+    - ``fp_circle``: ``cx``, ``cy``, ``ex``, ``ey``, ``width``
+      (``(end ...)`` is a point on the circumference as stored by KiCad)
+    - ``fp_curve``: ``pts`` (list of ``(x, y)`` tuples), ``width``
+
+    :param fp_node: A footprint S-expression list node — i.e. the list of
+        content items such as a placed footprint found via ``find_footprint``
+        or the parsed children of a ``.kicad_mod`` file.
+    :returns: List of graphic-item dicts on the footprint's Edge.Cuts layer.
+    """
+
+    def _stroke_width(node: list[Any]) -> float | None:
+        """Return the stroke width of a graphic node, or None."""
+        for sub in node:
+            if isinstance(sub, list) and _sym(sub[0]) == "stroke":
+                for ssub in sub:
+                    if isinstance(ssub, list) and len(ssub) >= 2 and _sym(ssub[0]) == "width":
+                        return float(ssub[1])
+            elif isinstance(sub, list) and len(sub) >= 2 and _sym(sub[0]) == "width":
+                return float(sub[1])
+        return None
+
+    result: list[dict[str, Any]] = []
+    for item in fp_node:
+        if not (isinstance(item, list) and len(item) > 0):
+            continue
+        kind = _sym(item[0])
+        if kind not in _FP_GRAPHIC_TYPES:
+            continue
+        layer = _get_layer(item)
+        if not _is_edge_cuts(layer):
+            continue
+
+        info: dict[str, Any] = {"type": kind, "layer": layer}
+
+        if kind in ("fp_line", "fp_rect"):
+            for sub in item:
+                if isinstance(sub, list) and len(sub) >= 3:
+                    k = _sym(sub[0])
+                    if k == "start":
+                        info["x1"], info["y1"] = float(sub[1]), float(sub[2])
+                    elif k == "end":
+                        info["x2"], info["y2"] = float(sub[1]), float(sub[2])
+
+        elif kind == "fp_arc":
+            for sub in item:
+                if isinstance(sub, list) and len(sub) >= 3:
+                    k = _sym(sub[0])
+                    if k == "start":
+                        info["start_x"], info["start_y"] = float(sub[1]), float(sub[2])
+                    elif k == "mid":
+                        info["mid_x"], info["mid_y"] = float(sub[1]), float(sub[2])
+                    elif k == "end":
+                        info["end_x"], info["end_y"] = float(sub[1]), float(sub[2])
+
+        elif kind == "fp_circle":
+            for sub in item:
+                if isinstance(sub, list) and len(sub) >= 3:
+                    k = _sym(sub[0])
+                    if k == "center":
+                        info["cx"], info["cy"] = float(sub[1]), float(sub[2])
+                    elif k == "end":
+                        info["ex"], info["ey"] = float(sub[1]), float(sub[2])
+
+        elif kind == "fp_curve":
+            pts: list[tuple[float, float]] = []
+            for sub in item:
+                if not (isinstance(sub, list) and _sym(sub[0]) == "pts"):
+                    continue
+                for pt in sub[1:]:
+                    if isinstance(pt, list) and len(pt) >= 3 and _sym(pt[0]) == "xy":
+                        pts.append((float(pt[1]), float(pt[2])))
+            if pts:
+                info["pts"] = pts
+
+        width = _stroke_width(item)
+        if width is not None:
+            info["width"] = width
+        result.append(info)
+    return result

--- a/kcaa/utils/pcb_library_utils.py
+++ b/kcaa/utils/pcb_library_utils.py
@@ -16,6 +16,7 @@ from typing import Any
 import sexpdata
 
 from kcaa.utils.config import ServerConfig
+from kcaa.utils.pcb_board_utils import get_fp_edge_cuts_items
 
 log = logging.getLogger(__name__)
 
@@ -272,6 +273,7 @@ def parse_kicad_mod(path: str) -> dict[str, Any]:
         "has_3d_model": False,
         "pads": [],
         "courtyard_bbox": None,
+        "edge_cuts": [],
     }
 
     try:
@@ -317,6 +319,8 @@ def parse_kicad_mod(path: str) -> dict[str, Any]:
             "max_x": max(xs),
             "max_y": max(ys),
         }
+
+    result["edge_cuts"] = get_fp_edge_cuts_items(data)
 
     return result
 

--- a/kicad_plugin/__init__.py
+++ b/kicad_plugin/__init__.py
@@ -134,14 +134,7 @@ class KiCadAIPlugin(_ActionPluginBase):
             settings = PluginSettings.load()
             server_mgr = ServerManager(settings)
 
-            parent = None
-            if _IN_KICAD:
-                try:
-                    parent = _pcbnew.GetCurrentFrame()
-                except Exception as e:
-                    log.debug("Could not get KiCad parent frame: %s", e)
-
-            self._panel = AssistantPanel(parent, server_mgr=server_mgr, settings=settings)
+            self._panel = AssistantPanel(None, server_mgr=server_mgr, settings=settings)
             self._panel.Show()
             self._panel.Raise()
 

--- a/kicad_plugin/context_bridge.py
+++ b/kicad_plugin/context_bridge.py
@@ -7,9 +7,32 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+# KiCad window titles name project/board/schematic files, e.g.
+# "PCB Editor: /path/to/board.kicad_pcb [*]" or a .kicad_pro path.
+_TITLE_PROJECT_RE = re.compile(r"([^\s\[]+\.kicad_pro)\b")
+_TITLE_FRAME_RE = re.compile(r"([^\s\[]+\.kicad_(?:pcb|sch))\b")
+
+
+def project_path_from_title(title: str) -> str | None:
+    """Extract a ``.kicad_pro`` path from a KiCad window title, or None.
+
+    Editor windows title the active file (``.kicad_pcb`` / ``.kicad_sch``),
+    the project manager window may title the ``.kicad_pro`` itself.  When
+    only a board/schematic path is named, the sibling ``.kicad_pro`` is
+    derived and returned only if it actually exists.
+    """
+    for m in _TITLE_PROJECT_RE.finditer(title):
+        return os.path.abspath(m.group(1))
+    m = _TITLE_FRAME_RE.search(title)
+    if not m:
+        return None
+    pro = os.path.splitext(m.group(1))[0] + ".kicad_pro"
+    return os.path.abspath(pro) if os.path.exists(pro) else None
 
 
 def _try_import_pcbnew():

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -1237,13 +1237,18 @@ class LLMClient:
 
         self._emit_tool_callback(on_tool_call, tool_name, args, result)
 
+        # Mark the path dirty even when the tool call fails: a failed edit may
+        # still have partially modified the file (e.g. IPC routing tools), so
+        # the end-of-turn reload must still run — keeping the actual refresh
+        # consistent with the UI's refresh entry.
+        if policy.mark_dirty and path:
+            state.dirty_paths.add(path)
+
         if not self._tool_result_succeeded(result):
             return result
 
         if policy.track_snapshot and path:
             state.snapshotted_paths.add(path)
-        if policy.mark_dirty and path:
-            state.dirty_paths.add(path)
         if policy.clear_dirty_paths_arg:
             reload_paths = args.get(policy.clear_dirty_paths_arg, [])
             if isinstance(reload_paths, list):
@@ -1310,60 +1315,79 @@ class LLMClient:
             )
 
         state = _ToolExecutionState()
+        reply: str | None = None
+        is_final_text = False
 
-        for _ in range(20):  # max 20 iterations (guard against infinite loops)
-            response = self._call_llm(system, tools, on_text_delta=on_text_delta)
+        try:
+            for _ in range(20):  # max 20 iterations (guard against infinite loops)
+                response = self._call_llm(system, tools, on_text_delta=on_text_delta)
 
-            if response.get("error"):
-                return f"[LLM error] {response['error']}"
+                if response.get("error"):
+                    reply = f"[LLM error] {response['error']}"
+                    break
 
-            message = response.get("message", {})
-            tool_calls = message.get("tool_calls") or []
+                message = response.get("message", {})
+                tool_calls = message.get("tool_calls") or []
 
-            if not tool_calls:
-                # Final text response
-                text = message.get("content") or ""
-                reload_warning = self._auto_reload_modified_files(state, on_tool_call)
-                if reload_warning:
-                    text = (
-                        f"{text}\n\n[Framework warning] {reload_warning}"
-                        if text
-                        else f"[Framework warning] {reload_warning}"
+                if not tool_calls:
+                    # Final text response
+                    reply = message.get("content") or ""
+                    is_final_text = True
+                    break
+
+                # Execute tool calls
+                # Save message, preserving thinking content for DeepSeek models
+                msg_to_save = {"role": "assistant"}
+                if message.get("content"):
+                    msg_to_save["content"] = message["content"]
+                if message.get("reasoning_content"):
+                    msg_to_save["reasoning_content"] = message["reasoning_content"]
+                if message.get("tool_calls"):
+                    msg_to_save["tool_calls"] = message["tool_calls"]
+                self._history.append(msg_to_save)
+                tool_results = []
+                for tc in tool_calls:
+                    name = tc["function"]["name"]
+                    try:
+                        args = json.loads(tc["function"].get("arguments", "{}"))
+                    except json.JSONDecodeError:
+                        args = {}
+
+                    result = self._execute_tool_with_policy(name, args, state, on_tool_call)
+
+                    tool_results.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc["id"],
+                            "content": json.dumps(result),
+                        }
                     )
-                self._history.append({"role": "assistant", "content": text})
-                return text
 
-            # Execute tool calls
-            # Save message, preserving thinking content for DeepSeek models
-            msg_to_save = {"role": "assistant"}
-            if message.get("content"):
-                msg_to_save["content"] = message["content"]
-            if message.get("reasoning_content"):
-                msg_to_save["reasoning_content"] = message["reasoning_content"]
-            if message.get("tool_calls"):
-                msg_to_save["tool_calls"] = message["tool_calls"]
-            self._history.append(msg_to_save)
-            tool_results = []
-            for tc in tool_calls:
-                name = tc["function"]["name"]
-                try:
-                    args = json.loads(tc["function"].get("arguments", "{}"))
-                except json.JSONDecodeError:
-                    args = {}
-
-                result = self._execute_tool_with_policy(name, args, state, on_tool_call)
-
-                tool_results.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc["id"],
-                        "content": json.dumps(result),
-                    }
+                self._history.extend(tool_results)
+            else:
+                reply = (
+                    "[Error] Maximum tool-call iterations reached. Please try a simpler request."
+                )
+        finally:
+            # Single shared flush for every exit path (final reply, LLM error,
+            # iteration cap, or an escaping exception): keep the KiCad reload in
+            # sync with the UI refresh display even when tools or the LLM failed.
+            # Wrapped so a reload failure can never mask the turn's own result.
+            try:
+                reload_warning = self._auto_reload_modified_files(state, on_tool_call)
+            except Exception as e:
+                log.warning("Auto-reload at end of turn failed: %s", e)
+                reload_warning = None
+            if reload_warning and reply is not None:
+                reply = (
+                    f"{reply}\n\n[Framework warning] {reload_warning}"
+                    if reply
+                    else f"[Framework warning] {reload_warning}"
                 )
 
-            self._history.extend(tool_results)
-
-        return "[Error] Maximum tool-call iterations reached. Please try a simpler request."
+        if is_final_text:
+            self._history.append({"role": "assistant", "content": reply})
+        return reply if reply is not None else "[Error] Unknown failure."
 
     @staticmethod
     def _build_user_content(

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -855,6 +855,15 @@ class LLMClient:
         """Clear conversation history."""
         self._history = []
 
+    def set_base_url(self, url: str | None) -> None:
+        """Set the MCP backend base URL after construction.
+
+        The URL is only known once the backend has finished starting, which
+        may happen after the client is created (e.g. on panel display before
+        the backend came up).
+        """
+        self._mcp_base_url = url
+
     def get_history(self) -> list[dict[str, Any]]:
         """Return a copy of the conversation history for session persistence."""
         return list(self._history)

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -247,6 +247,211 @@ sys.stdout.write(json.dumps(result))
 sys.stdout.flush()
 """
 
+# Environment allowlist for plugin-venv subprocesses. KiCad's AppImage sets
+# PYTHONHOME/PYTHONPATH/LD_LIBRARY_PATH for its own embedded interpreter;
+# inheriting them would break the venv Python.
+_SUBPROCESS_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "XDG_RUNTIME_DIR",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Build a clean environment for plugin-venv subprocesses."""
+    return {k: os.environ[k] for k in _SUBPROCESS_ENV_ALLOWLIST if k in os.environ}
+
+
+# Subprocess SSE relay: read raw body bytes from stdin, perform the POST,
+# stream-parse the SSE response, and relay parsed deltas back over stdout.
+# Used when in-process SSL is unavailable so streaming still works with the
+# same per-read socket timeout as the in-process path.
+# Protocol (one JSON payload per line, whitespace-separated kind prefix):
+#   SSE-DATA  {"content": "..."}  text delta -> on_text_delta
+#   SSE-DONE  {"finish_reason": ..., "message": {...}}
+#   SSE-ERROR {"kind": "exception", "error": "..."} |
+#             {"status": <http_code>, "body": "..."} |
+#             {"kind": "stream", "error": "..."}
+_SUBPROCESS_SSE_SCRIPT = r"""
+import json, sys, urllib.request, urllib.error
+
+
+def emit(kind, payload):
+    sys.stdout.write("%s %s\n" % (kind, json.dumps(payload)))
+    sys.stdout.flush()
+
+
+try:
+    url = sys.argv[1]
+    headers = json.loads(sys.argv[2])
+    timeout = float(sys.argv[3])
+    fmt = sys.argv[4]
+    body = sys.stdin.buffer.read()
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if fmt == "anthropic":
+                text_blocks = {}
+                tool_blocks = {}
+                stop_reason = "end_turn"
+                current_event = ""
+                while True:
+                    raw = resp.readline()
+                    if raw == b"":
+                        break
+                    line = raw.decode("utf-8", "replace").rstrip("\r\n")
+                    if line.startswith("event:"):
+                        current_event = line[6:].strip()
+                        continue
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[5:].strip()
+                    try:
+                        event_data = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+                    etype = event_data.get("type", current_event)
+                    if etype == "content_block_start":
+                        idx = event_data.get("index", 0)
+                        block = event_data.get("content_block", {})
+                        btype = block.get("type")
+                        if btype == "text":
+                            text_blocks[idx] = block.get("text", "")
+                        elif btype == "tool_use":
+                            tool_blocks[idx] = {
+                                "id": block["id"],
+                                "name": block["name"],
+                                "input_json": "",
+                            }
+                    elif etype == "content_block_delta":
+                        idx = event_data.get("index", 0)
+                        delta = event_data.get("delta", {})
+                        dtype = delta.get("type")
+                        if dtype == "text_delta":
+                            chunk = delta.get("text", "")
+                            text_blocks[idx] = text_blocks.get(idx, "") + chunk
+                            if chunk:
+                                emit("SSE-DATA", {"content": chunk})
+                        elif dtype == "input_json_delta":
+                            partial = delta.get("partial_json", "")
+                            if idx in tool_blocks:
+                                tool_blocks[idx]["input_json"] += partial
+                    elif etype == "message_delta":
+                        sr = event_data.get("delta", {}).get("stop_reason")
+                        if sr:
+                            stop_reason = sr
+                    elif etype == "error":
+                        err = event_data.get("error", {})
+                        emit("SSE-ERROR", {"kind": "stream", "error": err.get("message", str(err))})
+                        sys.exit(0)
+                full_text = "\n".join(text_blocks[k] for k in sorted(text_blocks))
+                tool_calls = []
+                for k in sorted(tool_blocks):
+                    tb = tool_blocks[k]
+                    try:
+                        inp = json.loads(tb["input_json"]) if tb["input_json"] else {}
+                    except json.JSONDecodeError:
+                        inp = {}
+                    tool_calls.append({
+                        "id": tb["id"], "type": "function",
+                        "function": {"name": tb["name"], "arguments": json.dumps(inp)},
+                    })
+                message_out = {"content": full_text}
+                if tool_calls:
+                    message_out["tool_calls"] = tool_calls
+                finish = "tool_calls" if tool_calls else "stop"
+                if stop_reason == "max_tokens":
+                    finish = "stop"
+                emit("SSE-DONE", {"finish_reason": finish, "message": message_out})
+                sys.exit(0)
+
+            # fmt == "openai"
+            text_parts = []
+            tool_calls = {}
+            finish_reason = "stop"
+            reasoning = []
+            while True:
+                raw = resp.readline()
+                if raw == b"":
+                    break
+                line = raw.decode("utf-8", "replace").rstrip("\r\n")
+                if not line.startswith("data:"):
+                    continue
+                data_str = line[5:].strip()
+                if data_str == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+                choice = chunk.get("choices", [{}])[0]
+                fr = choice.get("finish_reason")
+                if fr is not None:
+                    finish_reason = fr
+                delta = choice.get("delta", {})
+                content = delta.get("content")
+                if content:
+                    text_parts.append(content)
+                    emit("SSE-DATA", {"content": content})
+                reasoning_part = delta.get("reasoning_content")
+                if reasoning_part:
+                    reasoning.append(reasoning_part)
+                for tc_delta in delta.get("tool_calls") or []:
+                    idx = tc_delta["index"]
+                    if idx not in tool_calls:
+                        tool_calls[idx] = {
+                            "id": "", "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        }
+                    tc = tool_calls[idx]
+                    if tc_delta.get("id"):
+                        tc["id"] += tc_delta["id"]
+                    fn = tc_delta.get("function", {})
+                    if fn.get("name"):
+                        tc["function"]["name"] += fn["name"]
+                    if fn.get("arguments"):
+                        tc["function"]["arguments"] += fn["arguments"]
+            tool_calls_list = [tool_calls[k] for k in sorted(tool_calls)]
+            message_out = {"content": "".join(text_parts)}
+            if tool_calls_list:
+                message_out["tool_calls"] = tool_calls_list
+            if reasoning:
+                message_out["reasoning_content"] = "".join(reasoning)
+            emit("SSE-DONE", {"finish_reason": finish_reason, "message": message_out})
+            sys.exit(0)
+    except urllib.error.HTTPError as e:
+        emit("SSE-ERROR", {"status": e.code, "body": e.read().decode("utf-8", "replace")})
+        sys.exit(0)
+    except Exception as e:
+        emit("SSE-ERROR", {"kind": "exception", "error": f"{type(e).__name__}: {e}"})
+        sys.exit(0)
+except Exception as e:
+    emit("SSE-ERROR", {"kind": "exception", "error": f"subprocess setup error: {type(e).__name__}: {e}"})
+    sys.exit(0)
+"""
+
 
 def _https_post_json(
     url: str,
@@ -290,35 +495,7 @@ def _https_post_json(
         )
 
     # Build a clean env using an explicit allowlist (mirrors ServerManager).
-    # KiCad's AppImage sets PYTHONHOME/PYTHONPATH/LD_LIBRARY_PATH for its own
-    # embedded interpreter; inheriting them would break the venv Python.
-    _ENV_ALLOWLIST = (
-        "PATH",
-        "HOME",
-        "USER",
-        "LOGNAME",
-        "LANG",
-        "LC_ALL",
-        "LC_CTYPE",
-        "TMPDIR",
-        "TEMP",
-        "TMP",
-        "XDG_RUNTIME_DIR",
-        "XDG_CONFIG_HOME",
-        "XDG_DATA_HOME",
-        "XDG_CACHE_HOME",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-        "http_proxy",
-        "https_proxy",
-        "no_proxy",
-        "SSL_CERT_FILE",
-        "SSL_CERT_DIR",
-        "REQUESTS_CA_BUNDLE",
-        "CURL_CA_BUNDLE",
-    )
-    clean_env = {k: os.environ[k] for k in _ENV_ALLOWLIST if k in os.environ}
+    clean_env = _subprocess_env()
 
     try:
         proc = subprocess.run(  # nosec B603 -- input is validated
@@ -345,6 +522,122 @@ def _https_post_json(
     if status == 0:
         raise RuntimeError(f"HTTPS request failed: {out.get('error', 'unknown error')}")
     return int(status), str(out.get("body", ""))
+
+
+def _subprocess_sse_stream(
+    url: str,
+    headers: dict[str, str],
+    payload: bytes,
+    timeout: float,
+    fmt: str,
+    on_text_delta: Callable[[str], None] | None,
+) -> dict[str, Any]:
+    """Stream an HTTP SSE response through the plugin-venv Python subprocess.
+
+    Mirrors the in-process streaming path when KiCad's embedded Python lacks
+    SSL: the subprocess owns the socket (its ``urlopen`` timeout is the same
+    per-read deadline as in-process), parses deltas, and relays them over
+    stdout via ``SSE-DATA`` / ``SSE-DONE`` / ``SSE-ERROR`` lines.
+
+    Returns the same shape as the in-process ``_stream_*`` methods, including
+    the ``{"error": ...}`` convention.
+    """
+    venv_python = _resolve_plugin_python()
+    if not venv_python:
+        return {
+            "error": (
+                "KiCad's embedded Python lacks SSL support and no plugin venv "
+                "Python was found. Run 'kicad_plugin/setup_plugin.sh' to create one."
+            )
+        }
+
+    proc = subprocess.Popen(  # nosec B603 -- input is validated
+        [
+            venv_python,
+            "-u",
+            "-I",
+            "-c",
+            _SUBPROCESS_SSE_SCRIPT,
+            url,
+            json.dumps(headers),
+            str(timeout),
+            fmt,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_subprocess_env(),
+    )
+    if proc.stdin is None or proc.stdout is None:
+        proc.kill()
+        return {"error": "HTTPS subprocess stream could not be started"}
+    try:
+        proc.stdin.write(payload)
+        proc.stdin.close()
+    except OSError as e:
+        proc.kill()
+        return {"error": f"HTTPS request failed: {e}"}
+
+    done: dict[str, Any] | None = None
+    error_result: dict[str, Any] | None = None
+    for raw in proc.stdout:
+        line = raw.decode("utf-8", "replace").rstrip("\r\n")
+        kind, _, body = line.partition(" ")
+        if kind == "SSE-DATA" and body:
+            try:
+                content = json.loads(body).get("content") or ""
+            except json.JSONDecodeError:
+                continue
+            if content and on_text_delta is not None:
+                try:
+                    on_text_delta(content)
+                except Exception as e:  # noqa: BLE001 -- UI callback errors must not kill the turn
+                    log.debug("Subprocess text delta callback error: %s", e)
+        elif kind == "SSE-DONE" and body:
+            try:
+                done = json.loads(body)
+            except json.JSONDecodeError as e:
+                return {"error": f"HTTPS subprocess returned invalid SSE-DONE: {e}"}
+        elif kind == "SSE-ERROR" and body:
+            try:
+                err = json.loads(body)
+            except json.JSONDecodeError:
+                error_result = {
+                    "error": f"HTTPS subprocess returned invalid SSE-ERROR: {body[:200]}"
+                }
+                break
+            if err.get("kind") == "exception":
+                error_result = {"error": f"HTTPS request failed: {err['error']}"}
+                break
+            status = err.get("status")
+            if status:
+                error_result = {"error": f"HTTP {status}: {err.get('body', '')[:200]}"}
+                break
+            error_result = {"error": f"HTTPS request failed: {err.get('error', 'unknown error')}"}
+            break
+
+    if error_result is not None:
+        return error_result
+    if done is None:
+        stderr_tail = ""
+        if proc.stderr is not None:
+            stderr_tail = proc.stderr.read().decode("utf-8", "replace")[:500]
+        return {
+            "error": "HTTPS subprocess stream ended unexpectedly "
+            f"(exit {proc.returncode}): {stderr_tail}"
+        }
+    try:
+        proc.wait(timeout=30)  # recycle; the relay exits right after SSE-DONE
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+    message: dict[str, Any] = {"content": (done.get("message") or {}).get("content", "")}
+    done_message = done.get("message") or {}
+    if done_message.get("tool_calls"):
+        message["tool_calls"] = done_message["tool_calls"]
+    if done_message.get("reasoning_content"):
+        message["reasoning_content"] = done_message["reasoning_content"]
+    return {"finish_reason": done.get("finish_reason", "stop"), "message": message}
 
 
 # ---------------------------------------------------------------------------
@@ -1686,19 +1979,14 @@ class LLMClient:
                 if _NO_HTTPS_MARKER not in str(e.reason):
                     return {"error": f"HTTPS request failed: {e}"}
                 _in_process_ssl = False
-                # Fall through to non-streaming fallback below.
+                # Fall through to subprocess streaming below.
             except Exception as e:
                 return {"error": f"Streaming request failed: {e}"}
 
-        # In-process SSL unavailable: fall back to non-streaming via subprocess.
-        result = self._call_openai(system, tools)
-        content = result.get("message", {}).get("content", "")
-        if content:
-            try:
-                on_text_delta(content)
-            except Exception as e:
-                log.debug("Non-streaming callback error: %s", e)
-        return result
+        # In-process SSL unavailable: stream via the plugin-venv Python subprocess.
+        return _subprocess_sse_stream(
+            url, headers, payload, timeout=300, fmt="openai", on_text_delta=on_text_delta
+        )
 
     def _ollama_messages(self) -> list[dict[str, Any]]:
         """Convert self._history to Ollama /api/chat message format.
@@ -1961,19 +2249,14 @@ class LLMClient:
                 if _NO_HTTPS_MARKER not in str(e.reason):
                     return {"error": f"HTTPS request failed: {e}"}
                 _in_process_ssl = False
-                # Fall through to non-streaming fallback below.
+                # Fall through to subprocess streaming below.
             except Exception as e:
                 return {"error": f"Streaming request failed: {e}"}
 
-        # In-process SSL unavailable: fall back to non-streaming via subprocess.
-        result = self._call_anthropic(system, tools)
-        content = result.get("message", {}).get("content", "")
-        if content:
-            try:
-                on_text_delta(content)
-            except Exception as e:
-                log.debug("Non-streaming callback error: %s", e)
-        return result
+        # In-process SSL unavailable: stream via the plugin-venv Python subprocess.
+        return _subprocess_sse_stream(
+            url, headers, encoded, timeout=300, fmt="anthropic", on_text_delta=on_text_delta
+        )
 
     def _call_openai(self, system: str, tools: list[dict]) -> dict[str, Any]:
         base = (self._settings.llm_base_url or "https://api.openai.com").rstrip("/")
@@ -2000,7 +2283,7 @@ class LLMClient:
             "Authorization": f"Bearer {self._settings.llm_api_key}",
         }
         try:
-            status, text = _https_post_json(url, headers, payload, timeout=60)
+            status, text = _https_post_json(url, headers, payload, timeout=300)
         except RuntimeError as e:
             return {"error": str(e)}
 
@@ -2043,7 +2326,7 @@ class LLMClient:
         headers = {"Content-Type": "application/json"}
 
         try:
-            status, text = _https_post_json(url, headers, payload, timeout=60)
+            status, text = _https_post_json(url, headers, payload, timeout=300)
         except RuntimeError as e:
             return {"error": str(e)}
 
@@ -2103,7 +2386,7 @@ class LLMClient:
             "anthropic-version": "2023-06-01",
         }
         try:
-            status, text = _https_post_json(url, headers, encoded, timeout=60)
+            status, text = _https_post_json(url, headers, encoded, timeout=300)
         except RuntimeError as e:
             return {"error": str(e)}
 

--- a/kicad_plugin/session_store.py
+++ b/kicad_plugin/session_store.py
@@ -1,0 +1,217 @@
+"""Session persistence for the KiCad AI Assistant (schema v2).
+
+Schema history
+--------------
+v1 (original)::
+
+    {"version": 1, "title", "timestamp", "conv_entries", "llm_history"}
+
+v2 (project-scoped): adds ``project_path`` — the absolute path of the
+``.kicad_pro`` the session was created in, or ``None`` when no project was
+open at save time::
+
+    {"version": 2, "project_path", "title", "timestamp",
+     "conv_entries", "llm_history"}
+
+Project scoping rules
+---------------------
+- A v2 session is owned by exactly one project (``project_path``).
+- A v1 file (missing ``project_path``) is *legacy*: it must never be
+  auto-restored into a project, and is not offered in project-scoped lookups.
+  It stays loadable via the manual Load Session dialog in the UI.
+- ``current.json`` (symlink or plain-text fallback) points at the most
+  recently active session file regardless of project; the caller decides
+  whether the pointed session belongs to the open project.
+"""
+
+from __future__ import annotations
+
+import datetime
+import glob
+import json
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 2
+
+SESSIONS_DIRNAME = "kicad_ai_sessions"
+CURRENT_LINK_NAME = "current.json"
+SESSION_PREFIX = "session_"
+SESSION_SUFFIX = ".json"
+SESSION_GLOB = SESSION_PREFIX + "*" + SESSION_SUFFIX
+
+
+def sessions_dir(config_dir: str) -> str:
+    """Directory holding session files under the kcaa config dir."""
+    return os.path.join(config_dir, SESSIONS_DIRNAME)
+
+
+def current_link_path(config_dir: str) -> str:
+    """Path of the current.json pointer file."""
+    return os.path.join(sessions_dir(config_dir), CURRENT_LINK_NAME)
+
+
+def resolve_current_session(config_dir: str) -> str | None:
+    """Resolve current.json to a session file path, or None.
+
+    Handles both the symlink form and the plain-text fallback.  A dangling
+    symlink or a pointer to a missing file resolves to None.
+    """
+    link = current_link_path(config_dir)
+    if not os.path.exists(link):
+        return None
+    if os.path.islink(link):
+        target = os.readlink(link)
+        # readlink may return a relative path — resolve against the dir.
+        if not os.path.isabs(target):
+            target = os.path.join(sessions_dir(config_dir), target)
+        if os.path.isfile(target):
+            return target
+        return None
+    try:
+        with open(link, encoding="utf-8") as lf:
+            fname = lf.read().strip()
+        candidate = os.path.join(sessions_dir(config_dir), fname)
+        if os.path.isfile(candidate):
+            return candidate
+    except OSError:
+        pass
+    return None
+
+
+def load_session(path: str) -> tuple[dict | None, str | None]:
+    """Load a session file.
+
+    Returns (data, None) on success; (None, error) when the file is missing
+    or contains invalid JSON.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f), None
+    except (OSError, ValueError) as e:
+        return None, str(e)
+
+
+def session_project_path(session: dict | None) -> str | None:
+    """Project stamp of a session; None for legacy v1 files."""
+    if not session:
+        return None
+    return session.get("project_path")
+
+
+def is_project_session(session: dict | None, project_path: str | None) -> bool:
+    """True when *session* is v2-owned by exactly *project_path*.
+
+    Legacy v1 files (no project stamp) and a missing current project never
+    match, so they can never be auto-restored into a project.
+    """
+    return bool(project_path) and session_project_path(session) == project_path
+
+
+def list_session_files(config_dir: str) -> list[str]:
+    """All session files under the sessions dir, newest first."""
+    return sorted(
+        glob.glob(os.path.join(sessions_dir(config_dir), SESSION_GLOB)),
+        reverse=True,
+    )
+
+
+def list_project_sessions(config_dir: str, project_path: str | None) -> list[str]:
+    """Session files owned by *project_path*, newest first.
+
+    Legacy v1 sessions are never included.
+    """
+    if not project_path:
+        return []
+    return [
+        f
+        for f in list_session_files(config_dir)
+        if is_project_session(load_session(f)[0], project_path)
+    ]
+
+
+def list_loadable_sessions(config_dir: str, project_path: str | None) -> list[str]:
+    """Sessions offered in the Load dialog: current project's plus unowned.
+
+    Unowned = legacy v1 files (no project stamp) and v2 files saved with no
+    project open.  Other projects' sessions are hidden so a session can never
+    be picked into the wrong project.  Current project's sessions come first,
+    then unowned — each group newest first.
+    """
+    own = list_project_sessions(config_dir, project_path) if project_path else []
+    unowned = [
+        f for f in list_session_files(config_dir) if not session_project_path(load_session(f)[0])
+    ]
+    return own + unowned
+
+
+def session_title(conv_entries: list[dict]) -> str:
+    """First user message text (truncated), or the default title."""
+    return next((e["text"][:60] for e in conv_entries if e["type"] == "user"), "session")
+
+
+def make_payload(
+    conv_entries: list[dict],
+    llm_history: list,
+    project_path: str | None,
+) -> dict:
+    """Build the on-disk schema v2 payload for a session."""
+    return {
+        "version": SCHEMA_VERSION,
+        "project_path": project_path,
+        "title": session_title(conv_entries),
+        "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+        "conv_entries": conv_entries,
+        "llm_history": llm_history,
+    }
+
+
+def save_session(config_dir: str, filename: str, payload: dict) -> str | None:
+    """Write *payload* to sessions_dir/filename with owner-only perms.
+
+    Returns an error string on failure, None on success.
+    """
+    sessions = sessions_dir(config_dir)
+    try:
+        os.makedirs(sessions, exist_ok=True)
+    except OSError as e:
+        return str(e)
+    path = os.path.join(sessions, filename)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, default=str)
+    except OSError as e:
+        return str(e)
+    return None
+
+
+def update_current_link(config_dir: str, filename: str) -> None:
+    """Atomically point current.json at *filename* (basename).
+
+    Uses a symlink when possible (POSIX); falls back to a plain-text pointer
+    file when symlinks are unavailable (e.g. Windows without privilege).
+    """
+    link = current_link_path(config_dir)
+    tmp_link = link + ".tmp"
+    try:
+        os.symlink(filename, tmp_link)
+        os.replace(tmp_link, link)
+    except Exception:
+        try:
+            with open(link, "w", encoding="utf-8") as lf:
+                lf.write(filename)
+        except Exception as e:
+            log.debug("Could not write session file link: %s", e)
+
+
+def remove_current_link(config_dir: str) -> None:
+    """Remove current.json (both symlink and plain-text variants)."""
+    link = current_link_path(config_dir)
+    try:
+        if os.path.lexists(link):  # lexists catches dangling symlinks too
+            os.remove(link)
+    except OSError:
+        pass

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -91,6 +91,9 @@ if _WX_AVAILABLE:
             self._server_mgr = server_mgr
             self._settings = settings
             self._llm_client: Any | None = None
+            # True once the MCP backend reported a successful start; the LLM
+            # client is only created when this and panel display both hold.
+            self._server_ready: bool = False
             self._busy = False
             # threading.Event for cancelling an in-progress LLM turn
             self._cancel_event: threading.Event | None = None
@@ -148,6 +151,15 @@ if _WX_AVAILABLE:
             # glitch on Windows), reset _page_loading so renders are not
             # permanently blocked.
             self._page_watchdog = wx.Timer(self)
+            # Project-scoped session watch: tracks the open KiCad project so
+            # switching projects can re-offer that project's saved sessions
+            # (same flow as startup auto-restore). Started by _init_llm_client.
+            self._active_project: str | None = None
+            # Project-switch confirmation: first differing reading is held
+            # here and only acted on when the next tick agrees.
+            self._watch_candidate: str | None = None
+            self._watch_candidate_seen: bool = False
+            self._project_watch_timer = wx.Timer(self)
 
             self._build_ui()
             self._start_server()
@@ -396,6 +408,9 @@ if _WX_AVAILABLE:
                 style=wx.BU_EXACTFIT | wx.BORDER_NONE,
             )
             self._send_btn.SetToolTip("Send message (Enter)")
+            # Backend not ready until _on_server_started(True); the button is
+            # enabled there, not clickable while the backend is down.
+            self._send_btn.Disable()
             side_vbox.Add(self._send_btn, 0, wx.ALIGN_CENTER_HORIZONTAL)
 
             hbox.Add(side_vbox, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 4)
@@ -483,6 +498,8 @@ if _WX_AVAILABLE:
             # glitch on Windows), reset _page_loading so renders are not
             # permanently blocked.
             self.Bind(wx.EVT_TIMER, self._on_page_watchdog, self._page_watchdog)
+            self.Bind(wx.EVT_TIMER, self._on_project_watch_tick, self._project_watch_timer)
+            self.Bind(wx.EVT_SHOW, self._on_panel_show)
 
         # ------------------------------------------------------------------ #
         # Server lifecycle
@@ -501,14 +518,21 @@ if _WX_AVAILABLE:
                 if ok:
                     self._set_status("✅ Backend ready", self._C_OK)
                     self.GetMenuBar().Enable(self._menu_autoroute_id, True)
-                    self._init_llm_client()
                     self._check_kicad_ipc_environment()
                     self._auto_save_pcb_on_open()
+                    self._server_ready = True
+                    # The client captures the backend base URL at
+                    # construction; if it was created before the backend was
+                    # up (panel shown early), inject the URL now.
+                    if self._llm_client is not None:
+                        self._llm_client.set_base_url(self._server_mgr.base_url)
                 else:
+                    self._server_ready = False
                     self._set_status(
                         "❌ Backend failed to start — use Server → Restart Backend to retry",
                         self._C_ERR,
                     )
+                self._sync_send_button_state()
                 self.Layout()
             except Exception as e:
                 import traceback
@@ -521,10 +545,24 @@ if _WX_AVAILABLE:
 
                 self._llm_client = LLMClient(self._settings, self._server_mgr.base_url)
                 self._autoload_session()
+                self._start_project_watch()
             except Exception as e:
                 import traceback
 
                 log.error("_init_llm_client failed: %s\n%s", e, traceback.format_exc())
+
+        def _on_panel_show(self, event) -> None:
+            """Initialise the LLM client (and restore the session) on display.
+
+            Deferred from plugin registration so restore/prompt only happens
+            while the user looks at the panel.  The backend base URL is
+            injected later by _on_server_started once the backend is up, so
+            an early panel display is safe.  An already-initialised client
+            (e.g. after a backend Restart) is left untouched.
+            """
+            if event.IsShown() and self._llm_client is None:
+                self._init_llm_client()
+            event.Skip()
 
         # ------------------------------------------------------------------ #
         # KiCad IPC API status check
@@ -678,6 +716,9 @@ if _WX_AVAILABLE:
                     self._llm_client is not None,
                 )
                 return
+            if not self._server_ready:
+                log.debug("_on_send: skipped (backend not ready)")
+                return
             text = self._input.GetValue().strip()
             images = self._encode_attached_images()
             pdfs = [p for p, t in self._attached_files if t == "pdf"]
@@ -723,12 +764,13 @@ if _WX_AVAILABLE:
             self._attached_files.clear()
             self._refresh_attachments_bar()
             self._follow_output_to_bottom = True
-            # Create the session file on the very first message so current.json
-            # is established before the AI responds.
-            if self._current_session_file is None:
-                err = self._save_session_to_disk()
-                if err:
-                    log.warning("Could not create session file: %s", err)
+            # Persist on every user message: creates the file on the first
+            # message (so current.json exists before the AI responds) and makes
+            # the session durable immediately (also upgrading legacy v1 files
+            # to v2, since the user has now modified the session).
+            err = self._save_session_to_disk()
+            if err:
+                log.warning("Could not save session: %s", err)
             self._render_conversation(force_scroll_to_bottom=True)
             self._busy = True
             self._cancel_event = threading.Event()
@@ -961,6 +1003,13 @@ if _WX_AVAILABLE:
             else:
                 self._send_btn.SetBitmap(self._make_send_bitmap(bg=bg))
                 self._send_btn.SetToolTip("Send message (Enter)")
+
+        def _sync_send_button_state(self) -> None:
+            """Enable the send button unless the backend is not ready.
+
+            A busy button is the Stop button and must stay clickable.
+            """
+            self._send_btn.Enable(self._server_ready or self._busy)
 
         def _on_send_btn(self, event) -> None:
             """Handle send/stop button click depending on current state."""
@@ -1374,6 +1423,12 @@ if _WX_AVAILABLE:
             if self._tool_calls_made:
                 self._auto_refresh(ctx)
             self._follow_output_to_bottom = False
+            # Persist the completed turn so disk always holds the full
+            # conversation, including the streamed AI reply. On-exit autosave
+            # then only refreshes — no data depends on it.
+            err = self._save_session_to_disk()
+            if err:
+                log.warning("Could not save session after reply: %s", err)
 
         def _on_stream_flush(self, event) -> None:
             """Drain the streaming buffer into the pending AI text (main thread, timer-driven)."""
@@ -1591,6 +1646,11 @@ if _WX_AVAILABLE:
             self._busy = False
             self._cancel_event = None
             self._toggle_send_stop(busy=False)
+            # Persist what has been finalised so far — the turn was cancelled
+            # mid-flight and on-exit autosave is best-effort only.
+            err = self._save_session_to_disk()
+            if err:
+                log.warning("Could not save session after stop: %s", err)
 
         def _on_restart(self, event) -> None:
             if self._busy:
@@ -1601,6 +1661,9 @@ if _WX_AVAILABLE:
                 )
                 return
             self._set_status("⏳ Restarting backend…", self._C_WARN)
+            # Messages are blocked while the backend is down.
+            self._server_ready = False
+            self._sync_send_button_state()
             self._conv_entries.append(
                 {
                     "type": "status",
@@ -1626,6 +1689,9 @@ if _WX_AVAILABLE:
                     }
                 )
                 self._render_conversation()
+                # Rebuild the LLM client: the backend may have come back on a
+                # new port, so the old client's base URL is stale.  Session
+                # restore here is lossless — disk holds every completed turn.
                 self._init_llm_client()
                 self._on_server_started(True)
             else:
@@ -2084,9 +2150,6 @@ if _WX_AVAILABLE:
         # Session persistence
         # ------------------------------------------------------------------ #
 
-        def _sessions_dir(self) -> str:
-            return os.path.join(self._settings.config_dir, "kicad_ai_sessions")
-
         def _on_new_session(self, event) -> None:
             """Save the current session (if non-empty) then clear to start a new one."""
             if self._busy:
@@ -2115,7 +2178,9 @@ if _WX_AVAILABLE:
                 self._llm_client.reset()
 
             # Remove current.json so a blank close won't restore the old session.
-            self._remove_current_link()
+            from .. import session_store as _sstore
+
+            _sstore.remove_current_link(self._settings.config_dir)
 
             self._set_status(
                 "✅ New session started" + (" (previous session saved)" if has_content else ""),
@@ -2123,17 +2188,12 @@ if _WX_AVAILABLE:
             )
             self.Layout()
 
-        def _remove_current_link(self) -> None:
-            """Remove current.json (both symlink and plain-text variants)."""
-            link = os.path.join(self._sessions_dir(), "current.json")
-            try:
-                if os.path.lexists(link):  # lexists catches dangling symlinks too
-                    os.remove(link)
-            except OSError as e:
-                log.warning("Could not remove current.json: %s", e)
-
         def _save_session_to_disk(self) -> str | None:
             """Write current conv_entries + history to disk and update current.json.
+
+            Sessions are stamped with the currently open KiCad project
+            (schema v2), so a session never silently leaks into a different
+            project.  The stamp reflects the project active at save time.
 
             If ``_current_session_file`` is already set the existing file is
             overwritten; otherwise a new timestamped file is created and
@@ -2141,65 +2201,31 @@ if _WX_AVAILABLE:
 
             Returns an error string on failure, None on success.
             """
-            import datetime
-            import json as _json
+            from .. import session_store as _sstore
 
-            sessions_dir = self._sessions_dir()
-            try:
-                os.makedirs(sessions_dir, exist_ok=True)
-            except OSError as e:
-                return str(e)
-
-            title = next(
-                (e["text"][:60] for e in self._conv_entries if e["type"] == "user"),
-                "session",
-            )
             if self._current_session_file:
                 filename = self._current_session_file
             else:
                 ts = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
                 filename = f"session_{ts}.json"
                 self._current_session_file = filename
-            path = os.path.join(sessions_dir, filename)
-            data = {
-                "version": 1,
-                "title": title,
-                "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
-                "conv_entries": self._conv_entries,
-                "llm_history": (
+            payload = _sstore.make_payload(
+                self._conv_entries,
+                (
                     _strip_images_from_history(self._llm_client.get_history())
                     if self._llm_client
                     else []
                 ),
-            }
-            try:
-                fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    _json.dump(data, f, indent=2, default=str)
-            except OSError as e:
-                return str(e)
-
-            self._update_current_link(filename)
+                self._collect_active_project(),
+            )
+            err = _sstore.save_session(self._settings.config_dir, filename, payload)
+            if err:
+                return err
+            _sstore.update_current_link(self._settings.config_dir, filename)
             return None
 
-        def _update_current_link(self, filename: str) -> None:
-            """Atomically update current.json to point at *filename* (basename)."""
-            sessions_dir = self._sessions_dir()
-            link = os.path.join(sessions_dir, "current.json")
-            tmp_link = link + ".tmp"
-            try:
-                os.symlink(filename, tmp_link)
-                os.replace(tmp_link, link)
-            except Exception:
-                try:
-                    with open(link, "w", encoding="utf-8") as lf:
-                        lf.write(filename)
-                except Exception as e:
-                    log.debug("Could not write session file link: %s", e)
-
         def _on_load_session(self, event) -> None:
-            import glob
-            import json as _json
+            from .. import session_store as _sstore
 
             if self._busy:
                 wx.MessageBox(
@@ -2209,28 +2235,28 @@ if _WX_AVAILABLE:
                 )
                 return
 
-            sessions_dir = self._sessions_dir()
-            files = sorted(
-                glob.glob(os.path.join(sessions_dir, "session_*.json")),
-                reverse=True,
+            files = _sstore.list_loadable_sessions(
+                self._settings.config_dir, self._collect_active_project()
             )
             if not files:
                 wx.MessageBox(
-                    "No saved sessions found.", "Load Session", wx.OK | wx.ICON_INFORMATION
+                    "No saved sessions found for the current project.",
+                    "Load Session",
+                    wx.OK | wx.ICON_INFORMATION,
                 )
                 return
 
             # Build display labels
             labels = []
             for f in files:
-                try:
-                    with open(f, encoding="utf-8") as fh:
-                        d = _json.load(fh)
-                    ts = d.get("timestamp", "")[:19].replace("T", " ")
-                    title = d.get("title", "")[:50]
-                    labels.append(f"{ts}  —  {title}")
-                except Exception:
+                d, _ = _sstore.load_session(f)
+                if d is None:
                     labels.append(os.path.basename(f))
+                    continue
+                ts = d.get("timestamp", "")[:19].replace("T", " ")
+                title = d.get("title", "")[:50]
+                suffix = "" if d.get("project_path") else "  [no project]"
+                labels.append(f"{ts}  —  {title}{suffix}")
 
             dlg = wx.SingleChoiceDialog(
                 self,
@@ -2243,14 +2269,21 @@ if _WX_AVAILABLE:
                 return
             idx = dlg.GetSelection()
             dlg.Destroy()
+            if 0 <= idx < len(files):
+                self._restore_session_file(files[idx])
 
-            chosen = files[idx]
-            try:
-                with open(chosen, encoding="utf-8") as fh:
-                    data = _json.load(fh)
-            except (OSError, _json.JSONDecodeError) as e:
-                wx.MessageBox(f"Could not load session:\n{e}", "Error", wx.OK | wx.ICON_ERROR)
-                return
+        def _restore_session_file(self, path: str) -> bool:
+            """Load a saved session file into the panel and point current.json at it.
+
+            Returns True on success; shows an error dialog and returns False
+            when the file cannot be loaded.
+            """
+            from .. import session_store as _sstore
+
+            data, err = _sstore.load_session(path)
+            if data is None:
+                wx.MessageBox(f"Could not load session:\n{err}", "Error", wx.OK | wx.ICON_ERROR)
+                return False
 
             # Restore state
             self._stream_timer.Stop()
@@ -2260,11 +2293,147 @@ if _WX_AVAILABLE:
             if self._llm_client:
                 self._llm_client.set_history(data.get("llm_history", []))
             # Track which file is now active; point current.json at it.
-            self._current_session_file = os.path.basename(chosen)
-            self._update_current_link(self._current_session_file)
+            self._current_session_file = os.path.basename(path)
+            _sstore.update_current_link(self._settings.config_dir, self._current_session_file)
+
             self._render_conversation(force_scroll_to_bottom=True)
             self._set_status("✅ Session restored", self._C_OK)
             self.Layout()
+            return True
+
+        def _collect_active_project(self) -> str | None:
+            """Absolute path of the currently open .kicad_pro, or None.
+
+            Primary source: pcbnew.GetBoard() — only non-empty once a board
+            is loaded in the PCB Editor.  Fallback: KiCad top-level window
+            titles, which name the project/board/schematic path even while
+            GetBoard() is still settling (e.g. right after opening a project
+            or when only the project manager is open).
+            """
+            try:
+                from ..context_bridge import collect_context, project_path_from_title
+
+                proj = collect_context().get("active_project")
+                if proj:
+                    return proj
+                for w in wx.GetTopLevelWindows():
+                    title = w.GetTitle()
+                    if not title:
+                        continue
+                    p = project_path_from_title(title)
+                    if p:
+                        log.debug("project from window title %r -> %s", title, p)
+                        return p
+            except Exception:
+                log.debug("_collect_active_project failed", exc_info=True)
+            return None
+
+        def _start_project_watch(self) -> None:
+            """Start polling for KiCad project switches (1 s interval).
+
+            The first snapshot is taken here — after auto-restore — so the
+            watcher only reacts to *later* project changes, never to the
+            project already active at startup.
+            """
+            if not self._project_watch_timer:
+                return
+            self._active_project = self._collect_active_project()
+            self._watch_candidate_seen = False
+            self._project_watch_timer.Start(
+                1000
+            )  # 1 s poll: project switch is noticed quickly once a board signal is available
+
+        def _on_project_watch_tick(self, event) -> None:
+            """Close this panel when the open KiCad project changes.
+
+            The panel binds to the project that was active at startup; when
+            the project switches (or the board/project is closed), this
+            instance is stale.  Tear it down — including its MCP server —
+            instead of lingering; the panel opened in the new project
+            auto-restores the right session on first display.
+
+            The project signal flaps during project load (GetBoard() stays
+            empty until the board is up, and the window-title fallback is
+            equally transient), so a switch is only acted on after two
+            consecutive identical readings.
+            """
+            if self._busy:
+                return
+            project = self._collect_active_project()
+            if project == self._active_project:
+                self._watch_candidate_seen = False
+                return
+            if not self._watch_candidate_seen:
+                # First differing reading: remember it and wait for a second
+                # identical one before acting.
+                self._watch_candidate_seen = True
+                self._watch_candidate = project
+                return
+            if project != self._watch_candidate:
+                # Still flapping between values (project loading in
+                # background): re-arm with the latest reading.
+                self._watch_candidate = project
+                return
+            log.info(
+                "Project switch confirmed: %s -> %s; switching session",
+                self._active_project,
+                project,
+            )
+            self._active_project = project
+            self._watch_candidate_seen = False
+            # Keep this panel open and re-run the startup restore flow for
+            # the new project: matching current.json is restored in place,
+            # otherwise the new project's sessions are offered.  Never
+            # Destroy() the window — on a top-level wx.Frame that behaves as
+            # a forced Close and cascaded into closing KiCad's project
+            # windows.
+            self._autoload_session()
+
+        def _prompt_project_session_choice(self, project_path: str | None) -> None:
+            """Offer the open project's saved sessions after a skip.
+
+            Invoked when current.json cannot be auto-restored for the open
+            project — callers (auto-restore, project switch) check that first.
+            Candidates are the sessions stamped with *project_path*; a single
+            candidate is restored directly (a one-option dialog adds no
+            information), and the user may cancel a multi-candidate picker to
+            start blank.
+            """
+            from .. import session_store as _sstore
+
+            if not project_path:
+                return
+            candidates = _sstore.list_project_sessions(self._settings.config_dir, project_path)
+            log.info("Session picker for %s: %d candidate(s)", project_path, len(candidates))
+            if not candidates:
+                return
+            if len(candidates) == 1:
+                self._restore_session_file(candidates[0])
+                return
+
+            labels = []
+            for f in candidates:
+                d, _ = _sstore.load_session(f)
+                if d is None:
+                    labels.append(os.path.basename(f))
+                    continue
+                ts = d.get("timestamp", "")[:19].replace("T", " ")
+                title = d.get("title", "")[:50]
+                labels.append(f"{ts}  —  {title}")
+
+            dlg = wx.SingleChoiceDialog(
+                self,
+                "Saved sessions for this project found — restore one?",
+                "Restore Session",
+                labels,
+            )
+            if dlg.ShowModal() != wx.ID_OK:
+                dlg.Destroy()
+                return
+            idx = dlg.GetSelection()
+            dlg.Destroy()
+            if 0 <= idx < len(candidates):
+                self._restore_session_file(candidates[idx])
 
         def _on_clear(self, event) -> None:
             if self._busy:
@@ -2283,94 +2452,87 @@ if _WX_AVAILABLE:
                 self._llm_client.reset()
 
         def _on_close(self, event) -> None:
-            if event.CanVeto():
-                # User closed the plugin panel – hide it so the backend stays
-                # warm and KiCad is unaffected. The suicide watchdog timer
-                # (_on_suicide_check) will force-close us when KiCad itself
-                # exits, triggering the real teardown path below.
-                event.Veto()
-                self.Hide()
-                return
-            # Force-close (e.g. from _on_suicide_check when KiCad has exited)
-            # – tear down completely.
-            self._autosave_session()
+            """Panel close (user clicks X, or watchdog force-close): tear down
+            completely.
+
+            Every user message, AI reply and cancellation is persisted as it
+            happens, so closing loses nothing — the next open restores the
+            session from disk.  The panel is never merely hidden: a hidden
+            panel would keep its timers and MCP server running in the
+            background.  Either the panel stays usable (project switch keeps
+            it open and swaps the session) or it is destroyed — no
+            half-alive state.
+            """
+            if self._busy and self._cancel_event is not None:
+                # An in-flight turn ends with the panel: ask it to stop
+                # writing before we tear down.
+                self._cancel_event.set()
             self._server_mgr.stop()
             self.Destroy()
 
         def _on_suicide_check(self, event) -> None:
-            """Periodically check if KiCad is gone. If we are the only
-            visible top-level wx window left, KiCad's main window must
-            have been closed without sending us EVT_CLOSE — so close
-            ourselves now."""
-            others = [w for w in wx.GetTopLevelWindows() if w is not self and w.IsShown()]
+            """Periodically check if KiCad is gone.
+
+            If the only visible top-level wx windows left are our own plugin
+            panels — including any other AssistantPanel instances (a second
+            panel must not count as a reason to stay alive) — KiCad's own
+            windows are all gone, so close ourselves.  Any non-panel window
+            (project manager, editors, dialogs) keeps us alive.
+            """
+            others = [
+                w
+                for w in wx.GetTopLevelWindows()
+                if not isinstance(w, AssistantPanel) and w.IsShown()
+            ]
             if not others:
                 self.Close(force=True)
 
         def _on_destroy(self, event) -> None:
             """Called when the wx window is actually destroyed (e.g. KiCad shutdown)."""
             if event.GetEventObject() is self:
-                self._autosave_session()
+                if self._project_watch_timer is not None:
+                    self._project_watch_timer.Stop()
                 self._server_mgr.stop()
             event.Skip()
 
         # ------------------------------------------------------------------ #
-        # Auto-save / auto-load
+        # Auto-load
         # ------------------------------------------------------------------ #
-
-        def _autosave_session(self) -> None:
-            """Save a timestamped session file on every close.
-
-            Also atomically updates the ``current.json`` symlink in the sessions
-            directory so the next startup can load it directly without globbing.
-            """
-            # Only save if there is real conversational content — skip sessions
-            # that only contain status/warning notices.
-            if not any(e["type"] in ("user", "ai") for e in self._conv_entries):
-                return
-            err = self._save_session_to_disk()
-            if err:
-                log.warning("Auto-save failed: %s", err)
 
         def _autoload_session(self) -> None:
             """Restore the session pointed to by ``current.json`` on startup.
 
+            Project-aware since schema v2: a session is auto-restored only
+            when it belongs to the currently open KiCad project.  Legacy v1
+            sessions (no project stamp) and sessions saved in other projects
+            are skipped; if the open project has sessions of its own, the
+            user is asked to pick one.
+
             Only follows current.json — no glob fallback. This ensures "New
             Session" (which removes current.json) always starts blank.
+
+            Runs when the LLM client is initialised — on first panel display, or
+            after a manual backend Restart.  Since every turn is persisted as
+            it completes (send/reply/stop), the disk snapshot is always the
+            newest completed state, and restoring it is lossless.
             """
-            import json as _json
+            from .. import session_store as _sstore
 
-            sessions_dir = self._sessions_dir()
-            link = os.path.join(sessions_dir, "current.json")
-            path: str | None = None
-
-            if os.path.exists(link):
-                # Resolve: may be a real symlink or the plain-text fallback.
-                if os.path.islink(link):
-                    target = os.readlink(link)
-                    # readlink may return a relative path — resolve against dir.
-                    if not os.path.isabs(target):
-                        target = os.path.join(sessions_dir, target)
-                    if os.path.isfile(target):
-                        path = target
-                else:
-                    # Plain-text pointer written by the symlink fallback.
-                    try:
-                        with open(link, encoding="utf-8") as lf:
-                            fname = lf.read().strip()
-                        candidate = os.path.join(sessions_dir, fname)
-                        if os.path.isfile(candidate):
-                            path = candidate
-                    except OSError:
-                        pass
-
+            path = _sstore.resolve_current_session(self._settings.config_dir)
             if path is None:
                 return  # No current.json and no sessions dir — blank start.
 
-            try:
-                with open(path, encoding="utf-8") as f:
-                    data = _json.load(f)
-            except (OSError, _json.JSONDecodeError) as e:
-                log.warning("Auto-load failed: %s", e)
+            data, err = _sstore.load_session(path)
+            if data is None:
+                log.warning("Auto-load failed: %s (%s)", path, err)
+                return
+
+            current_project = self._collect_active_project()
+
+            # Legacy v1 sessions and sessions of other projects must not leak
+            # into the open project — skip and offer project sessions instead.
+            if not _sstore.is_project_session(data, current_project):
+                self._prompt_project_session_choice(current_project)
                 return
 
             conv = data.get("conv_entries", [])

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -127,12 +127,14 @@ if _WX_AVAILABLE:
             # True once the shell HTML (CSS + JS framework + empty containers)
             # has been successfully loaded into the WebView.
             self._shell_loaded: bool = False
-            # True while any RunScript call is in-flight.  On Windows WebView2,
-            # RunScript pumps the message loop; we guard against re-entrant
-            # RunScript calls with this flag.
+            # True while any WebView script is in-flight.  On Windows WebView2,
+            # RunScript pumps the message loop; re-entrant RunScript calls are
+            # guarded by _run_script, the only place that writes this flag.
             self._js_running: bool = False
-            # Set when a render is skipped (due to shell not loaded or
-            # _js_running).  The next opportunity triggers a deferred render.
+            # Set when a render is skipped (script in flight / shell not
+            # loaded / page loading).  Flushed as a full-conversation rebuild
+            # by whoever releases the render lock, or by the shell-load
+            # completion path.
             self._render_pending: bool = False
             # True when the stream-wrapper table is visible in the shell.
             self._stream_wrapper_visible: bool = False
@@ -740,6 +742,7 @@ if _WX_AVAILABLE:
             # Reset streaming state and start the flush timer
             self._stream_buffer.clear()
             self._pending_ai_text = ""
+            self._stream_delta_chars = 0
             self._tool_calls_made = False
             self._schematic_edited = False
             self._pcb_edited = False
@@ -750,8 +753,12 @@ if _WX_AVAILABLE:
             def _on_delta(chunk: str) -> None:
                 # Called from background thread — just push to buffer; timer handles UI
                 if self._cancel_event and self._cancel_event.is_set():
+                    if not state.get("cancel_dropped"):
+                        state["cancel_dropped"] = True
+                        log.debug("chat: dropping streamed chunks after cancel")
                     return
                 state["ai_turn_started"] = True
+                self._stream_delta_chars += len(chunk)
                 self._stream_buffer.append(chunk)
 
             def _run():
@@ -1314,6 +1321,16 @@ if _WX_AVAILABLE:
             self._stream_timer.Stop()
             self._on_stream_flush(None)
 
+            log.info(
+                "chat: _on_reply was_streamed=%s reply_len=%d pending_len=%d "
+                "buffer_left=%d delta_chars=%d",
+                was_streamed,
+                len(reply),
+                len(self._pending_ai_text),
+                len(self._stream_buffer),
+                getattr(self, "_stream_delta_chars", 0),
+            )
+
             # Hide streaming preview before appending the final entry
             if self._use_webview:
                 self._hide_stream_wrapper()
@@ -1337,12 +1354,19 @@ if _WX_AVAILABLE:
                         "text": self._pending_ai_text,
                         "timestamp": datetime.datetime.now().strftime("%H:%M:%S"),
                     }
+                    log.info(
+                        "chat: finalising streamed entry text_len=%d tail=%r",
+                        len(entry["text"]),
+                        entry["text"][-80:],
+                    )
                     self._conv_entries.append(entry)
                     self._pending_ai_text = ""
                     if self._use_webview and self._shell_loaded:
                         self._append_entry_js(entry, force_scroll_to_bottom=True)
                     else:
                         self._render_conversation(force_scroll_to_bottom=True)
+            # Any deferral during the turn is flushed by the lock holder's
+            # release (_run_script), so no turn-end safety net is needed.
             self._busy = False
             self._cancel_event = None
             self._toggle_send_stop(busy=False)
@@ -1372,8 +1396,14 @@ if _WX_AVAILABLE:
                 # Incremental DOM update — should always succeed with shell loaded
                 if self._incremental_stream_update():
                     return
-                # Shell not loaded yet — defer
-                self._render_pending = True
+                # Deferred (lock busy / shell not loaded) or update failed:
+                # _run_script already recorded _render_pending, so a full
+                # rebuild will replay (and the next flush re-shows stream
+                # text).  Nothing to bookkeep here.
+                log.warning(
+                    "chat: stream flush deferred render (pending=%d chars)",
+                    len(self._pending_ai_text),
+                )
             else:
                 self._render_conversation(force_scroll_to_bottom=self._follow_output_to_bottom)
 
@@ -1381,9 +1411,11 @@ if _WX_AVAILABLE:
             """Update streaming AI text via _updateStream JS call.
 
             The #pending-ai-text div always exists in the shell HTML, so this
-            should always succeed when the shell is loaded.
+            should always succeed when the shell is loaded.  Runs under the
+            render protocol via _run_script; on deferral or failure the
+            pending full-rebuild replay covers the missed incremental update.
             """
-            if not self._use_webview or not self._shell_loaded or self._js_running:
+            if not self._use_webview:
                 return False
 
             import json as _json
@@ -1392,17 +1424,13 @@ if _WX_AVAILABLE:
             scroll_arg = "true" if self._follow_output_to_bottom else "false"
             js = f"_updateStream({_json.dumps(body_html)}, {scroll_arg})"
 
-            self._js_running = True
-            try:
-                ok, result = self._conv_view.RunScript(js)
-                if not ok:
-                    log.warning("_incremental_stream_update: RunScript failed")
-                return ok
-            except Exception as e:
-                log.warning("_incremental_stream_update: exception: %s", e)
-                return False
-            finally:
-                self._js_running = False
+            return bool(
+                self._run_script(
+                    js,
+                    force_scroll_to_bottom=self._follow_output_to_bottom,
+                    retry_on_failure=True,
+                )[0]
+            )
 
         def _on_page_watchdog(self, event) -> None:
             """Safety net: detect shell load timeout.
@@ -1463,6 +1491,10 @@ if _WX_AVAILABLE:
             # If there is pending streamed text that preceded this tool call,
             # finalise it as an AI entry now so the timeline order is correct.
             if self._pending_ai_text:
+                log.debug(
+                    "chat: mid-turn finalise of streamed text len=%d",
+                    len(self._pending_ai_text),
+                )
                 self._conv_entries.append({"type": "ai", "text": self._pending_ai_text})
                 self._pending_ai_text = ""
             # Append as a permanent timeline entry so tool calls appear in
@@ -2529,49 +2561,57 @@ if _WX_AVAILABLE:
             Called 1 second after EVT_WEBVIEW_LOADED to give scripts time to execute.
             """
             log.debug("_verify_shell_and_render: starting verification")
-            self._js_running = True
             js_works = False
 
+            # Each probe runs under the render-protocol flag via
+            # _run_script(probe=True): before _shell_loaded is confirmed the
+            # normal acquire would defer instead of probing, so probe=True
+            # skips the shell-loaded gate while still excluding re-entrant
+            # renders from the probe windows.
             try:
                 # Check font
-                ok, result = self._conv_view.RunScript("getComputedStyle(document.body).fontFamily")
+                _, result = self._run_script(
+                    "getComputedStyle(document.body).fontFamily", probe=True
+                )
                 log.info("_verify_shell_and_render: font=%r", result)
 
                 # Check all window functions (what's actually defined in window)
-                ok, result = self._conv_view.RunScript(
-                    "Object.keys(window).filter(k => typeof window[k] === 'function' && k.startsWith('_')).join(',')"
+                _, result = self._run_script(
+                    "Object.keys(window).filter(k => typeof window[k] === 'function' && k.startsWith('_')).join(',')",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: window functions starting with _ =%r", result)
 
                 # Check scripts in document
-                ok, result = self._conv_view.RunScript(
-                    "document.scripts.length + ',' + (document.scripts[0] ? document.scripts[0].src : 'inline') + ',' + (document.scripts[0] ? document.scripts[0].innerHTML.length : 0)"
+                _, result = self._run_script(
+                    "document.scripts.length + ',' + (document.scripts[0] ? document.scripts[0].src : 'inline') + ',' + (document.scripts[0] ? document.scripts[0].innerHTML.length : 0)",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: scripts info=%r", result)
 
                 # Check for JS errors in the console
-                ok, result = self._conv_view.RunScript(
-                    "try { eval('1+1'); 'no_error'; } catch(e) { e.message; }"
+                _, result = self._run_script(
+                    "try { eval('1+1'); 'no_error'; } catch(e) { e.message; }", probe=True
                 )
                 log.info("_verify_shell_and_render: eval test=%r", result)
 
                 # Try to check for syntax errors in the script
-                ok, result = self._conv_view.RunScript(
-                    "try { new Function(document.scripts[0].innerHTML); 'syntax_ok'; } catch(e) { 'error:' + e.message; }"
+                _, result = self._run_script(
+                    "try { new Function(document.scripts[0].innerHTML); 'syntax_ok'; } catch(e) { 'error:' + e.message; }",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: script syntax check=%r", result)
 
                 # Try to call JS function
-                ok, result = self._conv_view.RunScript(
-                    "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }"
+                ok, result = self._run_script(
+                    "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }",
+                    probe=True,
                 )
                 log.info("_verify_shell_and_render: JS call result=%r", result)
                 if ok and result and ("ok" in str(result) or "error" in str(result).lower()):
                     js_works = True
             except Exception as e:
                 log.error("_verify_shell_and_render: exception: %s", e)
-            finally:
-                self._js_running = False
 
             if js_works:
                 self._shell_loaded = True
@@ -2646,10 +2686,10 @@ if _WX_AVAILABLE:
             """Full conversation update via RunScript (WebView path).
 
             Serializes all entries as JSON and calls _updateConversation()
-            in the shell.
+            in the shell.  Locking/deferral is handled by _run_script.
             """
-            if not self._try_acquire_render_lock():
-                return  # _try_acquire_render_lock already set _render_pending
+            if not self._use_webview:
+                return
 
             import json as _json
 
@@ -2665,31 +2705,21 @@ if _WX_AVAILABLE:
                 len(js),
             )
 
-            try:
-                ok, result = self._conv_view.RunScript(js)
-                if ok:
-                    self._stream_wrapper_visible = False
-                    result_str = str(result) if result else ""
-                    if result_str.startswith("error:"):
-                        log.error(
-                            "_updateConversation JS error: %s (js_size=%d, entries=%d)",
-                            result_str,
-                            len(js),
-                            len(js_entries),
-                        )
-                    else:
-                        log.debug("_updateConversation JS result: %s", result_str)
-                else:
-                    log.error(
-                        "_updateConversation RunScript FAILED: js_size=%d, result=%r, entries=%d",
-                        len(js),
-                        result,
-                        len(js_entries),
-                    )
-            except Exception as e:
-                log.error("_updateConversation exception: %s", e)
-            finally:
-                self._release_render_lock(force_scroll_to_bottom)
+            ok, result = self._run_script(js, force_scroll_to_bottom)
+            if not ok:
+                log.debug("_updateConversation deferred (pending rebuild scheduled)")
+                return
+            self._stream_wrapper_visible = False
+            result_str = str(result) if result else ""
+            if result_str.startswith("error:"):
+                log.error(
+                    "_updateConversation JS error: %s (js_size=%d, entries=%d)",
+                    result_str,
+                    len(js),
+                    len(js_entries),
+                )
+            else:
+                log.debug("_updateConversation JS result: %s", result_str)
 
         def _process_pending_render(self, force_scroll_to_bottom: bool) -> None:
             """Process any pending render after _js_running is reset."""
@@ -2698,13 +2728,66 @@ if _WX_AVAILABLE:
                 wx.CallAfter(self._update_conversation, force_scroll_to_bottom)
 
         # ------------------------------------------------------------------ #
+        # Render protocol: single RunScript funnel
+        # ------------------------------------------------------------------ #
+        # Every conversation-rendering script goes through _run_script, which
+        # owns the _js_running / _render_pending bookkeeping.  RunScript on
+        # Windows WebView2 pumps the message loop, so a script submitted
+        # while another is in flight gets re-entrant instead of serialized;
+        # the _js_running flag turns that into "defer and replay as a full
+        # rebuild".  Callers of _run_script never touch lock state.
+
+        def _run_script(
+            self,
+            js: str,
+            force_scroll_to_bottom: bool = False,
+            retry_on_failure: bool = False,
+            probe: bool = False,
+        ) -> tuple[bool, object]:
+            """Run a WebView script under the render protocol.
+
+            Acquires the render lock (deferring -- _render_pending set -- when
+            another script is in flight or the shell is not confirmed loaded),
+            runs the script, then releases; the release flushes any deferral
+            as a wx.CallAfter full-conversation rebuild once the current
+            event stack has unwound.
+
+            probe=True runs before the shell is confirmed loaded (shell
+            verification): takes the lock flag to keep re-entrant renders out,
+            but skips the shell-loaded gate.
+
+            retry_on_failure=True records a pending rebuild when the script
+            itself fails, so a full rebuild replays the missed update.
+            """
+            if not self._use_webview:
+                return False, None
+            if not self._try_acquire_render_lock(probe=probe):
+                return False, None  # deferred: _render_pending already set
+            try:
+                ok, result = self._conv_view.RunScript(js)
+                if not ok:
+                    log.warning("_run_script: RunScript failed: %r", result)
+                    if retry_on_failure:
+                        self._render_pending = True
+                return ok, result
+            except Exception as e:
+                log.warning("_run_script exception: %s", e)
+                if retry_on_failure:
+                    self._render_pending = True
+                return False, None
+            finally:
+                self._release_render_lock(force_scroll_to_bottom)
+
+        # ------------------------------------------------------------------ #
         # Render lock helpers: encapsulate sync state management
         # ------------------------------------------------------------------ #
-        def _try_acquire_render_lock(self) -> bool:
+        def _try_acquire_render_lock(self, probe: bool = False) -> bool:
             """Try to acquire the render lock. Returns True if acquired.
 
-            If acquisition fails (shell not loaded or another render in progress),
-            sets _render_pending so the render will be retried later.
+            If acquisition fails (shell not loaded or another render in
+            progress), sets _render_pending so the render will be retried
+            later.  With probe=True the shell-loaded gate is skipped (shell
+            verification runs before _shell_loaded is confirmed).
             """
             self._render_pending = False  # Reset first to allow recursion
 
@@ -2712,51 +2795,54 @@ if _WX_AVAILABLE:
                 self._render_pending = True
                 return False
 
-            # If shell_loaded is False, try to detect if it actually is loaded
-            # (EVT_WEBVIEW_LOADED may not fire on all Windows WebView2 versions)
-            if not self._shell_loaded:
-                # Try to detect shell state by checking if the conversation div exists
-                # AND if JS functions are defined. Try multiple times in case scripts
-                # haven't executed yet.
-                shell_loaded_detected = False
-                for attempt in range(3):
-                    try:
-                        ok, result = self._conv_view.RunScript(
-                            "document.getElementById('conversation') ? 'loaded' : 'not_loaded'"
-                        )
-                        if ok and result and "loaded" in str(result):
-                            # Also verify JS functions exist by trying to call one
-                            ok2, result2 = self._conv_view.RunScript(
-                                "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }"
-                            )
-                            log.info("JS test attempt %d: %r", attempt + 1, result2)
-                            if (
-                                ok2
-                                and result2
-                                and ("ok" in str(result2) or "error" in str(result2).lower())
-                            ):
-                                log.info("Detected shell and JS working (attempt %d)", attempt + 1)
-                                self._shell_loaded = True
-                                self._page_loading = False
-                                shell_loaded_detected = True
-                                break
-                            else:
-                                log.warning(
-                                    "Shell loaded but JS not working (attempt %d)", attempt + 1
-                                )
-                        else:
-                            break
-                    except Exception as e:
-                        log.warning("Failed to detect shell state (attempt %d): %s", attempt + 1, e)
-                        break
+            # Claim first: shell detection (below) runs raw RunScript probes,
+            # so the flag must be held while they are in flight to keep
+            # re-entrant renders out of the detection window too.
+            self._js_running = True
 
-                if not shell_loaded_detected:
-                    log.warning("Shell loaded but JS not working after 3 attempts, allowing retry")
+            if not probe and not self._shell_loaded:
+                if not self._detect_shell_loaded():
+                    self._js_running = False
                     self._render_pending = True
                     return False
 
-            self._js_running = True
             return True
+
+        def _detect_shell_loaded(self) -> bool:
+            """Probe the WebView for a working shell (div + JS functions).
+
+            EVT_WEBVIEW_LOADED may not fire on all Windows WebView2 versions,
+            so renders probe for shell readiness.  Runs with the render lock
+            held (_js_running=True).
+            """
+            for attempt in range(3):
+                try:
+                    ok, result = self._conv_view.RunScript(
+                        "document.getElementById('conversation') ? 'loaded' : 'not_loaded'"
+                    )
+                    if ok and result and "loaded" in str(result):
+                        # Also verify JS functions exist by trying to call one
+                        ok2, result2 = self._conv_view.RunScript(
+                            "try { _updateConversation('[]', 'preserve'); 'ok'; } catch(e) { e.message; }"
+                        )
+                        log.info("JS test attempt %d: %r", attempt + 1, result2)
+                        if (
+                            ok2
+                            and result2
+                            and ("ok" in str(result2) or "error" in str(result2).lower())
+                        ):
+                            log.info("Detected shell and JS working (attempt %d)", attempt + 1)
+                            self._shell_loaded = True
+                            self._page_loading = False
+                            return True
+                        log.warning("Shell loaded but JS not working (attempt %d)", attempt + 1)
+                    else:
+                        break
+                except Exception as e:
+                    log.warning("Failed to detect shell state (attempt %d): %s", attempt + 1, e)
+                    break
+            log.warning("Shell loaded but JS not working after 3 attempts, allowing retry")
+            return False
 
         def _release_render_lock(self, force_scroll_to_bottom: bool) -> None:
             """Release the render lock and process pending if needed."""
@@ -2765,80 +2851,64 @@ if _WX_AVAILABLE:
 
         def _append_entry_js(self, entry: dict, force_scroll_to_bottom: bool = False) -> None:
             """Append a single entry via JS _appendEntry (WebView path)."""
-            if not self._try_acquire_render_lock():
-                return  # _try_acquire_render_lock already set _render_pending
-
             import json as _json
 
             prepared = self._prepare_single_entry(entry)
             scroll = '"bottom"' if force_scroll_to_bottom else '"preserve"'
             js = f"_appendEntry({_json.dumps(_json.dumps(prepared))}, {scroll})"
-            log.debug("_appendEntry: type=%s, scroll=%s", entry.get("type"), scroll)
+            text = entry.get("text") or ""
+            log.debug(
+                "_appendEntry: type=%s, text_len=%d, tail=%r, scroll=%s",
+                entry.get("type"),
+                len(text),
+                text[-80:],
+                scroll,
+            )
 
-            try:
-                ok, result = self._conv_view.RunScript(js)
-                if ok:
-                    self._stream_wrapper_visible = False
-                    result_str = str(result) if result else ""
-                    if result_str.startswith("error:"):
-                        log.error(
-                            "_appendEntry JS error: %s (type=%s, js_size=%d)",
-                            result_str,
-                            entry.get("type"),
-                            len(js),
-                        )
-                    else:
-                        log.debug("_appendEntry JS result: %s", result_str)
-                else:
-                    log.error(
-                        "_appendEntry RunScript FAILED: result=%r, type=%s, js_size=%d",
-                        result,
-                        entry.get("type"),
-                        len(js),
-                    )
-                    self._render_pending = True
-            except Exception:
-                self._render_pending = True
-            finally:
-                self._release_render_lock(force_scroll_to_bottom)
+            ok, result = self._run_script(js, force_scroll_to_bottom, retry_on_failure=True)
+            if not ok:
+                # Deferred (lock busy / shell not loaded) or script failed —
+                # acquire/retry_on_failure already recorded a pending full
+                # rebuild that will replay this entry.
+                log.warning(
+                    "chat: append_entry_js deferred/retry (type=%s, text_len=%d) — pending rebuild scheduled",
+                    entry.get("type"),
+                    len(text),
+                )
+                return
+            self._stream_wrapper_visible = False
+            result_str = str(result) if result else ""
+            if result_str.startswith("error:"):
+                log.error(
+                    "_appendEntry JS error: %s (type=%s, js_size=%d)",
+                    result_str,
+                    entry.get("type"),
+                    len(js),
+                )
+            else:
+                log.debug("_appendEntry JS result: %s", result_str)
 
         def _show_stream_wrapper(self) -> None:
             """Make the stream-wrapper table visible (first streaming chunk)."""
             if not self._shell_loaded or self._stream_wrapper_visible:
                 return  # No-op
 
-            # Use the lock but handle the case where we don't need full update
-            if not self._try_acquire_render_lock():
-                return
-
-            try:
-                ok, _ = self._conv_view.RunScript(
-                    "document.getElementById('stream-wrapper').style.display=''"
-                )
-                if ok:
-                    self._stream_wrapper_visible = True
-            finally:
-                self._release_render_lock(False)
+            ok, _ = self._run_script("document.getElementById('stream-wrapper').style.display=''")
+            if ok:
+                self._stream_wrapper_visible = True
 
         def _hide_stream_wrapper(self) -> None:
             """Hide the stream-wrapper table and clear pending text."""
             if not self._shell_loaded or not self._stream_wrapper_visible:
                 return  # No-op
 
-            # Use the lock but handle the case where we don't need full update
-            if not self._try_acquire_render_lock():
-                return
-
-            try:
-                ok, _ = self._conv_view.RunScript(
-                    "var w=document.getElementById('stream-wrapper');"
-                    "if(w)w.style.display='none';"
-                    "document.getElementById('pending-ai-text').innerHTML='';"
-                )
-                if ok:
-                    self._stream_wrapper_visible = False
-            finally:
-                self._release_render_lock(False)
+            ok, _ = self._run_script(
+                "var w=document.getElementById('stream-wrapper');"
+                "if(w)w.style.display='none';"
+                "document.getElementById('pending-ai-text').innerHTML='';"
+            )
+            if ok:
+                self._stream_wrapper_visible = False
 
         def _render_conversation(self, force_scroll_to_bottom: bool = False) -> None:
             """Re-render the conversation.  Routes to WebView or HtmlWindow path."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcaa"
-version = "0.2.0"
+version = "0.2.1"
 description = "Model Context Protocol (MCP) server for KiCad electronic design automation (EDA) files"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/integration/test_pcb_routing.py
+++ b/tests/integration/test_pcb_routing.py
@@ -132,6 +132,8 @@ class TestAutoRoutePair:
     def test_multi_layer_route_inserts_via(self, pcb_copy):
         # R1.2 is on F.Cu (GND). D1.1 is on In1.Cu (GND). The router must
         # insert at least one via to reach the destination layer.
+        # R1.2 is SMD → fixed F.Cu. D1.1 is SMD on In1.Cu → fixed In1.Cu.
+        # No layer_hint needed: SMD layers are auto-detected.
         req = RouteRequest(
             pcb_path=pcb_copy,
             ref_a="R1",
@@ -139,8 +141,6 @@ class TestAutoRoutePair:
             ref_b="D1",
             pad_b="1",
             net="GND",
-            start_layer="F.Cu",
-            end_layer="In1.Cu",
             via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
         )
         result = auto_route_pair(req)
@@ -158,8 +158,6 @@ class TestAutoRoutePair:
             ref_b="D1",
             pad_b="1",
             net="GND",
-            start_layer="F.Cu",
-            end_layer="In1.Cu",
             via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
         )
         result = auto_route_pair(req)
@@ -168,7 +166,8 @@ class TestAutoRoutePair:
             assert 0.0 <= via.y <= 60.0
 
     def test_single_layer_with_via_pair_still_works(self, pcb_copy):
-        # When start_layer == end_layer, no vias are inserted even if via_pairs set.
+        # R1.1 and C1.1 are both SMD on F.Cu → same layer → no vias,
+        # even if via_pairs are set.
         req = RouteRequest(
             pcb_path=pcb_copy,
             ref_a="R1",
@@ -176,8 +175,6 @@ class TestAutoRoutePair:
             ref_b="C1",
             pad_b="1",
             net="VCC",
-            start_layer="F.Cu",
-            end_layer="F.Cu",
             via_pairs=(("F.Cu", "B.Cu"),),
         )
         result = auto_route_pair(req)
@@ -478,8 +475,8 @@ class TestRoutingTool:
         assert len(vias) == 2
 
     def test_multi_layer_tool_writes_segments_and_via(self, pcb_copy):
-        # R1.2 is on F.Cu; D1.1 is on In1.Cu (GND).  Calling the tool
-        # with target_layer="In1.Cu" should produce at least one via.
+        # R1.2 is SMD on F.Cu; D1.1 is SMD on In1.Cu.  Layers are
+        # auto-detected from pad types — no layer_hint needed.
         mcp = self._make_mcp()
         result = self._call_tool(
             mcp,
@@ -491,8 +488,6 @@ class TestRoutingTool:
             pad_b="1",
             net="GND",
             ctx=None,
-            layer="F.Cu",
-            target_layer="In1.Cu",
             via_pairs=(("F.Cu", "B.Cu"), ("B.Cu", "In1.Cu")),
         )
         assert "segment_count" in result
@@ -500,27 +495,26 @@ class TestRoutingTool:
         assert result["via_count"] >= 1
         assert "In1.Cu" in result["layers_used"]
 
-    def test_multi_layer_tool_default_via_pair(self, pcb_copy):
-        # When target_layer differs from layer, default via_pairs
-        # ((F.Cu, B.Cu),) is used.  F.Cu → B.Cu reaches a B.Cu pad.
+    def test_single_layer_tool_smd_pads(self, pcb_copy):
+        # R1.1 and C1.1 are both SMD on F.Cu.  layer_hint="B.Cu" is
+        # ignored for SMD pads — route stays on F.Cu.
         mcp = self._make_mcp()
         result = self._call_tool(
             mcp,
             "pcb_route_pad_to_pad",
             pcb_path=pcb_copy,
             ref_a="R1",
-            pad_a="2",
+            pad_a="1",
             ref_b="C1",
-            pad_b="2",
+            pad_b="1",
             net="VCC",
             ctx=None,
-            layer="F.Cu",
-            target_layer="B.Cu",
+            width=0.25,
+            layer_hint="B.Cu",
         )
-        # C1.2 is on F.Cu, so this should fall back to F.Cu routing
-        # (the pad has no copper on B.Cu) — the tool surfaces the error
-        # in result["error"].
-        assert "error" in result or result.get("via_count", 0) >= 0
+        assert "segment_count" in result
+        assert result["via_count"] == 0
+        assert set(result["layers_used"]) == {"F.Cu"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_pcb_tools.py
+++ b/tests/integration/test_pcb_tools.py
@@ -296,6 +296,14 @@ class TestGetFootprint:
         )
         assert "error" in result
 
+    def test_includes_edge_cuts_field(self, mcp_server):
+        """get_footprint response carries an edge_cuts list over JSON-RPC."""
+        port, sid = mcp_server
+        result = _call_tool(
+            port, sid, "get_footprint", {"pcb_path": BOARD_FIXTURE, "reference": "R1"}
+        )
+        assert isinstance(result.get("edge_cuts"), list)
+
 
 class TestListNets:
     def test_excludes_net_zero(self, mcp_server):

--- a/tests/unit/plugin/test_context_bridge.py
+++ b/tests/unit/plugin/test_context_bridge.py
@@ -3,7 +3,11 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from kicad_plugin.context_bridge import collect_context, context_to_system_prompt_block
+from kicad_plugin.context_bridge import (
+    collect_context,
+    context_to_system_prompt_block,
+    project_path_from_title,
+)
 
 
 class TestCollectContextNoPcbnew:
@@ -167,3 +171,35 @@ class TestContextToSystemPromptBlock:
         }
         block = context_to_system_prompt_block(ctx)
         assert "Active PCB: /" not in block  # Should show "(none)" not a path
+
+
+class TestProjectPathFromTitle:
+    def test_pcb_editor_title_derives_existing_project(self, tmp_path):
+        pcb = tmp_path / "board.kicad_pcb"
+        pro = pcb.with_suffix(".kicad_pro")
+        pcb.write_text("(kicad_pcb)")
+        pro.write_text("(kicad_project)")
+        assert project_path_from_title(f"PCB Editor: {pcb}") == os.path.abspath(str(pro))
+
+    def test_schematic_editor_title_derives_project(self, tmp_path):
+        sch = tmp_path / "board.kicad_sch"
+        sch.with_suffix(".kicad_pro").write_text("(kicad_project)")
+        sch.write_text("(kicad_sch)")
+        assert project_path_from_title(f"Eeschema: {sch}") == os.path.abspath(
+            str(sch.with_suffix(".kicad_pro"))
+        )
+
+    def test_project_title_direct(self, tmp_path):
+        pro = tmp_path / "proj.kicad_pro"
+        pro.write_text("(kicad_project)")
+        assert project_path_from_title(f"KiCad - {pro}") == os.path.abspath(str(pro))
+
+    def test_derived_project_missing_returns_none(self, tmp_path):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        # No sibling .kicad_pro — derivation fails and returns None.
+        assert project_path_from_title(f"PCB Editor: {pcb}") is None
+
+    def test_unrelated_title_returns_none(self):
+        assert project_path_from_title("Settings Dialog") is None
+        assert project_path_from_title("") is None

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -90,6 +90,21 @@ def _tool(tool_call_id="tc1", content="result"):
 # ---------------------------------------------------------------------------
 
 
+class TestSetBaseUrl:
+    def test_updates_url_after_construction(self):
+        client = _make_client()
+        assert client._mcp_base_url == "http://127.0.0.1:9999"
+        client.set_base_url("http://127.0.0.1:5555")
+        assert client._mcp_base_url == "http://127.0.0.1:5555"
+
+    def test_none_then_real_url(self):
+        client = _make_client()
+        # Client constructed before the backend is up sees base URL None.
+        client.set_base_url(None)
+        client.set_base_url("http://127.0.0.1:1234")
+        assert client._mcp_base_url == "http://127.0.0.1:1234"
+
+
 class TestDedupToolCalls:
     def test_no_change_when_no_tool_calls(self):
         client = _make_client()

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -4,6 +4,8 @@ import json
 import types
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from kicad_plugin.llm_client import LLMClient
 from kicad_plugin.tool_registry import TOOL_POLICIES
 
@@ -458,6 +460,201 @@ class TestRunIntegration:
             "set_footprint_position",
             "reload_kicad",
         ]
+
+    def test_failed_mutation_still_reloads_dirty_path_at_turn_end(self):
+        """A failed PCB mutation still marks the path dirty so reload_kicad
+        runs at turn end, keeping the UI refresh consistent with the action."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc1",
+                        "type": "function",
+                        "function": {
+                            "name": "pcb_route_pad_to_pad",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "pad1": "A1", "pad2": "B2"}
+                            ),
+                        },
+                    }
+                ],
+            },
+        }
+        final_response = {"finish_reason": "stop", "message": {"content": "done"}}
+        client._call_llm = MagicMock(side_effect=[tool_response, final_response])
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[{"function": {"name": "pcb_route_pad_to_pad"}}]
+        )
+        on_tool_call = MagicMock()
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = [
+                {"success": True},  # save_document
+                {"success": True, "version_id": "v1"},
+                {"success": False, "error": "routing failed"},  # pcb_route_pad_to_pad fails
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []},
+            ]
+            result = client.run("route A1 to B2", context_block="", on_tool_call=on_tool_call)
+
+        assert result == "done"
+        assert mock_call_tool.call_args_list == [
+            ((client._mcp_base_url, "save_document", {"file_path": "/tmp/board.kicad_pcb"}),),
+            ((client._mcp_base_url, "save_file_version", {"file_path": "/tmp/board.kicad_pcb"}),),
+            (
+                (
+                    client._mcp_base_url,
+                    "pcb_route_pad_to_pad",
+                    {"pcb_path": "/tmp/board.kicad_pcb", "pad1": "A1", "pad2": "B2"},
+                ),
+            ),
+            ((client._mcp_base_url, "reload_kicad", {"paths": ["/tmp/board.kicad_pcb"]}),),
+        ]
+        assert [call.args[0] for call in on_tool_call.call_args_list] == [
+            "save_document",
+            "save_file_version",
+            "pcb_route_pad_to_pad",
+            "reload_kicad",
+        ]
+
+    def test_llm_error_after_mutation_still_reloads_dirty_path(self):
+        """An [LLM error] exit still flushes dirty paths via the shared
+        end-of-turn reload, matching the UI refresh display."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc1",
+                        "type": "function",
+                        "function": {
+                            "name": "set_footprint_position",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R1", "x": 1.0}
+                            ),
+                        },
+                    }
+                ],
+            },
+        }
+        client._call_llm = MagicMock(side_effect=[tool_response, {"error": "API down"}])
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[{"function": {"name": "set_footprint_position"}}]
+        )
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = [
+                {"success": True},  # save_document
+                {"success": True, "version_id": "v1"},
+                {"success": True, "pcb_path": "/tmp/board.kicad_pcb"},
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []},
+            ]
+            result = client.run("move R1", context_block="")
+
+        assert result == "[LLM error] API down"
+        assert mock_call_tool.call_args_list[-1] == (
+            (client._mcp_base_url, "reload_kicad", {"paths": ["/tmp/board.kicad_pcb"]}),
+        )
+
+    def test_max_iterations_exit_still_reloads_dirty_path(self):
+        """Hitting the iteration cap still flushes dirty paths via the shared
+        end-of-turn reload."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc-loop",
+                        "type": "function",
+                        "function": {
+                            "name": "set_footprint_position",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R1", "x": 1.0}
+                            ),
+                        },
+                    }
+                ],
+            },
+        }
+        client._call_llm = MagicMock(return_value=tool_response)  # never stops calling tools
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[{"function": {"name": "set_footprint_position"}}]
+        )
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = lambda base, name, args: (
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []}
+                if name == "reload_kicad"
+                else {"success": True}
+            )
+            result = client.run("move R1", context_block="")
+
+        assert (
+            result == "[Error] Maximum tool-call iterations reached. Please try a simpler request."
+        )
+        assert mock_call_tool.call_args_list[-1][0][1] == "reload_kicad"
+        assert mock_call_tool.call_args_list[-1][0][2] == {"paths": ["/tmp/board.kicad_pcb"]}
+
+    def test_tool_exception_still_reloads_dirty_path(self):
+        """An exception escaping run() still flushes dirty paths from earlier
+        successful mutations in the same turn."""
+        client = _make_client()
+        tool_response = {
+            "finish_reason": "tool_calls",
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc1",
+                        "type": "function",
+                        "function": {
+                            "name": "set_footprint_position",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R1", "x": 1.0}
+                            ),
+                        },
+                    },
+                    {
+                        "id": "tc2",
+                        "type": "function",
+                        "function": {
+                            "name": "flip_footprint",
+                            "arguments": json.dumps(
+                                {"pcb_path": "/tmp/board.kicad_pcb", "reference": "R2"}
+                            ),
+                        },
+                    },
+                ],
+            },
+        }
+        client._call_llm = MagicMock(side_effect=[tool_response])
+        client._fetch_tool_definitions = MagicMock(
+            return_value=[
+                {"function": {"name": "set_footprint_position"}},
+                {"function": {"name": "flip_footprint"}},
+            ]
+        )
+
+        with patch("kicad_plugin.llm_client.call_mcp_tool") as mock_call_tool:
+            mock_call_tool.side_effect = [
+                {"success": True},  # save_document (snapshot for set_footprint_position)
+                {"success": True, "version_id": "v1"},
+                {"success": True, "pcb_path": "/tmp/board.kicad_pcb"},
+                # flip_footprint reuses the same-turn snapshot (no save calls)
+                RuntimeError("boom"),  # flip_footprint raises
+                {"success": True, "reloaded": ["/tmp/board.kicad_pcb"], "failed": []},
+            ]
+            with pytest.raises(RuntimeError, match="boom"):
+                client.run("edit board", context_block="")
+
+        assert mock_call_tool.call_args_list[-1][0][1] == "reload_kicad"
+        assert mock_call_tool.call_args_list[-1][0][2] == {"paths": ["/tmp/board.kicad_pcb"]}
 
     def test_framework_snapshots_each_file_once_per_turn(self):
         client = _make_client()

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -1,13 +1,57 @@
 """Tests for LLMClient history management (dedup + compaction)."""
 
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
+import os
+import sys
+import threading
 import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kicad_plugin.llm_client import LLMClient
+from kicad_plugin.llm_client import LLMClient, _subprocess_sse_stream
 from kicad_plugin.tool_registry import TOOL_POLICIES
+
+
+class _SSETestServer(ThreadingHTTPServer):
+    """Threaded localhost server that answers POST with an SSE body."""
+
+    def __init__(self, lines, status=200, body=b""):
+        self._lines = lines
+        self._status = status
+        self._body = body
+        super().__init__(("127.0.0.1", 0), self._make_handler(), bind_and_activate=True)
+        self._thread = threading.Thread(target=self.serve_forever, daemon=True)
+        self._thread.start()
+
+    def _make_handler(self):
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                self.send_response(server._status)
+                if server._status == 200:
+                    payload = "".join(line + "\n" for line in server._lines)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Content-Length", str(len(payload.encode())))
+                    self.end_headers()
+                    self.wfile.write(payload.encode())
+                    self.wfile.flush()
+                else:
+                    self.send_header("Content-Type", "text/plain")
+                    self.send_header("Content-Length", str(len(server._body)))
+                    self.end_headers()
+                    self.wfile.write(server._body)
+
+            def log_message(self, *args):  # silence test-server noise
+                pass
+
+        return Handler
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.server_port}"
 
 
 def _make_client(
@@ -980,15 +1024,15 @@ class TestStreaming:
         assert args == {"path": "sch.kicad_sch"}
         assert result["finish_reason"] == "tool_calls"
 
-    def test_stream_openai_ssl_fallback(self):
+    def test_stream_openai_ssl_fallback_streams_via_subprocess(self):
         import urllib.error
 
         client = _make_client()
         chunks = []
 
-        fallback_result = {
+        subprocess_result = {
             "finish_reason": "stop",
-            "message": {"content": "Fallback text", "tool_calls": []},
+            "message": {"content": "Relayed text", "tool_calls": []},
         }
 
         with (
@@ -996,13 +1040,50 @@ class TestStreaming:
                 "urllib.request.urlopen",
                 side_effect=urllib.error.URLError("unknown url type: https"),
             ),
-            patch.object(client, "_call_openai", return_value=fallback_result) as mock_call,
+            patch("kicad_plugin.llm_client._in_process_ssl", None),
+            patch(
+                "kicad_plugin.llm_client._subprocess_sse_stream",
+                return_value=subprocess_result,
+            ) as mock_stream,
         ):
             result = client._stream_openai("sys", [], on_text_delta=chunks.append)
 
-        mock_call.assert_called_once()
-        assert chunks == ["Fallback text"]
-        assert result["message"]["content"] == "Fallback text"
+        mock_stream.assert_called_once()
+        call_kwargs = mock_stream.call_args.kwargs
+        assert call_kwargs["fmt"] == "openai"
+        assert call_kwargs["timeout"] == 300
+        assert result["message"]["content"] == "Relayed text"
+
+    def test_stream_anthropic_ssl_fallback_streams_via_subprocess(self):
+        import urllib.error
+
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        chunks = []
+
+        subprocess_result = {
+            "finish_reason": "tool_calls",
+            "message": {"content": "", "tool_calls": [{"id": "tu1"}]},
+        }
+
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=urllib.error.URLError("unknown url type: https"),
+            ),
+            patch("kicad_plugin.llm_client._in_process_ssl", None),
+            patch(
+                "kicad_plugin.llm_client._subprocess_sse_stream",
+                return_value=subprocess_result,
+            ) as mock_stream,
+        ):
+            result = client._stream_anthropic("sys", [], on_text_delta=chunks.append)
+
+        mock_stream.assert_called_once()
+        call_kwargs = mock_stream.call_args.kwargs
+        assert call_kwargs["fmt"] == "anthropic"
+        assert call_kwargs["timeout"] == 300
+        assert result["message"]["tool_calls"] == [{"id": "tu1"}]
 
     def test_run_passes_on_text_delta_to_call_llm(self):
         client = _make_client()
@@ -1020,6 +1101,150 @@ class TestStreaming:
         # _call_llm must have been called with on_text_delta=on_delta
         call_kwargs = client._call_llm.call_args
         assert call_kwargs.kwargs.get("on_text_delta") is on_delta
+
+
+class TestSubprocessSSEStream:
+    """End-to-end relay: _subprocess_sse_stream runs a real subprocess Python
+    against a local HTTP server speaking SSE, verifying deltas, aggregation,
+    and error surfacing across the pipe protocol."""
+
+    def _relay(self, lines, status=200, body=b"", fmt="openai"):
+        server = _SSETestServer(lines, status=status, body=body)
+        chunks = []
+        try:
+            with (
+                patch(
+                    "kicad_plugin.llm_client._resolve_plugin_python",
+                    return_value=sys.executable,
+                ),
+                # Keep proxy env vars out of the subprocess so it reaches 127.0.0.1 directly.
+                patch(
+                    "kicad_plugin.llm_client._subprocess_env",
+                    return_value={"PATH": os.environ.get("PATH", "")},
+                ),
+            ):
+                result = _subprocess_sse_stream(
+                    url=server.url,
+                    headers={"Content-Type": "application/json"},
+                    payload=b'{"model":"t","stream":true}',
+                    timeout=30,
+                    fmt=fmt,
+                    on_text_delta=chunks.append,
+                )
+        finally:
+            server.shutdown()
+        return result, chunks
+
+    def test_openai_text_deltas_and_aggregation(self):
+        lines = [
+            'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+        result, chunks = self._relay(lines, fmt="openai")
+
+        assert "error" not in result
+        assert chunks == ["Hello", " world"]
+        assert result["message"]["content"] == "Hello world"
+        assert result["finish_reason"] == "stop"
+
+    def test_openai_tool_calls_and_reasoning_aggregated(self):
+        lines = [
+            'data: {"choices":[{"delta":{"reasoning_content":"think "},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"reasoning_content":"hard"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc1","function":{"name":"add_wire","arguments":""}}]},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"x\\":1}"}}]},"finish_reason":"tool_calls"}]}',
+            "data: [DONE]",
+        ]
+        result, chunks = self._relay(lines, fmt="openai")
+
+        assert "error" not in result
+        assert chunks == []
+        tc = result["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["id"] == "tc1"
+        assert tc[0]["function"]["name"] == "add_wire"
+        assert tc[0]["function"]["arguments"] == '{"x":1}'
+        assert result["message"]["reasoning_content"] == "think hard"
+        assert result["finish_reason"] == "tool_calls"
+
+    def test_anthropic_text_and_tool_use(self):
+        lines = [
+            "event: content_block_start",
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+            "",
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+            "",
+            "event: content_block_start",
+            'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu1","name":"get_netlist","input":{}}}',
+            "",
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"}}',
+            "",
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\\"sch.kicad_sch\\"}"}}',
+            "",
+            "event: message_delta",
+            'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}',
+        ]
+        result, chunks = self._relay(lines, fmt="anthropic")
+
+        assert "error" not in result
+        assert chunks == ["Hello"]
+        assert result["message"]["content"] == "Hello"
+        tc = result["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["id"] == "tu1"
+        assert tc[0]["function"]["name"] == "get_netlist"
+        args = json.loads(tc[0]["function"]["arguments"])
+        assert args == {"path": "sch.kicad_sch"}
+        assert result["finish_reason"] == "tool_calls"
+
+    def test_http_error_surfaces_status_and_body(self):
+        result, chunks = self._relay([], status=429, body=b"rate limited", fmt="openai")
+
+        assert chunks == []
+        assert result["error"] == "HTTP 429: rate limited"
+
+    def test_delta_callback_error_does_not_abort_stream(self):
+        lines = [
+            'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+        server = _SSETestServer(lines)
+        seen = []
+
+        def boom(chunk):
+            seen.append(chunk)
+            raise ValueError("ui hiccup")
+
+        try:
+            with (
+                patch(
+                    "kicad_plugin.llm_client._resolve_plugin_python",
+                    return_value=sys.executable,
+                ),
+                patch(
+                    "kicad_plugin.llm_client._subprocess_env",
+                    return_value={"PATH": os.environ.get("PATH", "")},
+                ),
+            ):
+                result = _subprocess_sse_stream(
+                    url=server.url,
+                    headers={"Content-Type": "application/json"},
+                    payload=b"{}",
+                    timeout=30,
+                    fmt="openai",
+                    on_text_delta=boom,
+                )
+        finally:
+            server.shutdown()
+
+        assert seen == ["Hello", " world"]
+        assert result["message"]["content"] == "Hello world"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/plugin/test_session_store.py
+++ b/tests/unit/plugin/test_session_store.py
@@ -1,0 +1,242 @@
+"""Tests for session_store: schema v2 project scoping and v1 legacy support.
+
+Defends the contract that drives session auto-restore:
+
+- v1 files (no ``project_path``) are legacy and never project-matched, so
+  they can never be auto-restored into a project;
+- v2 files match only the project they were stamped with;
+- ``current.json`` is followed only when it points to a session of the open
+  project, and project-scoped lookups never leak other projects' sessions;
+- existing files (v1 and v2) remain readable/writable — no data loss upgrade.
+"""
+
+import json
+import os
+
+from kicad_plugin import session_store as sstore
+
+PROJECT_A = "/home/user/projects/alpha/alpha.kicad_pro"
+PROJECT_B = "/home/user/projects/beta/beta.kicad_pro"
+
+
+def _write_v1_session(config_dir: str, filename: str) -> str:
+    """Write a legacy v1 session file exactly as the old plugin did."""
+    sessions = sstore.sessions_dir(config_dir)
+    os.makedirs(sessions, exist_ok=True)
+    data = {
+        "version": 1,
+        "title": "legacy",
+        "timestamp": "2026-08-01T10:00:00",
+        "conv_entries": [{"type": "user", "text": "legacy question"}],
+        "llm_history": [],
+    }
+    path = os.path.join(sessions, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return path
+
+
+def _write_v2_session(config_dir: str, filename: str, project_path: str, title: str = "v2") -> str:
+    """Write a v2 session file stamped with *project_path*."""
+    payload = sstore.make_payload([{"type": "user", "text": title}], [], project_path)
+    sessions = sstore.sessions_dir(config_dir)
+    os.makedirs(sessions, exist_ok=True)
+    path = os.path.join(sessions, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    return path
+
+
+class TestSchemaV2:
+    def test_make_payload_stamps_project(self):
+        payload = sstore.make_payload(
+            [{"type": "user", "text": "hello"}], [{"role": "user"}], PROJECT_A
+        )
+        assert payload["version"] == 2
+        assert payload["project_path"] == PROJECT_A
+        assert payload["title"] == "hello"
+        assert "timestamp" in payload
+        assert payload["conv_entries"] == [{"type": "user", "text": "hello"}]
+        assert payload["llm_history"] == [{"role": "user"}]
+
+    def test_make_payload_defaults(self):
+        payload = sstore.make_payload([{"type": "ai", "text": "hi"}], [], None)
+        assert payload["version"] == 2
+        assert payload["project_path"] is None
+        assert payload["title"] == "session"
+
+    def test_title_uses_first_user_message(self):
+        payload = sstore.make_payload(
+            [
+                {"type": "status", "text": "notice"},
+                {"type": "user", "text": "  " * 30 + "real question"},
+            ],
+            [],
+            PROJECT_A,
+        )
+        assert payload["title"] == ("  " * 30 + "real question")[:60]
+
+
+class TestProjectMatching:
+    def test_v2_session_matches_own_project(self):
+        assert sstore.is_project_session({"project_path": PROJECT_A}, PROJECT_A)
+
+    def test_v2_session_rejects_other_project(self):
+        assert not sstore.is_project_session({"project_path": PROJECT_A}, PROJECT_B)
+
+    def test_v1_legacy_session_never_matches(self):
+        # v1 payloads have no project_path key at all.
+        assert not sstore.is_project_session({"version": 1, "conv_entries": []}, PROJECT_A)
+
+    def test_session_with_none_project_never_matches(self):
+        assert not sstore.is_project_session({"project_path": None}, PROJECT_A)
+
+    def test_no_open_project_never_matches(self):
+        assert not sstore.is_project_session({"project_path": PROJECT_A}, None)
+
+    def test_none_data_never_matches(self):
+        assert not sstore.is_project_session(None, PROJECT_A)
+
+
+class TestCurrentLink:
+    def test_resolve_plain_text_pointer(self, tmp_path):
+        _write_v1_session(str(tmp_path), "session_old.json")
+        link = sstore.current_link_path(str(tmp_path))
+        with open(link, "w", encoding="utf-8") as f:
+            f.write("session_old.json")
+        resolved = sstore.resolve_current_session(str(tmp_path))
+        assert resolved == os.path.join(str(tmp_path), "kicad_ai_sessions", "session_old.json")
+
+    def test_resolve_symlink_form(self, tmp_path):
+        path = _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        sstore.update_current_link(str(tmp_path), "session_a.json")
+        assert sstore.resolve_current_session(str(tmp_path)) == path
+
+    def test_resolve_missing_returns_none(self, tmp_path):
+        assert sstore.resolve_current_session(str(tmp_path)) is None
+
+    def test_resolve_dangling_symlink_returns_none(self, tmp_path):
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        os.symlink("session_ghost.json", os.path.join(sessions, "current.json"))
+        assert sstore.resolve_current_session(str(tmp_path)) is None
+
+    def test_remove_current_link(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        sstore.update_current_link(str(tmp_path), "session_a.json")
+        assert sstore.resolve_current_session(str(tmp_path)) is not None
+        sstore.remove_current_link(str(tmp_path))
+        assert sstore.resolve_current_session(str(tmp_path)) is None
+
+    def test_remove_current_link_missing_is_noop(self, tmp_path):
+        sstore.remove_current_link(str(tmp_path))  # must not raise
+
+
+class TestProjectSessions:
+    def test_lists_only_matching_project(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A, title="a1")
+        _write_v2_session(str(tmp_path), "session_2.json", PROJECT_B, title="b1")
+        _write_v1_session(str(tmp_path), "session_3.json")
+        found = sstore.list_project_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == ["session_1.json"]
+
+    def test_newest_first_ordering(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A)
+        _write_v2_session(str(tmp_path), "session_2.json", PROJECT_A)
+        found = sstore.list_project_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == [
+            "session_2.json",
+            "session_1.json",
+        ]
+
+    def test_legacy_sessions_excluded(self, tmp_path):
+        _write_v1_session(str(tmp_path), "session_1.json")
+        assert sstore.list_project_sessions(str(tmp_path), PROJECT_A) == []
+
+    def test_none_project_returns_empty(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A)
+        assert sstore.list_project_sessions(str(tmp_path), None) == []
+
+    def test_corrupt_file_is_skipped_not_crash(self, tmp_path):
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        with open(os.path.join(sessions, "session_bad.json"), "w") as f:
+            f.write("{not json")
+        _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A)
+        found = sstore.list_project_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == ["session_1.json"]
+
+
+class TestLoadableSessions:
+    def test_own_project_sessions_plus_unowned(self, tmp_path):
+        own = _write_v2_session(str(tmp_path), "session_1.json", PROJECT_A, title="own1")
+        _write_v2_session(str(tmp_path), "session_2.json", PROJECT_B, title="other")
+        legacy = _write_v1_session(str(tmp_path), "session_3.json")
+        found = sstore.list_loadable_sessions(str(tmp_path), PROJECT_A)
+        assert found == [own, legacy]
+
+    def test_unowned_v2_without_project_included(self, tmp_path):
+        unowned = sstore.make_payload([{"type": "user", "text": "no proj"}], [], None)
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        unowned_path = os.path.join(sessions, "session_x.json")
+        with open(unowned_path, "w", encoding="utf-8") as f:
+            json.dump(unowned, f)
+        _write_v2_session(str(tmp_path), "session_own.json", PROJECT_A)
+        found = sstore.list_loadable_sessions(str(tmp_path), PROJECT_A)
+        assert found == [
+            os.path.join(sessions, "session_own.json"),
+            unowned_path,
+        ]
+
+    def test_none_project_returns_only_unowned(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        _write_v1_session(str(tmp_path), "session_legacy.json")
+        found = sstore.list_loadable_sessions(str(tmp_path), None)
+        assert [os.path.basename(f) for f in found] == ["session_legacy.json"]
+
+    def test_empty_dir(self, tmp_path):
+        assert sstore.list_loadable_sessions(str(tmp_path), PROJECT_A) == []
+
+    def test_other_projects_excluded(self, tmp_path):
+        _write_v2_session(str(tmp_path), "session_a.json", PROJECT_A)
+        _write_v2_session(str(tmp_path), "session_b.json", PROJECT_B)
+        found = sstore.list_loadable_sessions(str(tmp_path), PROJECT_A)
+        assert [os.path.basename(f) for f in found] == ["session_a.json"]
+
+
+class TestRoundTrip:
+    def test_save_then_load_v2(self, tmp_path):
+        payload = sstore.make_payload(
+            [{"type": "user", "text": "q"}], [{"role": "user"}], PROJECT_A
+        )
+        err = sstore.save_session(str(tmp_path), "session_x.json", payload)
+        assert err is None
+
+        path = os.path.join(sstore.sessions_dir(str(tmp_path)), "session_x.json")
+        assert os.path.isfile(path)
+        if os.name != "nt":
+            assert os.stat(path).st_mode & 0o777 == 0o600
+
+        data, err2 = sstore.load_session(path)
+        assert err2 is None
+        assert data is not None
+        assert data["version"] == 2
+        assert data["project_path"] == PROJECT_A
+        assert data["conv_entries"] == [{"type": "user", "text": "q"}]
+
+    def test_load_missing_file(self, tmp_path):
+        data, err = sstore.load_session(
+            os.path.join(sstore.sessions_dir(str(tmp_path)), "session_none.json")
+        )
+        assert data is None
+        assert err is not None
+
+    def test_load_corrupt_file(self, tmp_path):
+        sessions = sstore.sessions_dir(str(tmp_path))
+        os.makedirs(sessions, exist_ok=True)
+        with open(os.path.join(sessions, "session_bad.json"), "w") as f:
+            f.write("{not json")
+        data, err = sstore.load_session(os.path.join(sessions, "session_bad.json"))
+        assert data is None
+        assert err is not None

--- a/tests/unit/router/test_grid_a_star.py
+++ b/tests/unit/router/test_grid_a_star.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from shapely.geometry import Polygon
+from shapely.geometry import Point, Polygon
 
 from kcaa.router.grid_a_star import (
     multi_layer_a_star,
@@ -167,7 +167,7 @@ class TestMultiLayerAStar:
             if prev.layer != cur.layer:
                 # via transition — cur is on the destination layer.
                 # Its position should be outside the obstacle.
-                assert not (8.0 <= cur.x <= 12.0 and 9.0 <= cur.y <= 11.0), (
+                assert not obs.shape.contains(Point(cur.x, cur.y)), (
                     f"via landed on blocked cell at ({cur.x:.2f},{cur.y:.2f})"
                 )
 
@@ -176,6 +176,56 @@ class TestMultiLayerAStar:
         from kcaa.router.grid_a_star import _VIA_COST
 
         assert _VIA_COST == 2.0
+
+
+# ── shortcut_path ─────────────────────────────────────────────────────
+
+
+class TestShortcutPath:
+    """Tests for :func:`shortcut_path` 45°-family constraint.
+
+    The router must never emit a shortcut that is not 0/45/90/135°:
+    snap_to_45_path_safe can only repair such segments into a Manhattan
+    corner pair, which often collapses into a 90° turn (and can even be
+    blocked).  Keep the original 45°+axis-aligned waypoints instead.
+    """
+
+    def test_rejects_non_45_shortcut_keeps_waypoint(self):
+        """A 50° shortcut (45° diagonal + vertical tail) must be rejected,
+        keeping the intermediate point so the path stays 0/45/90."""
+        from kcaa.router.grid_a_star import shortcut_path
+
+        # Mirror the test-route end shape: 45° approach then a vertical
+        # tail into the pad.  Shortcutting (10,10)->(20,25) is a ~50° line.
+        pts = [(0.0, 20.0), (10.0, 10.0), (20.0, 25.0)]
+        bbox = (-2.0, 8.0, 24.0, 27.0)
+        out = shortcut_path(pts, [], bbox, resolution=0.1)
+        # The near-45 shortcut is rejected -> intermediate point kept.
+        assert out == pts
+
+    def test_accepts_aligned_shortcuts(self):
+        """Axis-aligned and true-45° shortcuts are still collapsed."""
+        from kcaa.router.grid_a_star import shortcut_path
+
+        # Three collinear points on a single horizontal line -> one segment.
+        pts = [(0.0, 5.0), (5.0, 5.0), (10.0, 5.0)]
+        bbox = (-2.0, 3.0, 12.0, 7.0)
+        out = shortcut_path(pts, [], bbox, resolution=0.1)
+        assert len(out) == 2
+        assert out[0] == (0.0, 5.0)
+        assert out[-1] == (10.0, 5.0)
+
+    def test_true_45_diagonal_collapses(self):
+        """A genuine 45° corner is one segment after shortcutting."""
+        from kcaa.router.grid_a_star import shortcut_path
+
+        # (0,10) -> (10,0) is exactly 45°; intermediate point removable.
+        pts = [(0.0, 10.0), (5.0, 5.0), (10.0, 0.0)]
+        bbox = (-2.0, -2.0, 12.0, 12.0)
+        out = shortcut_path(pts, [], bbox, resolution=0.1)
+        assert len(out) == 2
+        assert out[0] == (0.0, 10.0)
+        assert out[-1] == (10.0, 0.0)
 
 
 # ── _subtract_pad_aabb ────────────────────────────────────────────────

--- a/tests/unit/router/test_router.py
+++ b/tests/unit/router/test_router.py
@@ -32,12 +32,15 @@ from kcaa.router.router import (
     _default_clearance,
     _default_track_width,
     _find_footprint,
+    _find_pad_center,
+    _find_pad_size,
     _layers_used,
     _project_file_for,
     _routing_layers,
     auto_route_pair,
     connect_with_via,
 )
+from kcaa.utils.pcb_sexp_utils import load_pcb
 
 # ---------------------------------------------------------------------------
 # _project_file_for
@@ -331,6 +334,24 @@ def test_check_segments_in_board_rejects_degenerate_bbox() -> None:
     assert "degenerate" in str(excinfo.value)
 
 
+def test_check_segments_in_board_accepts_segment_onto_edge_pad_zone() -> None:
+    """A segment ending past the shrunk boundary is legal when it lands on
+    an endpoint pad that straddles the edge (edge connector)."""
+    # Board 0..10; width 0.25 shrinks the fence to 0.125..9.875, so
+    # x=9.9 alone would be out of bounds — the pad zone makes it legal.
+    segs = [_seg(5.0, 5.0, 9.9, 5.0)]
+    _check_segments_in_board(segs, (0.0, 0.0, 10.0, 10.0), pad_zones=[(9.9, 5.0, 1.0, 1.0)])
+
+
+def test_check_segments_in_board_rejects_past_edge_without_pad_zone() -> None:
+    """The pad-zone exemption is scoped: same segment, different pad —
+    still rejected."""
+    segs = [_seg(5.0, 5.0, 4.0, 9.9)]
+    with pytest.raises(RouteFailure) as excinfo:
+        _check_segments_in_board(segs, (0.0, 0.0, 10.0, 10.0), pad_zones=[(9.9, 5.0, 1.0, 1.0)])
+    assert "outside the Edge.Cuts boundary" in str(excinfo.value)
+
+
 # ---------------------------------------------------------------------------
 # auto_route_pair — board-bounds check integration
 # ---------------------------------------------------------------------------
@@ -380,8 +401,8 @@ def test_auto_route_pair_warns_when_no_edge_cuts(
 
 
 def test_unknown_layer_in_pcb_raises_route_failure(tmp_path: Path) -> None:
-    """A start_layer / end_layer / via_pair layer that the PCB doesn't declare
-    must fail loudly with a RouteFailure that names the offending layer."""
+    """A via_pair layer that the PCB doesn't declare must fail loudly with
+    a RouteFailure that names the offending layer."""
     src = _fixture_pcb()
     dst = tmp_path / "board.kicad_pcb"
     dst.write_text(Path(src).read_text())
@@ -395,20 +416,23 @@ def test_unknown_layer_in_pcb_raises_route_failure(tmp_path: Path) -> None:
         net="VCC",
         width=0.3,
         clearance=0.2,
-        start_layer="In1.Cu",  # 2-layer fixture has no In1.Cu
+        via_pairs=(("F.Cu", "In2.Cu"),),  # 4-layer fixture has no In2.Cu
     )
     with pytest.raises(RouteFailure) as excinfo:
         auto_route_pair(req)
     assert "In1.Cu" in str(excinfo.value)
 
 
-def test_pad_missing_on_layer_raises_route_failure(tmp_path: Path) -> None:
-    """If a pad has no copper shape on the requested layer, routing from it
-    must fail loudly — never silently fall back to a guessed size."""
+def test_smd_pad_layer_hint_ignored_route_on_pad_layer(tmp_path: Path) -> None:
+    """SMD pads fix their layer: layer_hint="B.Cu" is ignored for R1.1/C1.1
+    (SMD on F.Cu), so the route proceeds on F.Cu and succeeds."""
     src = _fixture_pcb()
     dst = tmp_path / "board.kicad_pcb"
     dst.write_text(Path(src).read_text())
 
+    # R1.1 / C1.1 are SMD on F.Cu in the fixture; layer_hint="B.Cu" is
+    # ignored for SMD pads (layer is fixed), so the route stays on F.Cu
+    # and succeeds.
     req = RouteRequest(
         pcb_path=str(dst),
         ref_a="R1",
@@ -418,11 +442,11 @@ def test_pad_missing_on_layer_raises_route_failure(tmp_path: Path) -> None:
         net="VCC",
         width=0.3,
         clearance=0.2,
-        end_layer="B.Cu",  # R1.1 / C1.1 are SMD on F.Cu in the fixture
+        layer_hint="B.Cu",  # ignored for SMD pads; route stays F.Cu
     )
-    with pytest.raises(RouteFailure) as excinfo:
-        auto_route_pair(req)
-    assert "no copper shape" in str(excinfo.value)
+    # R1.1 / C1.1 are SMD on F.Cu — route should succeed on F.Cu.
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -438,11 +462,10 @@ def test_routing_layers_includes_start_end_and_via_pairs():
         ref_b="B",
         pad_b="1",
         net="N",
-        start_layer="F.Cu",
-        end_layer="B.Cu",
+        layer_hint="F.Cu",
         via_pairs=(("F.Cu", "B.Cu"),),
     )
-    layers = _routing_layers(req)
+    layers = _routing_layers(req, "F.Cu", "B.Cu")
     assert layers == ["F.Cu", "B.Cu"]
 
 
@@ -454,11 +477,10 @@ def test_routing_layers_dedupes():
         ref_b="B",
         pad_b="1",
         net="N",
-        start_layer="F.Cu",
-        end_layer="F.Cu",
+        layer_hint="F.Cu",
         via_pairs=(("F.Cu", "F.Cu"),),
     )
-    layers = _routing_layers(req)
+    layers = _routing_layers(req, "F.Cu", "F.Cu")
     assert layers == ["F.Cu"]
 
 
@@ -588,21 +610,550 @@ def test_invalid_ref_b_pad_raises_failure(pcb_copy):
 # ---------------------------------------------------------------------------
 
 
-def test_thru_hole_pad_on_unused_layer_raises_failure(pcb_copy):
-    # A thru-hole pad is on *.Cu layers but has a "through_hole" pad
-    # type with a hole, not an SMD rect — _find_pad_size returns None
-    # when the requested layer doesn't host the copper shape.  R1.1
-    # is an SMD on F.Cu only; requesting the route on B.Cu should
-    # fail because R1.1 has no copper shape there.
+def test_smd_pad_layer_is_fixed(pcb_copy):
+    # SMD pads are on exactly one copper layer.  layer_hint is ignored
+    # for SMD pads — the layer is fixed by the pad itself.  R1.1 and
+    # C1.2 are both SMD on F.Cu, so the route stays on F.Cu even when
+    # layer_hint suggests B.Cu.
     req = RouteRequest(
         pcb_path=pcb_copy,
         ref_a="R1",
         pad_a="1",
         ref_b="C1",
-        pad_b="2",
+        pad_b="1",
         net="VCC",
-        start_layer="B.Cu",
-        end_layer="B.Cu",
+        width=0.25,
+        clearance=0.2,
+        layer_hint="B.Cu",  # ignored — SMD pads are on F.Cu
     )
-    with pytest.raises(RouteFailure, match="no copper shape"):
+    result = auto_route_pair(req)
+    assert result.layers_used == ["F.Cu"]
+
+
+# ---------------------------------------------------------------------------
+# duplicate pad names in one footprint (edge-connector style)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_pad_name_resolves_to_layer_matching_pad(tmp_path: Path) -> None:
+    """A footprint may declare several pads with the same name (e.g. edge-
+    connector fingers sharing a net). Looking up that name on a given
+    copper layer must resolve to the pad whose copper is actually there —
+    the first same-named pad must not shadow the rest, and a pad with a
+    drill hole (thru-hole) is a valid target."""
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    x1 = (
+        "\n\t# ---- X1: duplicate 'T' pads; F.Cu finger first, thru-hole *.Cu second ----\n"
+        '\t(footprint "user_add:edge-connector"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "66666666-0000-0000-0000-000000000006")\n'
+        "\t\t(at 62.0 45.0 0.0)\n"
+        '\t\t(property "Reference" "X1")\n'
+        '\t\t(property "Value" "X1")\n'
+        '\t\t(pad "T" smd rect\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 1.0 1.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        '\t\t(pad "T" thru_hole custom\n'
+        "\t\t\t(at 2.0 0.0)\n"
+        "\t\t\t(size 1.6 1.6)\n"
+        "\t\t\t(drill 1.0)\n"
+        '\t\t\t(layers "*.Cu" "*.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x1 + ")\n")
+
+    data = load_pcb(str(dst))
+    # F.Cu resolves to the first pad; B.Cu skips it and finds the thru-hole
+    # pad.  Center and size must describe the SAME pad.
+    assert _find_pad_size(data, "X1", "T", "F.Cu") == (1.0, 1.0)
+    assert _find_pad_size(data, "X1", "T", "B.Cu") == (1.6, 1.6)
+    assert _find_pad_center(data, "X1", "T", "F.Cu") == pytest.approx((62.0, 45.0))
+    assert _find_pad_center(data, "X1", "T", "B.Cu") == pytest.approx((64.0, 45.0))
+    # Unfiltered lookup keeps the legacy first-match behaviour.
+    assert _find_pad_center(data, "X1", "T") == pytest.approx((62.0, 45.0))
+
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="X1",
+        pad_b="T",
+        net="VCC",
+        layer_hint="B.Cu",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    # The route must end on the thru-hole pad at world (62+2, 45), not on
+    # the F.Cu-only finger at (62, 45).
+    assert result.end == pytest.approx((64.0, 45.0), abs=0.1)
+    assert result.layers_used == ["F.Cu", "B.Cu"]
+    assert len(result.segments) > 0
+
+
+def test_multi_layer_via_not_on_same_net_pad(tmp_path: Path) -> None:
+    """A via must never land on any same-net pad face (DFM defect:
+    solder wicking / annular-ring breakout).  Via-forbidden zones
+    cover ALL same-net pads, not just the two endpoint pads."""
+    from shapely.geometry import Point, box
+
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    # X3: same-net SMD pads on F.Cu near the route corridor between
+    # R1/1 (29.5, 30) and X1/T (64, 45).  Neither pad is an endpoint;
+    # a multi-layer route's via must avoid both.
+    x3 = (
+        "\n\t# ---- X3: same-net SMD pads, via must avoid ----\n"
+        '\t(footprint "user_add:via-dodge"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "99999999-0000-0000-0000-000000000009")\n'
+        "\t\t(at 45.0 40.0 0.0)\n"
+        '\t\t(property "Reference" "X3")\n'
+        '\t\t(property "Value" "X3")\n'
+        '\t\t(pad "1" smd rect\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 2.0 2.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        '\t\t(pad "2" smd rect\n'
+        "\t\t\t(at 5.0 0.0)\n"
+        "\t\t\t(size 2.0 2.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+        # X1: duplicate T pads — THT variant on B.Cu (endpoint).
+        "\n\t# ---- X1: THT endpoint pad on B.Cu ----\n"
+        '\t(footprint "user_add:edge-connector"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "66666666-0000-0000-0000-000000000006")\n'
+        "\t\t(at 62.0 45.0 0.0)\n"
+        '\t\t(property "Reference" "X1")\n'
+        '\t\t(property "Value" "X1")\n'
+        '\t\t(pad "T" thru_hole circle\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 1.6 1.6)\n"
+        "\t\t\t(drill 1.0)\n"
+        '\t\t\t(layers "*.Cu" "*.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x3 + ")\n")
+
+    # R1/1 F.Cu -> X1/T B.Cu (both VCC).  A via is unavoidable (layer
+    # change).  The via must not land on X3/1 (45,40) or X3/2 (50,40).
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="X1",
+        pad_b="T",
+        net="VCC",
+        layer_hint="B.Cu",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.vias) > 0
+    # Pad copper rectangles (unbuffered, world coords): 2×2 at (45,40)
+    # and (50,40).
+    pad_rects = [box(44, 39, 46, 41), box(49, 39, 51, 41)]
+    for via in result.vias:
+        pt = Point(via.x, via.y)
+        for i, rect in enumerate(pad_rects):
+            assert not rect.contains(pt), (
+                f"Via at ({via.x:.3f},{via.y:.3f}) lands on X3/{i + 1} pad"
+            )
+
+
+def test_multi_layer_route_avoids_same_net_tht_hole(tmp_path: Path) -> None:
+    """A same-net thru-hole pad's drill hole physically severs any track
+    crossing it.  The router must re-add the hole as an obstacle (the
+    world model drops same-net pad copper entirely) so A* routes around
+    the hole instead of running a track straight through it."""
+    from shapely.geometry import LineString, Point
+
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    # X2: same-net THT pad sitting between R1/1 and C1/1.  Drill 3.0 mm
+    # is large enough that a straight track at x≈45 would cross the hole.
+    x2 = (
+        "\n\t# ---- X2: same-net THT transit pad between R1 and C1 ----\n"
+        '\t(footprint "user_add:tht-blocker"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "88888888-0000-0000-0000-000000000008")\n'
+        "\t\t(at 45.0 30.0 0.0)\n"
+        '\t\t(property "Reference" "X2")\n'
+        '\t\t(property "Value" "X2")\n'
+        '\t\t(pad "1" thru_hole circle\n'
+        "\t\t\t(at 0.0 0.0)\n"
+        "\t\t\t(size 4.0 4.0)\n"
+        "\t\t\t(drill 3.0)\n"
+        '\t\t\t(layers "*.Cu" "*.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x2 + ")\n")
+
+    # R1/1 (29.5, 30) F.Cu -> C1/1 (60, 29.5) F.Cu, both VCC.
+    # Without the hole obstacle, A* would run a track at y≈30 through
+    # X2's drill (center 45,30, r=1.5).  The hole forces a detour.
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="C1",
+        pad_b="1",
+        net="VCC",
+        # Both R1/1 and C1/1 are SMD on F.Cu → single-layer route.
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
+    # No segment may cross the actual drill hole (r=1.5 at (45, 30)).
+    hole = Point(45.0, 30.0).buffer(1.5)
+    for seg in result.segments:
+        line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
+        assert not line.intersects(hole), (
+            f"Segment {seg.x1:.3f},{seg.y1:.3f}->{seg.x2:.3f},{seg.y2:.3f} crosses X2 drill hole"
+        )
+
+
+def _board_with_bay_connector(tmp_path: Path) -> Path:
+    """Fixture board + X1 edge connector at the top edge (baseline outline
+    top y=60): X1 draws its bay with fp Edge.Cuts items (top at local y=4,
+    world y=64) and carries pad T at local (2, 2) — world (64, 62) — which
+    sits in the bay, above the gr-only outline."""
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    x1 = (
+        "\n\t# ---- X1: edge connector bay drawn with fp Edge.Cuts ----\n"
+        '\t(footprint "user_add:edge-connector"\n'
+        '\t\t(layer "F.Cu")\n'
+        '\t\t(uuid "77777777-0000-0000-0000-000000000007")\n'
+        "\t\t(at 62.0 60.0 0.0)\n"
+        '\t\t(property "Reference" "X1")\n'
+        '\t\t(property "Value" "X1")\n'
+        "\t\t(fp_line\n"
+        "\t\t\t(start -3.0 0.0)\n"
+        "\t\t\t(end -3.0 4.0)\n"
+        "\t\t\t(stroke (width 0.1) (type solid))\n"
+        '\t\t\t(layer "Edge.Cuts")\n'
+        "\t\t)\n"
+        "\t\t(fp_line\n"
+        "\t\t\t(start -3.0 4.0)\n"
+        "\t\t\t(end 7.0 4.0)\n"
+        "\t\t\t(stroke (width 0.1) (type solid))\n"
+        '\t\t\t(layer "Edge.Cuts")\n'
+        "\t\t)\n"
+        "\t\t(fp_line\n"
+        "\t\t\t(start 7.0 4.0)\n"
+        "\t\t\t(end 7.0 0.0)\n"
+        "\t\t\t(stroke (width 0.1) (type solid))\n"
+        '\t\t\t(layer "Edge.Cuts")\n'
+        "\t\t)\n"
+        '\t\t(pad "T" smd rect\n'
+        "\t\t\t(at 2.0 2.0)\n"
+        "\t\t\t(size 1.0 1.0)\n"
+        '\t\t\t(layers "F.Cu" "F.Mask")\n'
+        '\t\t\t(net 1 "VCC")\n'
+        "\t\t)\n"
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + x1 + ")\n")
+    return dst
+
+
+def test_board_bbox_includes_footprint_edge_cuts_profile(tmp_path: Path) -> None:
+    """Edge-mounted connectors describe the notch they sit in with
+    footprint-level Edge.Cuts items; those are part of the board outline
+    and must widen the AABB (baseline outline (0,0)-(70,60) → top 64)."""
+    from kcaa.router.world_model import _board_bbox
+
+    dst = _board_with_bay_connector(tmp_path)
+    data = load_pcb(str(dst))
+    bbox = _board_bbox(data)
+    assert bbox == (20.0, 20.0, 70.0, 64.0)
+
+
+def test_auto_route_pair_reaches_pad_in_footprint_drawn_bay(tmp_path: Path) -> None:
+    """A route into a pad sitting in a footprint-drawn bay (above the gr-only
+    outline) must pass the board-bounds check once the outline includes the
+    footprint Edge.Cuts profile."""
+    dst = _board_with_bay_connector(tmp_path)
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="X1",
+        pad_b="T",
+        net="VCC",
+        # R1/1 SMD F.Cu → X1/T THT; both share F.Cu → single-layer.
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert result.end == pytest.approx((64.0, 62.0), abs=0.02)
+    assert len(result.segments) > 0
+
+
+# ---------------------------------------------------------------------------
+# Edge.Cuts internal openings
+# ---------------------------------------------------------------------------
+
+
+def _board_with_opening(tmp_path: Path, rect: tuple[float, float, float, float]) -> Path:
+    """Fixture board + one internal gr_rect opening on Edge.Cuts.
+
+    Baseline outline is (20,20)-(70,60); the opening must sit inside it.
+    """
+    src = _fixture_pcb()
+    dst = tmp_path / "board.kicad_pcb"
+    board = Path(src).read_text().rstrip()
+    assert board.endswith(")")
+    x1, y1, x2, y2 = rect
+    opening = (
+        "\n\t# ---- internal Edge.Cuts opening ----\n"
+        "\t(gr_rect\n"
+        f"\t\t(start {x1} {y1})\n"
+        f"\t\t(end {x2} {y2})\n"
+        "\t\t(stroke (width 0.1) (type solid))\n"
+        "\t\t(fill none)\n"
+        '\t\t(layer "Edge.Cuts")\n'
+        "\t)\n"
+    )
+    dst.write_text(board[:-1] + opening + ")\n")
+    return dst
+
+
+def test_edge_cuts_internal_rect_becomes_opening_obstacle(tmp_path: Path) -> None:
+    """A closed gr_rect fully inside the outline is a routing-slot opening:
+    it must appear in the world model as an all-layer obstacle of kind
+    "opening", not just widen the board AABB."""
+    from kcaa.router.world_model import build_world_model
+
+    dst = _board_with_opening(tmp_path, (40.0, 25.0, 50.0, 35.0))
+    world = build_world_model(str(dst), net_filter=None)
+    openings = [o for o in world.obstacles if o.kind == "opening"]
+    assert len(openings) == 1
+    o = openings[0]
+    # Slot polygon matches the requested rect (world coords).
+    assert o.shape.bounds == pytest.approx((40.0, 25.0, 50.0, 35.0))
+    assert o.layers == frozenset({"F.Cu", "B.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu"})
+    assert o.net is None
+
+
+def test_auto_route_pair_detours_around_internal_opening(tmp_path: Path) -> None:
+    """R1 (30,30) -> C1 (60,30) crosses a 40..50 x 25..35 opening on the
+    straight line; the router must route around it (no segment may cross
+    the slot)."""
+    from shapely.geometry import LineString, Polygon
+
+    dst = _board_with_opening(tmp_path, (40.0, 25.0, 50.0, 35.0))
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="C1",
+        pad_b="1",
+        net="VCC",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
+    slot = Polygon([(40.0, 25.0), (50.0, 25.0), (50.0, 35.0), (40.0, 35.0)])
+    for seg in result.segments:
+        line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
+        assert not line.intersects(slot), (
+            f"Segment {seg.x1:.3f},{seg.y1:.3f}->{seg.x2:.3f},{seg.y2:.3f} "
+            f"crosses the Edge.Cuts opening"
+        )
+
+
+def test_auto_route_pair_detours_around_tall_opening(tmp_path: Path) -> None:
+    """An opening TALLER than the pad +/-5 mm search box (it extends beyond
+    the bbox on both sides, e.g. a slot between two connectors) previously
+    looked like an impassable wall: the A* grid is clipped to route_bbox, so
+    the detour around the slot was outside the search area and the route
+    failed even though one exists.  The bbox must grow to cover the opening
+    so the router can find the detour."""
+    from shapely.geometry import LineString, Polygon
+
+    # Baseline outline (20,20)-(70,60); opening is taller than the
+    # R1(30,30) -> C1(60,30) search box (bbox y = 25..35, even with the
+    # 2 mm grid margin: 23..37) on both sides, yet fully inside the
+    # outline (y 20..60).
+    dst = _board_with_opening(tmp_path, (40.0, 21.0, 50.0, 45.0))
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",
+        ref_b="C1",
+        pad_b="1",
+        net="VCC",
+        width=0.25,
+        clearance=0.2,
+    )
+    result = auto_route_pair(req)
+    assert len(result.segments) > 0
+    slot = Polygon([(40.0, 21.0), (50.0, 21.0), (50.0, 45.0), (40.0, 45.0)])
+    for seg in result.segments:
+        line = LineString([(seg.x1, seg.y1), (seg.x2, seg.y2)])
+        assert not line.intersects(slot), (
+            f"Segment {seg.x1:.3f},{seg.y1:.3f}->{seg.x2:.3f},{seg.y2:.3f} "
+            f"crosses the tall Edge.Cuts opening"
+        )
+
+
+def test_auto_route_pair_rejects_pads_on_different_nets(tmp_path: Path) -> None:
+    """Routing two pads that are on DIFFERENT nets must fail fast with a
+    clear message instead of treating the target pad as a foreign-net
+    obstacle and failing deep inside A*."""
+    dst = _board_with_opening(tmp_path, (40.0, 25.0, 50.0, 35.0))
+    req = RouteRequest(
+        pcb_path=str(dst),
+        ref_a="R1",
+        pad_a="1",  # R1/1 is on VCC
+        ref_b="C1",
+        pad_b="1",  # C1/1 is on VCC
+        net="NET_A",  # matches neither pad -> early rejection
+        width=0.25,
+        clearance=0.2,
+    )
+    with pytest.raises(RouteFailure, match="cannot route between different nets"):
         auto_route_pair(req)
+
+
+def test_edge_cuts_open_notch_is_not_opening(tmp_path: Path) -> None:
+    """The X1 bay notch touches the board outline (it is carved out of the
+    edge), so it is part of the outline -- NOT an internal opening.  The
+    world model must not produce an "opening" obstacle for it."""
+    from kcaa.router.world_model import build_world_model
+
+    dst = _board_with_bay_connector(tmp_path)
+    world = build_world_model(str(dst), net_filter=None)
+    openings = [o for o in world.obstacles if o.kind == "opening"]
+    assert openings == []
+
+
+# ---------------------------------------------------------------------------
+# NPTH pad type index (type lives at [2], not [1])
+# ---------------------------------------------------------------------------
+
+
+def _fp_with_pad(pad_body: str, ref: str = "X1") -> str:
+    """One footprint with a single pad; returned as raw PCB text snippet."""
+    return (
+        '(footprint "test:npth"\n'
+        '\t(layer "F.Cu")\n'
+        "\t(at 100 100)\n"
+        f'\t(property "Reference" "{ref}")\n'
+        f'\t(property "Value" "{ref}")\n'
+        f"{pad_body}\n"
+        ")\n"
+    )
+
+
+def _load_pcb_text(pcb_text: str, tmp_path: Path) -> Path:
+    from kcaa.utils.pcb_sexp_utils import load_pcb as _lp
+
+    dst = tmp_path / "npth.kicad_pcb"
+    dst.write_text(f"(kicad_pcb (version 20240108) (generator pcbnew)\n{pcb_text}\n)\n")
+    _lp(str(dst))  # parse-validity smoke
+    return dst
+
+
+def test_npth_pad_becomes_drill_obstacle_not_pad_obstacle(tmp_path: Path) -> None:
+    """A KiCad NPTH pad (type at index [2], name '' at [1]) must produce a
+    drill-kind circular obstacle, not a pad-kind rectangle."""
+    from kcaa.router.world_model import build_world_model
+
+    pcb = _load_pcb_text(
+        _fp_with_pad(
+            '\t(pad "" np_thru_hole circle\n'
+            "\t\t(at 0 0)\n"
+            "\t\t(size 3.2 3.2)\n"
+            "\t\t(drill 1.6)\n"
+            '\t\t(layers "*.Cu" "*.Mask")\n'
+            "\t)\n"
+        ),
+        tmp_path,
+    )
+    world = build_world_model(str(pcb), net_filter=None)
+    drills = [o for o in world.obstacles if o.kind == "drill"]
+    pads = [o for o in world.obstacles if o.kind == "pad"]
+    assert len(drills) == 1, f"expected one drill obstacle, got {len(drills)}"
+    assert pads == [], "NPTH must not produce a pad-kind obstacle"
+    d = drills[0]
+    # Drill diameter 1.6 -> obstacle circle r=0.8 at footprint origin (100,100).
+    assert d.shape.area == pytest.approx(3.14159 * 0.8**2, rel=0.05)
+    assert (d.shape.centroid.x, d.shape.centroid.y) == pytest.approx((100.0, 100.0))
+    assert d.layers == frozenset({"F.Cu", "B.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu"})
+    assert d.net is None
+
+
+def test_npth_pad_rotated_with_footprint(tmp_path: Path) -> None:
+    """The drill center follows the footprint placement/rotation."""
+    from kcaa.router.world_model import build_world_model
+
+    pcb = _load_pcb_text(
+        _fp_with_pad(
+            '\t(pad "" np_thru_hole circle\n'
+            "\t\t(at 5 0)\n"
+            "\t\t(size 3.2 3.2)\n"
+            "\t\t(drill 1.6)\n"
+            '\t\t(layers "*.Cu" "*.Mask")\n'
+            "\t)\n",
+            ref="X1",
+        ).replace("(at 100 100)", "(at 100 100 90)"),
+        tmp_path,
+    )
+    world = build_world_model(str(pcb), net_filter=None)
+    drills = [o for o in world.obstacles if o.kind == "drill"]
+    assert len(drills) == 1
+    # Local (5,0) rotated 90 CW on screen -> world (100, 95).
+    assert (drills[0].shape.centroid.x, drills[0].shape.centroid.y) == pytest.approx((100.0, 95.0))
+
+
+def test_plated_thru_hole_pad_still_pad_obstacle(tmp_path: Path) -> None:
+    """A regular plated THT pad must keep producing a pad-kind obstacle --
+    the index fix must not misclassify non-NPTH pads."""
+    from kcaa.router.world_model import build_world_model
+
+    pcb = _load_pcb_text(
+        _fp_with_pad(
+            '\t(pad "1" thru_hole circle\n'
+            "\t\t(at 0 0)\n"
+            "\t\t(size 2.0 2.0)\n"
+            "\t\t(drill 1.0)\n"
+            '\t\t(layers "*.Cu" "*.Mask")\n'
+            '\t\t(net 1 "VCC")\n'
+            "\t)\n"
+        ),
+        tmp_path,
+    )
+    world = build_world_model(str(pcb), net_filter="OtherNet")
+    pads = [o for o in world.obstacles if o.kind == "pad"]
+    drills = [o for o in world.obstacles if o.kind == "drill"]
+    assert len(pads) == 1, "plated THT pad must remain a pad-kind obstacle"
+    assert drills == [], "plated THT pad must not become a drill obstacle"
+    assert pads[0].net == "VCC"

--- a/tests/unit/tools/test_footprint_index.py
+++ b/tests/unit/tools/test_footprint_index.py
@@ -108,6 +108,51 @@ class TestParseKicadModAttr:
 
 
 # ---------------------------------------------------------------------------
+# parse_kicad_mod — edge_cuts
+# ---------------------------------------------------------------------------
+
+
+class TestParseKicadModEdgeCuts:
+    def test_empty_by_default(self):
+        info = parse_kicad_mod(TEST_MOD)
+        assert info["edge_cuts"] == []
+
+    def test_parses_edge_cuts_lines(self, tmp_path):
+        mod = tmp_path / "EC.kicad_mod"
+        mod.write_text(
+            '(footprint "EC" (layer "F.Cu")'
+            "  (fp_line (start -1 0.5) (end 1.5 -0.5)"
+            '    (stroke (width 0.1) (type solid)) (layer "Edge.Cuts"))'
+            ")"
+        )
+        info = parse_kicad_mod(str(mod))
+        assert info["edge_cuts"] == [
+            {
+                "type": "fp_line",
+                "layer": "Edge.Cuts",
+                "x1": -1.0,
+                "y1": 0.5,
+                "x2": 1.5,
+                "y2": -0.5,
+                "width": 0.1,
+            }
+        ]
+
+    def test_ignores_non_edge_cuts_layers(self, tmp_path):
+        mod = tmp_path / "Mixed.kicad_mod"
+        mod.write_text(
+            '(footprint "Mixed" (layer "F.Cu")'
+            '  (fp_line (start 0 0) (end 1 1) (stroke (width 0.1)) (layer "F.CrtYd"))'
+            '  (fp_line (start 0 0) (end 2 2) (stroke (width 0.1)) (layer "Edge.Cuts"))'
+            ")"
+        )
+        info = parse_kicad_mod(str(mod))
+        assert len(info["edge_cuts"]) == 1
+        assert info["edge_cuts"][0]["x2"] == 2.0
+        assert info["edge_cuts"][0]["x1"] == 0.0
+
+
+# ---------------------------------------------------------------------------
 # parse_fp_lib_table — Table-type indirection
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/tools/test_pcb_query_tools.py
+++ b/tests/unit/tools/test_pcb_query_tools.py
@@ -191,6 +191,12 @@ class TestGetFootprint:
         result = _run(tools["get_footprint"](pcb_path=BOARD_FIXTURE, reference="U99", ctx=None))
         assert "error" in result
 
+    def test_includes_edge_cuts_field(self, tools):
+        """get_footprint returns an edge_cuts list (empty when none exist)."""
+        result = _run(tools["get_footprint"](pcb_path=BOARD_FIXTURE, reference="R1", ctx=None))
+        assert "edge_cuts" in result
+        assert isinstance(result["edge_cuts"], list)
+
 
 class TestGetFootprintBbox:
     def test_r1_bbox_no_rotation(self, tools, board_with_outline_copy):

--- a/tests/unit/utils/test_pcb_board_utils.py
+++ b/tests/unit/utils/test_pcb_board_utils.py
@@ -13,6 +13,7 @@ from kcaa.utils.pcb_board_utils import (
     add_gr_rect,
     get_edge_cuts_items,
     get_fp_courtyard_bbox,
+    get_fp_edge_cuts_items,
     remove_edge_cuts_items,
 )
 from kcaa.utils.pcb_sexp_utils import load_pcb
@@ -330,3 +331,185 @@ class TestGetFpCourtyardBbox:
         s = sx.Symbol
         fp = [s("footprint"), "TestLib:R", [s("at"), 0.0, 0.0, 0.0], [s("layer"), "F.Cu"]]
         assert get_fp_courtyard_bbox(fp, 0.0, 0.0, 0.0) is None
+
+
+# ---------------------------------------------------------------------------
+# get_fp_edge_cuts_items
+# ---------------------------------------------------------------------------
+
+
+class TestGetFpEdgeCutsItems:
+    def _fp_node(self):
+        """A footprint node with fp graphics on several layers."""
+        import sexpdata as sx
+
+        s = sx.Symbol
+        return [
+            s("footprint"),
+            "TestLib:EC",
+            [s("at"), 0.0, 0.0, 0.0],
+            [s("layer"), "F.Cu"],
+            [
+                s("fp_line"),
+                [s("start"), -1.0, 0.5],
+                [s("end"), 1.5, -0.5],
+                [s("stroke"), [s("width"), 0.1], [s("type"), s("solid")]],
+                [s("layer"), "Edge.Cuts"],
+            ],
+            [
+                s("fp_arc"),
+                [s("start"), 0.0, 0.0],
+                [s("mid"), 1.0, 1.0],
+                [s("end"), 2.0, 0.0],
+                [s("stroke"), [s("width"), 0.2]],
+                [s("layer"), "Edge.Cuts"],
+            ],
+            [
+                s("fp_rect"),
+                [s("start"), 0.0, 0.0],
+                [s("end"), 3.0, 4.0],
+                [s("stroke"), [s("width"), 0.05]],
+                [s("layer"), "Edge.Cuts"],
+            ],
+            [
+                s("fp_circle"),
+                [s("center"), 5.0, 5.0],
+                [s("end"), 6.0, 5.0],
+                [s("stroke"), [s("width"), 0.3]],
+                [s("layer"), "Edge.Cuts"],
+            ],
+            [
+                s("fp_curve"),
+                [s("pts"), [s("xy"), 0.0, 0.0], [s("xy"), 1.0, 2.0], [s("xy"), 2.0, 0.0]],
+                [s("stroke"), [s("width"), 0.15]],
+                [s("layer"), "Edge.Cuts"],
+            ],
+            # Must be ignored: courtyard layer, plain line layer
+            [
+                s("fp_line"),
+                [s("start"), 0.0, 0.0],
+                [s("end"), 10.0, 10.0],
+                [s("layer"), "F.CrtYd"],
+                [s("width"), 0.05],
+            ],
+            [
+                s("fp_line"),
+                [s("start"), 0.0, 0.0],
+                [s("end"), 1.0, 1.0],
+                [s("layer"), "F.SilkS"],
+                [s("width"), 0.05],
+            ],
+            # Must be ignored: pads
+            [
+                s("pad"),
+                "1",
+                s("smd"),
+                s("rect"),
+                [s("at"), 0.0, 0.0, 0.0],
+                [s("size"), 1.0, 1.0],
+                [s("layer"), "F.Cu"],
+            ],
+        ]
+
+    def test_parses_all_fp_types(self):
+        items = get_fp_edge_cuts_items(self._fp_node())
+        assert [i["type"] for i in items] == [
+            "fp_line",
+            "fp_arc",
+            "fp_rect",
+            "fp_circle",
+            "fp_curve",
+        ]
+
+    def test_line_geometry(self):
+        item = get_fp_edge_cuts_items(self._fp_node())[0]
+        assert item["x1"] == pytest.approx(-1.0)
+        assert item["y1"] == pytest.approx(0.5)
+        assert item["x2"] == pytest.approx(1.5)
+        assert item["y2"] == pytest.approx(-0.5)
+        assert item["width"] == pytest.approx(0.1)
+        assert item["layer"] == "Edge.Cuts"
+
+    def test_arc_geometry(self):
+        item = get_fp_edge_cuts_items(self._fp_node())[1]
+        assert item["start_x"] == pytest.approx(0.0)
+        assert item["start_y"] == pytest.approx(0.0)
+        assert item["mid_x"] == pytest.approx(1.0)
+        assert item["mid_y"] == pytest.approx(1.0)
+        assert item["end_x"] == pytest.approx(2.0)
+        assert item["end_y"] == pytest.approx(0.0)
+        assert item["width"] == pytest.approx(0.2)
+
+    def test_rect_geometry(self):
+        item = get_fp_edge_cuts_items(self._fp_node())[2]
+        assert item["x2"] == pytest.approx(3.0)
+        assert item["y2"] == pytest.approx(4.0)
+
+    def test_circle_geometry(self):
+        item = get_fp_edge_cuts_items(self._fp_node())[3]
+        assert item["cx"] == pytest.approx(5.0)
+        assert item["cy"] == pytest.approx(5.0)
+        assert item["ex"] == pytest.approx(6.0)
+        assert item["ey"] == pytest.approx(5.0)
+        assert item["width"] == pytest.approx(0.3)
+
+    def test_curve_pts(self):
+        item = get_fp_edge_cuts_items(self._fp_node())[4]
+        assert item["pts"] == [(0.0, 0.0), (1.0, 2.0), (2.0, 0.0)]
+        assert item["width"] == pytest.approx(0.15)
+
+    def test_ignores_non_edge_cuts_layers_and_pads(self):
+        items = get_fp_edge_cuts_items(self._fp_node())
+        assert len(items) == 5
+        assert all(i["layer"] == "Edge.Cuts" for i in items)
+
+    def test_empty_without_edge_cuts(self):
+        import sexpdata as sx
+
+        s = sx.Symbol
+        fp = [
+            s("footprint"),
+            "TestLib:Plain",
+            [
+                s("fp_line"),
+                [s("start"), 0.0, 0.0],
+                [s("end"), 1.0, 1.0],
+                [s("layer"), "F.SilkS"],
+                [s("width"), 0.05],
+            ],
+        ]
+        assert get_fp_edge_cuts_items(fp) == []
+
+    def test_legacy_edge_cuts_layer_name(self):
+        import sexpdata as sx
+
+        s = sx.Symbol
+        fp = [
+            [
+                s("fp_line"),
+                [s("start"), 0.0, 0.0],
+                [s("end"), 2.0, 0.0],
+                [s("layer"), "Edge_Cuts"],
+                [s("width"), 0.1],
+            ],
+        ]
+        items = get_fp_edge_cuts_items(fp)
+        assert len(items) == 1
+        assert items[0]["layer"] == "Edge_Cuts"
+
+    def test_bare_width_node_supported(self):
+        """Legacy fp_line with a direct (width ...) child still yields width."""
+        import sexpdata as sx
+
+        s = sx.Symbol
+        fp = [
+            [
+                s("fp_line"),
+                [s("start"), 0.0, 0.0],
+                [s("end"), 1.0, 1.0],
+                [s("layer"), "Edge.Cuts"],
+                [s("width"), 0.07],
+            ],
+        ]
+        item = get_fp_edge_cuts_items(fp)[0]
+        assert item["width"] == pytest.approx(0.07)


### PR DESCRIPTION
Release of `develop` into `main`. 5 commits ahead.

## Features

- **#84 — per-project session persistence** (`feat(plugin)`): sessions stamped with the owning `.kicad_pro` (schema v2) and auto-restored on first panel display for the currently open project; a 1 s two-tick-confirmed poll follows project switches in place (the panel swaps session instead of lingering or stacking windows); also fixes the `None/mcp` URL error (`LLMClient.set_base_url()`)

## Fixes

- **#76 — footprint Edge.Cuts geometry**: expose footprint `Edge.Cuts` geometry through pcb-query
- **#78 — streamed LLM responses over subprocess**: the SSL-fallback path (KiCad's embedded Python lacks `ssl`) now relays SSE deltas chunk-by-chunk instead of degrading to a one-shot non-streaming call; non-streaming timeouts unified 60 s → 300 s
- **#80 — reload KiCad on every turn exit**: board reload was skipped when a tool call failed — failure paths now mark dirty paths and reach `_auto_reload_modified_files`
- **#82 — router pads**: routing to duplicate-named pads (edge-connector fingers sharing a net) and edge-mounted pads; single-layer A* now filters obstacles by routing layer

## Commits (`main..develop`, 5)

| Commit | Subject |
|---|---|
| `43003e6` | Merge pull request #76 from paul356/feat/footprint-edge-cuts |
| `8c09426` | fix(plugin): reload KiCad on every turn exit despite failed tool calls (#80) |
| `b18bb4b` | feat(plugin): stream LLM responses via subprocess relay and unify timeouts (#78) |
| `fb5dbef` | fix(router): route to duplicate-named and edge-mounted pads (#82) |
| `dd57776` | feat(plugin): per-project session persistence and follow project switches (#84) |