### PR TITLE
fix(plugin): LLM stream aborts on empty choices chunk; Anthropic-compatible provider requires max_tokens

### DIFF
--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -210,6 +210,12 @@ _in_process_ssl: bool | None = None
 # Storage for reasoning_content (DeepSeek thinking mode)
 _current_reasoning: list[str] = []
 
+# The Anthropic Messages API requires max_tokens on every request; some
+# Anthropic-compatible gateways (e.g. Alibaba Model Studio) reject requests
+# without it.  Use this default when the user has not configured an output
+# cap via llm_max_tokens.
+_ANTHROPIC_DEFAULT_MAX_TOKENS = 4096
+
 
 def _is_certificate_verification_error(error: BaseException) -> bool:
     """Return whether *error* was caused by an untrusted certificate chain."""
@@ -394,8 +400,8 @@ try:
                             text_blocks[idx] = block.get("text", "")
                         elif btype == "tool_use":
                             tool_blocks[idx] = {
-                                "id": block["id"],
-                                "name": block["name"],
+                                "id": block.get("id", ""),
+                                "name": block.get("name", ""),
                                 "input_json": "",
                             }
                     elif etype == "content_block_delta":
@@ -2202,9 +2208,10 @@ class LLMClient:
             "system": system,
             "messages": messages,
             "stream": True,
+            # Anthropic API requires max_tokens on every request; compatible
+            # gateways reject requests without it (400 InvalidParameter).
+            "max_tokens": self._max_tokens or _ANTHROPIC_DEFAULT_MAX_TOKENS,
         }
-        if self._max_tokens > 0:
-            payload["max_tokens"] = self._max_tokens
         if anthropic_tools:
             payload["tools"] = anthropic_tools
         encoded = json.dumps(payload).encode()
@@ -2246,8 +2253,8 @@ class LLMClient:
                                 text_blocks[idx] = block.get("text", "")
                             elif btype == "tool_use":
                                 tool_blocks[idx] = {
-                                    "id": block["id"],
-                                    "name": block["name"],
+                                    "id": block.get("id", ""),
+                                    "name": block.get("name", ""),
                                     "input_json": "",
                                 }
 
@@ -2452,9 +2459,10 @@ class LLMClient:
             "model": self._settings.llm_model,
             "system": system,
             "messages": messages,
+            # Anthropic API requires max_tokens on every request; compatible
+            # gateways reject requests without it (400 InvalidParameter).
+            "max_tokens": self._max_tokens or _ANTHROPIC_DEFAULT_MAX_TOKENS,
         }
-        if self._max_tokens > 0:
-            payload["max_tokens"] = self._max_tokens
         if anthropic_tools:
             payload["tools"] = anthropic_tools
         encoded = json.dumps(payload).encode()
@@ -2475,15 +2483,18 @@ class LLMClient:
             return {"error": f"Unexpected response from Anthropic: {text[:200]}"}
 
         content_blocks_resp = body.get("content", [])
-        text_blocks = [b["text"] for b in content_blocks_resp if b.get("type") == "text"]
+        text_blocks = [b.get("text", "") for b in content_blocks_resp if b.get("type") == "text"]
         tool_use_blocks = [b for b in content_blocks_resp if b.get("type") == "tool_use"]
         message: dict[str, Any] = {"content": "\n".join(text_blocks)}
         if tool_use_blocks:
             message["tool_calls"] = [
                 {
-                    "id": b["id"],
+                    "id": b.get("id", ""),
                     "type": "function",
-                    "function": {"name": b["name"], "arguments": json.dumps(b.get("input", {}))},
+                    "function": {
+                        "name": b.get("name", ""),
+                        "arguments": json.dumps(b.get("input", {})),
+                    },
                 }
                 for b in tool_use_blocks
             ]

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -213,8 +213,11 @@ _current_reasoning: list[str] = []
 # The Anthropic Messages API requires max_tokens on every request; some
 # Anthropic-compatible gateways (e.g. Alibaba Model Studio) reject requests
 # without it.  Use this default when the user has not configured an output
-# cap via llm_max_tokens.
-_ANTHROPIC_DEFAULT_MAX_TOKENS = 4096
+# cap via llm_max_tokens.  32768 is the highest value the token-plan gateway
+# is known to accept (probed up to 131072 without rejection) and far above
+# any realistic single-turn output, so max_tokens never becomes the binding
+# constraint that truncates a tool-calling response.
+_ANTHROPIC_DEFAULT_MAX_TOKENS = 32768
 
 
 def _is_certificate_verification_error(error: BaseException) -> bool:

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -1951,8 +1951,11 @@ class LLMClient:
     def _stream_openai(self, system: str, tools: list[dict], on_text_delta) -> dict[str, Any]:
         """Call OpenAI-compatible API with streaming enabled.
 
-        Uses in-process urllib for true SSE streaming when SSL is available.
-        Falls back to non-streaming via _call_openai (subprocess) otherwise.
+        Uses in-process urllib for true SSE streaming when SSL is available;
+        otherwise relays the SSE stream through the plugin-venv Python
+        subprocess (_subprocess_sse_stream).  Both paths stream — there is no
+        non-streaming fallback here; _call_openai is used only by callers
+        that do not provide on_text_delta (e.g. history compaction).
         """
         global _current_reasoning
         _current_reasoning = []
@@ -2181,8 +2184,11 @@ class LLMClient:
     def _stream_anthropic(self, system: str, tools: list[dict], on_text_delta) -> dict[str, Any]:
         """Call Anthropic API with streaming enabled.
 
-        Uses in-process urllib for true SSE streaming when SSL is available.
-        Falls back to non-streaming via _call_anthropic (subprocess) otherwise.
+        Uses in-process urllib for true SSE streaming when SSL is available;
+        otherwise relays the SSE stream through the plugin-venv Python
+        subprocess (_subprocess_sse_stream, fmt="anthropic").  Both paths
+        stream — there is no non-streaming fallback here; _call_anthropic is
+        used only by callers without on_text_delta (e.g. history compaction).
         """
         global _in_process_ssl
         import urllib.error

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -2052,6 +2052,8 @@ class LLMClient:
                         message["reasoning_content"] = "".join(_current_reasoning)
                     return {"finish_reason": finish_reason, "message": message}
 
+            except urllib.error.HTTPError as e:
+                return {"error": f"HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:200]}"}
             except urllib.error.URLError as e:
                 if not _needs_https_fallback(e):
                     return {"error": f"HTTPS request failed: {e}"}
@@ -2322,6 +2324,8 @@ class LLMClient:
                         finish = "stop"
                     return {"finish_reason": finish, "message": message_out}
 
+            except urllib.error.HTTPError as e:
+                return {"error": f"HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:200]}"}
             except urllib.error.URLError as e:
                 if not _needs_https_fallback(e):
                     return {"error": f"HTTPS request failed: {e}"}

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -213,11 +213,11 @@ _current_reasoning: list[str] = []
 # The Anthropic Messages API requires max_tokens on every request; some
 # Anthropic-compatible gateways (e.g. Alibaba Model Studio) reject requests
 # without it.  Use this default when the user has not configured an output
-# cap via llm_max_tokens.  32768 is the highest value the token-plan gateway
-# is known to accept (probed up to 131072 without rejection) and far above
-# any realistic single-turn output, so max_tokens never becomes the binding
-# constraint that truncates a tool-calling response.
-_ANTHROPIC_DEFAULT_MAX_TOKENS = 32768
+# cap via llm_max_tokens.  65536 is accepted by the token-plan gateway
+# (probed up to 131072 without rejection) and far above any realistic
+# single-turn output, so max_tokens never becomes the binding constraint
+# that truncates a tool-calling response.
+_ANTHROPIC_DEFAULT_MAX_TOKENS = 65536
 
 
 def _is_certificate_verification_error(error: BaseException) -> bool:

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -459,7 +459,10 @@ try:
                     chunk = json.loads(data_str)
                 except json.JSONDecodeError:
                     continue
-                choice = chunk.get("choices", [{}])[0]
+                _choices = chunk.get("choices") or []
+                if not _choices:
+                    continue
+                choice = _choices[0]
                 fr = choice.get("finish_reason")
                 if fr is not None:
                     finish_reason = fr
@@ -1991,7 +1994,10 @@ class LLMClient:
                         except json.JSONDecodeError:
                             continue
 
-                        choice = chunk.get("choices", [{}])[0]
+                        _choices = chunk.get("choices") or []
+                        if not _choices:
+                            continue
+                        choice = _choices[0]
                         fr = choice.get("finish_reason")
                         if fr is not None:
                             finish_reason = fr
@@ -2366,7 +2372,10 @@ class LLMClient:
         if not isinstance(body, dict):
             return {"error": f"Unexpected response from OpenAI: {text[:200]}"}
 
-        choice = body.get("choices", [{}])[0]
+        _choices = body.get("choices") or []
+        if not _choices:
+            return {"error": "OpenAI response contained no choices"}
+        choice = _choices[0]
         return {
             "finish_reason": choice.get("finish_reason", "stop"),
             "message": choice.get("message", {}),

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -552,16 +552,28 @@ if _WX_AVAILABLE:
                 log.error("_init_llm_client failed: %s\n%s", e, traceback.format_exc())
 
         def _on_panel_show(self, event) -> None:
-            """Initialise the LLM client (and restore the session) on display.
+            """Initialise on first display; re-sync the session after hides.
 
             Deferred from plugin registration so restore/prompt only happens
             while the user looks at the panel.  The backend base URL is
             injected later by _on_server_started once the backend is up, so
             an early panel display is safe.  An already-initialised client
-            (e.g. after a backend Restart) is left untouched.
+            (e.g. after a backend Restart) is left untouched.  On a re-show
+            the project may have changed while the panel was hidden (the
+            project watch stays silent then), so the session is re-synced
+            with the current project — applied exactly once, on display.
             """
             if event.IsShown() and self._llm_client is None:
                 self._init_llm_client()
+            elif event.IsShown():
+                try:
+                    project = self._collect_active_project()
+                    if project != self._active_project and not self._busy:
+                        self._active_project = project
+                        self._watch_candidate_seen = False
+                        self._autoload_session()
+                except Exception:
+                    log.debug("project re-sync on panel show failed", exc_info=True)
             event.Skip()
 
         # ------------------------------------------------------------------ #
@@ -2357,6 +2369,12 @@ if _WX_AVAILABLE:
             equally transient), so a switch is only acted on after two
             consecutive identical readings.
             """
+            if not self.IsShown():
+                # Panel dismissed: stay silent — no session dialogs from a
+                # hidden frame.  The snapshot resyncs on the next Show
+                # (_on_panel_show), so a project switched while hidden is
+                # applied exactly once, when the user looks at the panel.
+                return
             if self._busy:
                 return
             project = self._collect_active_project()
@@ -2452,17 +2470,21 @@ if _WX_AVAILABLE:
                 self._llm_client.reset()
 
         def _on_close(self, event) -> None:
-            """Panel close (user clicks X, or watchdog force-close): tear down
-            completely.
+            """Panel close: user X hides; watchdog force-close tears down.
 
-            Every user message, AI reply and cancellation is persisted as it
-            happens, so closing loses nothing — the next open restores the
-            session from disk.  The panel is never merely hidden: a hidden
-            panel would keep its timers and MCP server running in the
-            background.  Either the panel stays usable (project switch keeps
-            it open and swaps the session) or it is destroyed — no
-            half-alive state.
+            A user-close is vetoed and the panel hidden, never destroyed:
+            AssistantPanel is a top-level wx.Frame, and Destroy() on such a
+            frame behaves as a forced close that cascades into closing
+            KiCad's own project windows (issue #93).  The same frame and its
+            live MCP server are reused on the next reopen, and the suicide
+            watchdog ensures the hidden frame never outlives KiCad.  Only
+            the force-close path (KiCad itself already gone) tears down.
             """
+            if event.CanVeto():
+                event.Veto()
+                self.Hide()
+                return
+            # Force-close (suicide watchdog after KiCad exited) — tear down.
             if self._busy and self._cancel_event is not None:
                 # An in-flight turn ends with the panel: ask it to stop
                 # writing before we tear down.

--- a/kicad_plugin/ui/settings_dialog.py
+++ b/kicad_plugin/ui/settings_dialog.py
@@ -22,6 +22,9 @@ if _WX_AVAILABLE:
         """Simple dialog for editing plugin settings."""
 
         _PROVIDERS = ["openai", "anthropic", "ollama"]
+        # Vertical gap between form rows in the FlexGridSizer (must match the
+        # vgap literal used in _build_ui).
+        _GRID_VGAP = 6
 
         def __init__(self, parent, settings) -> None:
             super().__init__(parent, title="AI Assistant Settings", size=(600, 620))
@@ -153,6 +156,20 @@ if _WX_AVAILABLE:
 
             self.SetSizer(vbox)
             self.Layout()
+
+            # Reserve one extra form row (tallest typical control + grid vgap)
+            # so the last settings row is never clipped on dense themes.
+            control_heights = [
+                c.GetSize().GetHeight()
+                for c in (
+                    self._model,
+                    self._api_key,
+                    self._max_tokens,
+                    self._keep_recent_turns,
+                )
+            ]
+            row_extra = max(control_heights) + self._GRID_VGAP
+            self.SetSize(self.GetSize().GetWidth(), self.GetSize().GetHeight() + row_extra)
 
         def apply_to(self, settings) -> bool:
             """Write dialog values back to settings object.

--- a/kicad_plugin/ui/shell.js
+++ b/kicad_plugin/ui/shell.js
@@ -53,13 +53,14 @@ function _toolCallHtml(e) {
     var args = typeof e.args === 'string' ? _escapeHtml(e.args) : _escapeHtml(JSON.stringify(e.args, null, 2));
     var result = typeof e.result === 'string' ? _escapeHtml(e.result) : _escapeHtml(JSON.stringify(e.result, null, 2));
     var uid = 'tool_' + (e._seq || Math.random().toString(36).slice(2));
-    return '<details class="tools tool-details" id="' + uid + '" style="margin:2px 8px">'
+    return '<details open class="tools tool-details" id="' + uid + '" style="margin:2px 8px">'
         + '<summary class="tool-summary"><span style="color:' + iconColor + '">' + icon + '</span> '
         + '<span style="color:#444;font-weight:600">\u21B3 ' + _escapeHtml(e.name)
         + '</span></summary>'
         + '<div class="tool-body ' + css + '" data-details="' + uid + '">'
         + '<span style="color:#444">args:</span><br><pre style="margin:2px 0">' + args + '</pre>'
-        + '<span style="color:#444">result:</span><br><pre style="margin:2px 0">' + result + '</pre>'
+        + '<span style="color:#444">result:</span><br>'
+        + '<pre style="margin:2px 0;max-height:400px;overflow-y:auto">' + result + '</pre>'
         + '</div></details>';
 }
 
@@ -205,31 +206,55 @@ window._clearConversation = function() {
     window.scrollTo(0, 0);
 };
 
-// Click-to-collapse: clicking the tool body (args/result area) collapses
-// the details element.  Clicking the summary still expands natively.
-// Text selection is preserved: if the user has an active text selection
-// the click does NOT collapse (allowing copy via Ctrl+C).
+// Click-to-collapse: results are expanded by default; clicking the tool
+// body (args/result area) collapses the details element.  Clicking the
+// summary toggles natively.
+// Text selection is protected from interference:
+//  - a drag (mousedown then movement) is a selection gesture, never collapses
+//  - an active selection at click time prevents collapse
+//  - double-click (word / line selection) cancels the pending collapse that
+//    its first click would otherwise schedule
 (function _installToolCollapse() {
+    var _downX = 0, _downY = 0, _dragMoved = false, _collapseTimer = null;
+
+    document.addEventListener('mousedown', function(e) {
+        _downX = e.clientX;
+        _downY = e.clientY;
+        _dragMoved = false;
+    }, true);
+    document.addEventListener('mousemove', function(e) {
+        if (!_dragMoved &&
+                (Math.abs(e.clientX - _downX) > 4 || Math.abs(e.clientY - _downY) > 4)) {
+            _dragMoved = true;  // drag = selection gesture, not a click
+        }
+    }, true);
+    document.addEventListener('dblclick', function() {
+        if (_collapseTimer) {
+            clearTimeout(_collapseTimer);
+            _collapseTimer = null;
+        }
+    }, true);
+
     function _onToolBodyClick(e) {
+        if (e.button !== undefined && e.button !== 0) return;  // left button only
         var toolBody = e.target.closest('.tool-body');
         if (!toolBody) return;
-        // Don't collapse if the user is selecting / copying text.
+        if (_dragMoved) return;  // was a drag-select
         var sel = window.getSelection();
-        if (sel && sel.type === 'Range' && sel.toString().length > 0) return;
+        if (sel && !sel.isCollapsed && sel.toString().length > 0) return;  // active selection
         var detailsId = toolBody.getAttribute('data-details');
         if (!detailsId) return;
         var details = document.getElementById(detailsId);
-        if (details && details.open) {
+        if (!details || !details.open) return;
+        // Defer: the first click of a double-click would collapse before the
+        // dblclick event arrives; cancel the collapse when one follows.
+        if (_collapseTimer) clearTimeout(_collapseTimer);
+        _collapseTimer = setTimeout(function() {
+            _collapseTimer = null;
             details.open = false;
-        }
+        }, 250);
     }
-    if (document.readyState !== 'loading') {
-        document.addEventListener('click', _onToolBodyClick);
-    } else {
-        document.addEventListener('DOMContentLoaded', function() {
-            document.addEventListener('click', _onToolBodyClick);
-        });
-    }
+    document.addEventListener('click', _onToolBodyClick);
 })();
 
 // ---- Search / Find in conversation ----

--- a/kicad_plugin/ui/shell.js
+++ b/kicad_plugin/ui/shell.js
@@ -53,7 +53,7 @@ function _toolCallHtml(e) {
     var args = typeof e.args === 'string' ? _escapeHtml(e.args) : _escapeHtml(JSON.stringify(e.args, null, 2));
     var result = typeof e.result === 'string' ? _escapeHtml(e.result) : _escapeHtml(JSON.stringify(e.result, null, 2));
     var uid = 'tool_' + (e._seq || Math.random().toString(36).slice(2));
-    return '<details open class="tools tool-details" id="' + uid + '" style="margin:2px 8px">'
+    return '<details class="tools tool-details" id="' + uid + '" style="margin:2px 8px">'
         + '<summary class="tool-summary"><span style="color:' + iconColor + '">' + icon + '</span> '
         + '<span style="color:#444;font-weight:600">\u21B3 ' + _escapeHtml(e.name)
         + '</span></summary>'
@@ -206,26 +206,28 @@ window._clearConversation = function() {
     window.scrollTo(0, 0);
 };
 
-// Click-to-collapse: results are expanded by default; clicking the tool
-// body (args/result area) collapses the details element.  Clicking the
-// summary toggles natively.
+// Click-to-collapse: results expand via the summary (native toggle).
+// Clicking the tool body (args/result area) collapses the details element.
 // Text selection is protected from interference:
-//  - a drag (mousedown then movement) is a selection gesture, never collapses
+//  - only a genuine drag (mousedown then movement beyond normal click
+//    jitter) is treated as a selection gesture, never collapses
 //  - an active selection at click time prevents collapse
 //  - double-click (word / line selection) cancels the pending collapse that
 //    its first click would otherwise schedule
 (function _installToolCollapse() {
-    var _downX = 0, _downY = 0, _dragMoved = false, _collapseTimer = null;
+    var _downX = 0, _downY = 0, _drag = false, _collapseTimer = null;
 
     document.addEventListener('mousedown', function(e) {
         _downX = e.clientX;
         _downY = e.clientY;
-        _dragMoved = false;
+        _drag = false;
     }, true);
     document.addEventListener('mousemove', function(e) {
-        if (!_dragMoved &&
-                (Math.abs(e.clientX - _downX) > 4 || Math.abs(e.clientY - _downY) > 4)) {
-            _dragMoved = true;  // drag = selection gesture, not a click
+        // Human clicks wobble a few pixels; only flag movements well beyond
+        // that (10px radius) as drags that could create a text selection.
+        var dx = e.clientX - _downX, dy = e.clientY - _downY;
+        if (!_drag && (dx * dx + dy * dy) > 100) {
+            _drag = true;
         }
     }, true);
     document.addEventListener('dblclick', function() {
@@ -239,16 +241,16 @@ window._clearConversation = function() {
         if (e.button !== undefined && e.button !== 0) return;  // left button only
         var toolBody = e.target.closest('.tool-body');
         if (!toolBody) return;
-        if (_dragMoved) return;  // was a drag-select
+        if (_drag) return;  // genuine drag-select, not a click
         var sel = window.getSelection();
-        if (sel && !sel.isCollapsed && sel.toString().length > 0) return;  // active selection
+        if (sel && !sel.isCollapsed) return;  // active selection
         var detailsId = toolBody.getAttribute('data-details');
         if (!detailsId) return;
         var details = document.getElementById(detailsId);
         if (!details || !details.open) return;
         // Defer: the first click of a double-click would collapse before the
         // dblclick event arrives; cancel the collapse when one follows.
-        if (_collapseTimer) clearTimeout(_collapseTimer);
+        clearTimeout(_collapseTimer);
         _collapseTimer = setTimeout(function() {
             _collapseTimer = null;
             details.open = false;

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -1,6 +1,7 @@
 """Tests for LLMClient history management (dedup + compaction)."""
 
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import io
 import json
 import os
 import ssl
@@ -1176,6 +1177,28 @@ class TestStreaming:
         assert 'block.get("id", "")' in script
         assert 'block.get("name", "")' in script
 
+    def test_stream_openai_http_error_includes_body(self):
+        """In-process streaming must surface HTTP 4xx with the response body
+        (HTTPError is a URLError subclass; it must not be swallowed by the
+        HTTPS-fallback branch)."""
+        client = _make_client()
+        err = urllib.error.HTTPError(
+            "http://x",
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(b'{"code":"InvalidParameter","message":"Request body format invalid"}'),
+        )
+        with (
+            patch.object(llm_client, "_in_process_ssl", None),
+            patch("urllib.request.urlopen", side_effect=err),
+        ):
+            result = client._stream_openai("sys", [], on_text_delta=lambda c: None)
+
+        assert result["error"] == (
+            'HTTP 400: {"code":"InvalidParameter","message":"Request body format invalid"}'
+        )
+
     def test_stream_openai_tool_calls(self):
         client = _make_client()
         sse_lines = [
@@ -1197,6 +1220,26 @@ class TestStreaming:
         assert tc[0]["function"]["name"] == "add_wire"
         assert tc[0]["function"]["arguments"] == '{"x":1}'
         assert result["finish_reason"] == "tool_calls"
+
+    def test_stream_anthropic_http_error_includes_body(self):
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        err = urllib.error.HTTPError(
+            "http://x",
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(b'{"code":"InvalidParameter","message":"Request body format invalid"}'),
+        )
+        with (
+            patch.object(llm_client, "_in_process_ssl", None),
+            patch("urllib.request.urlopen", side_effect=err),
+        ):
+            result = client._stream_anthropic("sys", [], on_text_delta=lambda c: None)
+
+        assert result["error"] == (
+            'HTTP 400: {"code":"InvalidParameter","message":"Request body format invalid"}'
+        )
 
     def test_stream_anthropic_text_only(self):
         client = _make_client()

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -964,6 +964,39 @@ class TestOpenAICompatibleRequests:
 
         assert post.call_args.args[0] == "https://gateway.example/anthropic/v1/messages"
 
+    def test_call_anthropic_always_sends_max_tokens(self):
+        """Anthropic API requires max_tokens; compatible gateways reject
+        requests without it (400 InvalidParameter)."""
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        response = json.dumps(
+            {"content": [{"type": "text", "text": "ok"}], "stop_reason": "end_turn"}
+        )
+
+        with patch(
+            "kicad_plugin.llm_client._https_post_json", return_value=(200, response)
+        ) as post:
+            client._call_anthropic("system", [])
+
+        payload = json.loads(post.call_args.args[2])
+        assert payload["max_tokens"] == llm_client._ANTHROPIC_DEFAULT_MAX_TOKENS
+
+    def test_call_anthropic_honors_configured_max_tokens(self):
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        client._max_tokens = 128
+        response = json.dumps(
+            {"content": [{"type": "text", "text": "ok"}], "stop_reason": "end_turn"}
+        )
+
+        with patch(
+            "kicad_plugin.llm_client._https_post_json", return_value=(200, response)
+        ) as post:
+            client._call_anthropic("system", [])
+
+        payload = json.loads(post.call_args.args[2])
+        assert payload["max_tokens"] == 128
+
     def test_api_key_adds_bearer_authorization(self):
         client = _make_client()
 
@@ -1082,6 +1115,20 @@ class TestStreaming:
         obj.__exit__ = MagicMock(return_value=False)
         return obj
 
+    def test_stream_anthropic_always_sends_max_tokens(self):
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        sse_lines = [
+            "event: message_delta",
+            'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+        ]
+        mock_resp = self._make_sse_response(sse_lines)
+        with patch("urllib.request.urlopen", return_value=mock_resp) as m:
+            client._stream_anthropic("sys", [], on_text_delta=lambda c: None)
+
+        payload = json.loads(m.call_args[0][0].data)
+        assert payload["max_tokens"] == llm_client._ANTHROPIC_DEFAULT_MAX_TOKENS
+
     def test_stream_openai_text_only(self):
         client = _make_client()
         sse_lines = [
@@ -1098,6 +1145,36 @@ class TestStreaming:
         assert chunks == ["Hello", " world"]
         assert result["message"]["content"] == "Hello world"
         assert result["finish_reason"] == "stop"
+
+    def test_stream_openai_skips_empty_choices_chunk(self):
+        """Mid-stream empty choices chunks (usage/keepalive) must not abort
+        the parse — tool-call deltas that follow must still be captured."""
+        client = _make_client()
+        sse_lines = [
+            'data: {"choices":[{"delta":{"content":"Checking"},"finish_reason":null}]}',
+            'data: {"choices":[]}',
+            'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc1","function":{"name":"list_tracks","arguments":""}}]},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}',
+            "data: [DONE]",
+        ]
+        chunks = []
+        mock_resp = self._make_sse_response(sse_lines)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = client._stream_openai("sys", [], on_text_delta=chunks.append)
+
+        assert chunks == ["Checking"]
+        tc = result["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["function"]["name"] == "list_tracks"
+        assert result["finish_reason"] == "tool_calls"
+
+    def test_relay_script_guards_empty_choices_and_tool_use_keys(self):
+        """The venv subprocess relay must contain the same guards (it is the
+        path used by KiCad's SSL-less embedded Python)."""
+        script = llm_client._SUBPROCESS_SSE_SCRIPT
+        assert "if not _choices:" in script
+        assert 'block.get("id", "")' in script
+        assert 'block.get("name", "")' in script
 
     def test_stream_openai_tool_calls(self):
         client = _make_client()


### PR DESCRIPTION
## Summary

Two plugin-side LLM bugs that made multi-step tool-calling turns fail silently:

1. **Empty `choices: []` chunk kills the OpenAI-compatible stream** (#90)
   - The token-plan gateway emits a mid-stream chunk with `"choices": []` (before tool-call deltas).
   - The subprocess SSE relay (used because KiCad's embedded Python has no SSL) crashed with `IndexError` on `chunk.get("choices", [{}])[0]`, aborting the stream before tool calls arrived.
   - Result: every turn degraded to one partial message; no tool ever executed (panel log fingerprint: constant `reply_len=69`).

2. **Anthropic-compatible provider fails with 400 InvalidParameter** (#91)
   - The Anthropic Messages API requires `max_tokens`; the plugin only sent it when configured, so default config was rejected (`"Request body format invalid"`).
   - Probed the gateway: body without `max_tokens` → 400; with it → 200.

## Changes

- Guard empty `choices` in all three OpenAI parse sites (relay script, in-process streaming, non-streaming) — skip the chunk instead of indexing `[0]`.
- Always send `max_tokens` in `_stream_anthropic` / `_call_anthropic` (configured value, else `_ANTHROPIC_DEFAULT_MAX_TOKENS = 65536`, probed safe up to 131072).
- Harden Anthropic parsers against tool_use blocks missing `id`/`name` (relay script, in-process, non-streaming).
- Settings dialog: reserve one extra measured form row so the last row is not clipped.
- Regression tests: empty-choices survival with tool calls, anthropic payload includes `max_tokens` (default + configured), relay-script guards, max_tokens default value.

## Verification

- Unit: `1150 passed, 17 skipped` (full suite) / `75 passed` (llm_client).
- End-to-end (plugin code + real gateway + subprocess relay): `finish_reason=tool_calls` with complete tool calls on both OpenAI and Anthropic providers.
- pre-commit (ruff, ruff-format, bandit) green on every commit.

Closes #90
Closes #91

Closes #93

