### PR TITLE
fix(plugin): make Anthropic auth symmetric with OpenAI-compatible endpoints

### DIFF
--- a/kicad_plugin/README.md
+++ b/kicad_plugin/README.md
@@ -79,7 +79,7 @@ Settings are stored in the KiCad user config directory:
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `llm_provider` | `openai`, `anthropic`, or `ollama` | `openai` |
-| `llm_api_key` | API key; optional for unauthenticated OpenAI-compatible endpoints | (empty) |
+| `llm_api_key` | API key; optional for unauthenticated compatible endpoints | (empty) |
 | `llm_model` | Model name | `gpt-4o` |
 | `llm_base_url` | Custom OpenAI, Anthropic, or Ollama-compatible endpoint URL | (uses provider default) |
 | `server_port` | Fixed port for MCP server (0 = auto) | `0` |

--- a/kicad_plugin/README.md
+++ b/kicad_plugin/README.md
@@ -79,7 +79,7 @@ Settings are stored in the KiCad user config directory:
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `llm_provider` | `openai`, `anthropic`, or `ollama` | `openai` |
-| `llm_api_key` | API key; optional for compatible endpoints without authentication | (empty) |
+| `llm_api_key` | API key; optional for unauthenticated OpenAI-compatible endpoints | (empty) |
 | `llm_model` | Model name | `gpt-4o` |
 | `llm_base_url` | Custom OpenAI, Anthropic, or Ollama-compatible endpoint URL | (uses provider default) |
 | `server_port` | Fixed port for MCP server (0 = auto) | `0` |

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -213,8 +213,6 @@ _current_reasoning: list[str] = []
 
 def _is_certificate_verification_error(error: BaseException) -> bool:
     """Return whether *error* was caused by an untrusted certificate chain."""
-    import urllib.error
-
     reason = getattr(error, "reason", error)
     try:
         import ssl
@@ -223,8 +221,6 @@ def _is_certificate_verification_error(error: BaseException) -> bool:
             return True
     except ImportError:
         pass
-    if not isinstance(error, urllib.error.URLError):
-        return False
     return "certificate verify failed" in str(reason).lower()
 
 

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -213,6 +213,8 @@ _current_reasoning: list[str] = []
 
 def _is_certificate_verification_error(error: BaseException) -> bool:
     """Return whether *error* was caused by an untrusted certificate chain."""
+    import urllib.error
+
     reason = getattr(error, "reason", error)
     try:
         import ssl
@@ -221,6 +223,8 @@ def _is_certificate_verification_error(error: BaseException) -> bool:
             return True
     except ImportError:
         pass
+    if not isinstance(error, urllib.error.URLError):
+        return False
     return "certificate verify failed" in str(reason).lower()
 
 

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -2206,11 +2206,7 @@ class LLMClient:
         if anthropic_tools:
             payload["tools"] = anthropic_tools
         encoded = json.dumps(payload).encode()
-        headers = {
-            "Content-Type": "application/json",
-            "x-api-key": self._settings.llm_api_key,
-            "anthropic-version": "2023-06-01",
-        }
+        headers = self._anthropic_headers()
 
         if _in_process_ssl is not False:
             req = urllib.request.Request(url, data=encoded, headers=headers, method="POST")
@@ -2320,6 +2316,16 @@ class LLMClient:
         return _subprocess_sse_stream(
             url, headers, encoded, timeout=300, fmt="anthropic", on_text_delta=on_text_delta
         )
+
+    def _anthropic_headers(self) -> dict[str, str]:
+        """Build headers for Anthropic-compatible endpoints with optional auth."""
+        headers = {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+        if self._settings.llm_api_key:
+            headers["x-api-key"] = self._settings.llm_api_key
+        return headers
 
     def _openai_headers(self) -> dict[str, str]:
         """Build headers for OpenAI-compatible endpoints with optional auth."""
@@ -2447,11 +2453,7 @@ class LLMClient:
         if anthropic_tools:
             payload["tools"] = anthropic_tools
         encoded = json.dumps(payload).encode()
-        headers = {
-            "Content-Type": "application/json",
-            "x-api-key": self._settings.llm_api_key,
-            "anthropic-version": "2023-06-01",
-        }
+        headers = self._anthropic_headers()
         try:
             status, text = _https_post_json(url, headers, encoded, timeout=300)
         except RuntimeError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "kicad-python>=0.7.1",  # KiCad IPC API bindings (requires KiCad 9+ GUI running)
     "shapely>=2.0.0",      # Geometric operations for PNS router (polygon ops, buffering, visibility)
     "rtree>=1.3.0",        # Spatial index for fast obstacle queries in PNS router
+    "certifi>=2026.2.25",
 ] 
 
 [project.urls]

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -978,6 +978,24 @@ class TestOpenAICompatibleRequests:
 
         assert client._openai_headers() == {"Content-Type": "application/json"}
 
+    def test_api_key_adds_x_api_key(self):
+        client = _make_client()
+
+        assert client._anthropic_headers() == {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": "sk-test",
+        }
+
+    def test_empty_api_key_omits_x_api_key(self):
+        client = _make_client()
+        client._settings.llm_api_key = ""
+
+        assert client._anthropic_headers() == {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+
 
 class TestHttpsFallback:
     def test_certificate_error_retries_with_plugin_ca_bundle(self):

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -1066,12 +1066,6 @@ class TestHttpsFallback:
 
         assert llm_client._is_certificate_verification_error(error) is True
 
-    def test_certificate_text_without_urlerror_is_not_certificate_error(self):
-        assert (
-            llm_client._is_certificate_verification_error(OSError("certificate verify failed"))
-            is False
-        )
-
 
 # ---------------------------------------------------------------------------
 # Streaming tests

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -1038,6 +1038,22 @@ class TestHttpsFallback:
         assert result == (200, "ok")
         run.assert_called_once()
 
+    def test_certificate_error_matches_reason_text(self):
+        error = urllib.error.URLError(
+            OSError(
+                "CERTIFICATE_VERIFY_FAILED certificate verify failed: "
+                "unable to get local issuer certificate"
+            )
+        )
+
+        assert llm_client._is_certificate_verification_error(error) is True
+
+    def test_certificate_text_without_urlerror_is_not_certificate_error(self):
+        assert (
+            llm_client._is_certificate_verification_error(OSError("certificate verify failed"))
+            is False
+        )
+
 
 # ---------------------------------------------------------------------------
 # Streaming tests
@@ -1188,9 +1204,14 @@ class TestStreaming:
         assert call_kwargs["timeout"] == 300
         assert result["message"]["content"] == "Relayed text"
 
-    def test_stream_anthropic_ssl_fallback_streams_via_subprocess(self):
-        import urllib.error
-
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "unknown url type: https",
+            ssl.SSLCertVerificationError(1, "unable to get local issuer certificate"),
+        ],
+    )
+    def test_stream_anthropic_ssl_fallback_streams_via_subprocess(self, reason):
         client = _make_client()
         client._settings.llm_provider = "anthropic"
         chunks = []
@@ -1203,9 +1224,10 @@ class TestStreaming:
         with (
             patch(
                 "urllib.request.urlopen",
-                side_effect=urllib.error.URLError("unknown url type: https"),
+                side_effect=urllib.error.URLError(reason),
             ),
             patch("kicad_plugin.llm_client._in_process_ssl", None),
+            patch("kicad_plugin.llm_client._plugin_ssl_context", return_value=None),
             patch(
                 "kicad_plugin.llm_client._subprocess_sse_stream",
                 return_value=subprocess_result,

--- a/uv.lock
+++ b/uv.lock
@@ -1136,9 +1136,10 @@ wheels = [
 
 [[package]]
 name = "kcaa"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
+    { name = "certifi" },
     { name = "defusedxml" },
     { name = "fastmcp" },
     { name = "kicad-python" },
@@ -1188,6 +1189,7 @@ visualization = [
 
 [package.metadata]
 requires-dist = [
+    { name = "certifi", specifier = ">=2026.2.25" },
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "kicad-python", specifier = ">=0.7.1" },


### PR DESCRIPTION
Make the Anthropic provider treat an empty API key the same way the OpenAI-compatible path does: omit the auth header instead of sending it empty, so unauthenticated Anthropic-compatible endpoints work without a token.

## Changes

1. **Symmetric optional auth** — `kicad_plugin/llm_client.py`: new `_anthropic_headers()` mirrors `_openai_headers()`; `_stream_anthropic` and `_call_anthropic` now omit the `x-api-key` header when no API key is configured (previously they always sent `x-api-key: <possibly empty>`). Behavior against the real Anthropic API is unchanged — an empty key fails auth identically whether the header is empty or absent.

2. **Documentation** — `kicad_plugin/README.md`: `llm_api_key` row now accurately states the key is optional for unauthenticated compatible endpoints.

3. **certifi as a direct dependency** — `pyproject.toml` + `uv.lock`: the HTTPS retry for certificate-verification failures (added in #62) relies on the certifi CA bundle being present in the plugin venv, where certifi was only a transitive dependency. Declaring it directly guarantees the retry finds a bundle.

4. **Tests** — `tests/unit/plugin/test_llm_client.py`:
   - `test_api_key_adds_x_api_key` / `test_empty_api_key_omits_x_api_key` for the new helper
   - `test_stream_anthropic_ssl_fallback_streams_via_subprocess` parametrized with the certificate-verification reason + `_plugin_ssl_context` patch, mirroring the openai test
   - unit test for the `"certificate verify failed"` reason-text match in `_is_certificate_verification_error`

Note: `uv.lock` also repairs a stale root-package version entry (0.2.0 → 0.2.1, matching `pyproject.toml`), applied automatically by `uv add`.

## Testing

- Plugin unit tests: `173 passed`
- Ruff lint + format: passed
- Bandit: passed (pre-commit hook)