### PR TITLE
docs(pcb): unify CCW+ angle convention in skills/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ kcaa
 |------|-------------|
 | `get_board_info` | Get basic PCB board information |
 | `list_footprints` | List all footprints placed on the board |
-| `get_footprint` | Get details of a single placed footprint |
+| `get_footprint` | Get details of a placed footprint (pads, properties, Edge.Cuts geometry) |
 | `get_footprint_bbox` | Get the courtyard bounding box of a footprint |
 | `get_board_bounding_box` | Get the union bounding box of all footprints |
 | `list_nets` | List all nets on the board |

--- a/docs/coordinate-systems.md
+++ b/docs/coordinate-systems.md
@@ -117,8 +117,9 @@ y' = −x·sin(d) + y·cos(d)        # d=90 → (x, y) → (y, −x)   → scree
   degenerate-equal as expected).  Consistent with the official manual
   (PCBNew `R` hotkey = counter-clockwise, Shift+R = clockwise).
 - Pad angles: KiCad stores pad rotation as an absolute board-space angle
-  in the same CCW file convention (the `pcb_query_tools` docstring calls
-  it "CW+" — trust the matrix above, not the label).
+  in the same CCW file convention (`pcb_query_tools.get_footprint` and
+  `pcb_board_utils.get_fp_edge_cuts_items` docstrings use "CCW+" for it,
+  matching the matrix above).
 - Arc drawing helpers (`pcb_board_utils.add_gr_arc`) take angles in the
   same CCW file convention (0°=+X, 90°=up; point = `cx + r·cosθ,
   cy − r·sinθ`).

--- a/docs/issue_backlog.md
+++ b/docs/issue_backlog.md
@@ -4,6 +4,56 @@ Known issues discovered during review but not fixed in the originating PR.
 Each entry records the evidence, the impact, and the proposed fix so the work
 can be picked up independently.
 
+## PCB angle convention stale in skills/README after #76
+
+**Status:** fixed on `fix/pcb-angle-docs` (issue #94)
+
+### Symptom
+
+PR #76 introduced the footprint Edge.Cuts `local → world` transform docs
+under a **"clockwise-positive"** angle label, but the angle convention was
+later unified to **CCW+ on screen** (0°=right, 90°=up) in the code
+docstrings (`get_footprint`, `get_fp_edge_cuts_items`, `add_gr_arc`,
+`docs/coordinate-systems.md` §4). The skill/README docs kept the old
+labels:
+
+- `kicad_plugin/skills/pcb_query.md`: `rotation (CW+)`
+- `kicad_plugin/skills/pcb_zone.md`: "rotation clockwise-positive"
+- `kicad_plugin/skills/pcb_outline.md`: "Arc angles ... increase clockwise"
+  (contradicts the `add_gr_arc` / `add_board_outline_arc` CCW
+  implementation)
+- `README.md` tool table: `get_footprint` row did not mention the new
+  `edge_cuts` field
+- `docs/coordinate-systems.md` still warned "trust the matrix, not the
+  label" about a `pcb_query_tools` docstring that had already been fixed
+
+### Impact
+
+The LLM reads these skills; trusting them means passing/reading PCB
+rotations (footprint rotation, pad angles, Edge.Cuts arc angles) with the
+wrong sign, and missing the `edge_cuts` geometry that #76 added.
+
+### Fix (implemented)
+
+- `pcb_query.md`: `rotation (CW+)` → `(CCW+)`; documents the `edge_cuts`
+  field (fp_line/fp_arc/fp_circle/fp_curve in footprint-local mm,
+  CCW+-transformed like pads).
+- `pcb_zone.md` / `pcb_outline.md`: "clockwise-positive" → CCW-positive-on-
+  screen; arc angles → counter-clockwise (KiCad file convention, 90°=up).
+- `docs/coordinate-systems.md`: stale "docstring calls it CW+" note
+  replaced with the current "CCW+" wording.
+- `README.md`: `get_footprint` row mentions Edge.Cuts geometry.
+
+### Validation
+
+- Grep over `README.md`, `kicad_plugin/README.md`, `kicad_plugin/skills/`,
+  `docs/`, `llm_client.py` prompt, and the PCB tool modules finds no
+  remaining `CW+` / `clockwise-positive` angle claims; the only
+  "clockwise" mentions left are in correct CCW-contexts (schematic/symbol
+  notes, the "why not the textbook CW matrix" implementation comment).
+
+---
+
 ## Multi-unit netlist output has no unit dimension
 
 **Status:** open (discovered while fixing the skip pin-coordinate bug, PR #87)

--- a/kicad_plugin/skills/pcb_outline.md
+++ b/kicad_plugin/skills/pcb_outline.md
@@ -11,4 +11,6 @@ description: "Board Edge.Cuts creation and editing workflow"
   lines + four 90° arcs.  Edge.Cuts line width is typically 0.05 mm.
 - Add individual segments or arcs: **add_board_outline_segment** /
   **add_board_outline_arc**.  Wipe first with **clear_board_outline**.
-- Arc angles: 0° is +X, angles increase clockwise.
+- Arc angles: 0° is +X, angles increase **counter-clockwise** (CCW, the
+  KiCad file convention — 90°=up on screen). Same convention as the
+  footprint rotation and pad angles reported by the PCB query tools.

--- a/kicad_plugin/skills/pcb_query.md
+++ b/kicad_plugin/skills/pcb_query.md
@@ -7,9 +7,12 @@ description: "PCB query workflow: get_board_info, list_footprints, ratsnest, net
 1. Call **get_board_info** to learn layer stack, copper layer count, footprint
    count, net count, and board generator.
 2. Call **list_footprints** to get every footprint's reference, value, x/y
-   (world mm), rotation (CW+), and layer.
+   (world mm), rotation (CCW+), and layer.
 3. Call **get_footprint** for detailed info on a specific footprint: pad
-   numbers/types/nets, all properties, and local pad coordinates.
+   numbers/types/nets, all properties, local pad coordinates, and
+   `edge_cuts` (fp_line/fp_arc/fp_circle/fp_curve items on the
+   footprint's Edge.Cuts layer, in footprint-local mm — transform to
+   world the same way as pads: CCW+ rotation, +Y down).
    Note: pad coordinates from get_footprint are *local* (footprint-relative).
    Use **get_ratsnest** when you need world-coordinate pad positions.
 4. Call **list_nets** to enumerate nets with their pad counts.

--- a/kicad_plugin/skills/pcb_zone.md
+++ b/kicad_plugin/skills/pcb_zone.md
@@ -33,8 +33,9 @@ description: "Copper pour & keepout zone CRUD, zone refill via IPC, polygon geom
    `deleted: true` on success.
 
 # Coordinate convention
-- PCB coordinates: **millimetres, +X right, +Y down**, rotation **clockwise-positive**
-  (standard KiCad PCB convention). This is consistent with the rest of the PCB tools.
+- PCB coordinates: **millimetres, +X right, +Y down**, rotation
+  **CCW-positive on screen** (KiCad PCB convention: 0°=right, 90°=up,
+  180°=left, 270°=down). This is consistent with the rest of the PCB tools.
 
 # Caveats & gotchas
 - All mutation tools create a `.kicad_pcb.bak` backup before writing.


### PR DESCRIPTION
## Summary

PR #76 added the footprint Edge.Cuts geometry to `get_footprint` under a
"clockwise-positive" angle label, and the convention was later unified to
**CCW+ on screen** in the code docstrings. This PR syncs the skills and
README with the code's actual convention so an LLM reading them drives
PCB rotations (footprint rotation, pad angles, Edge.Cuts arc angles) with
the correct sign.

## Changes

- `kicad_plugin/skills/pcb_query.md` — `rotation (CW+)` → `(CCW+)`;
  documents the `edge_cuts` field added by #76 (fp_line/fp_arc/
  fp_circle/fp_curve in footprint-local mm, CCW+-transformed like pads).
- `kicad_plugin/skills/pcb_zone.md` — `clockwise-positive` →
  `CCW-positive on screen (0°=right, 90°=up, …)`.
- `kicad_plugin/skills/pcb_outline.md` — arc angles "increase clockwise"
  → counter-clockwise (KiCad file convention), matching
  `add_gr_arc`/`add_board_outline_arc`.
- `docs/coordinate-systems.md` — stale "docstring calls it CW+ — trust
  the matrix, not the label" note updated to the current "CCW+" wording.
- `README.md` — `get_footprint` row now mentions Edge.Cuts geometry.
- `docs/issue_backlog.md` — new entry for this issue, marked fixed.

## Validation

Grep over `README.md`, `kicad_plugin/README.md`, `kicad_plugin/skills/`,
`docs/`, the `llm_client.py` prompt, and the PCB tool modules: no
remaining `CW+` / `clockwise-positive` angle claims; the only
"clockwise" mentions are in correct CCW-contexts (schematic/symbol
notes and the "why not the textbook CW matrix" implementation comment).

Closes #94