### PR TITLE
fix(netlist): nest units per reference, per-unit bbox, delta moves

### DIFF
--- a/docs/issue_backlog.md
+++ b/docs/issue_backlog.md
@@ -6,7 +6,7 @@ can be picked up independently.
 
 ## Multi-unit netlist output has no unit dimension
 
-**Status:** open (discovered while fixing the skip pin-coordinate bug, PR #87)
+**Status:** fixed on `fix/issue-89-multi-unit-netlist` (issue #89)
 
 ### Symptom
 
@@ -41,21 +41,50 @@ Real board `two_ax_PCB.kicad_sch` (U2, two units):
   (each unit's pins were computed with its own `(at …)`); the gap is unit
   attribution and anchors, not geometry.
 
-### Fix (proposed)
+### Fix (implemented)
 
-Both data sources are already available on skip (`sym.unit`,
-`sym.at`); pass the unit into `_pin_world_from_lib`'s call sites:
+`SchematicParser._extract_components` now nests every placed unit under its
+reference:
 
-1. add a `unit` key to each pin dict, and/or
-2. add `unit_positions: [{unit, x, y, rotation, pin_nums}]` to the
-   component entry, keeping `position` as a documented summary.
+```json
+"components[ref]": {
+  "units": {
+    "1": {"position": {"x", "y", "rotation"}, "body_bbox": {...}, "pins": [...]},
+    "2": {...}
+  }
+}
+```
+
+- Every `units[unit]` carries that unit's own anchor, pins, and world
+  `body_bbox`; the ambiguous top-level `position`, flat `pins`, and the
+  merged union `body_bbox` are gone (a union of far-apart units is
+  meaningless for per-unit reasoning). Sheets are opaque single-unit
+  placeholders nested under `units["1"]`.
+- `netlist_parser.iter_component_pins()` flattens the nested pins for
+  netlist tracing, tools, and reports; `first_unit_position()` gives the
+  lowest-numbered unit's anchor; `component_body_bbox()` fuses the unit
+  bboxes for callers that need the whole occupied region (overlap
+  avoidance, group membership).
+- `move_component` takes **deltas**: `x`/`y` are shifts in mm (snapped to
+  the 1.27 mm grid), `rotation` is an incremental angle applied as
+  `old + rotation` per unit — reading an absolute target from the netlist
+  and subtracting gives the delta. `unit=N` moves/rotates one unit
+  individually; omitted moves every unit by the same delta, preserving
+  relative layout (the old absolute write collapsed all units onto the
+  target anchor). The overlap-avoidance search excludes the moved
+  reference itself, so a unit's stale position never blocks the move.
 
 ### Validation
 
-- Unit: `multi_unit.kicad_sch` merge test asserts per-unit pin attribution
-  matches the fixture's two anchors.
-- Real board: U2 unit1/unit2 pin-grouping equals the coordinate-cluster
-  split above.
+- Unit: `tests/unit/utils/test_netlist_multi_unit.py` — units nested with
+  per-unit anchors, pins, and body_bbox, no top-level pins/position/bbox,
+  single-unit components nested under unit 1;
+  `tests/unit/tools/test_symbol_edit_tools.py` `TestMoveComponentMultiUnit` —
+  whole delta move preserves offsets and rotations, unit-scoped
+  move/rotate touches only that unit, validation errors.
+- Real board: `two_ax_PCB.kicad_sch` U2 — `units["1"]` @ (101.6, 93.8022,
+  90°) with 55 pins, `units["2"]` @ (185.42, 223.3422, 90°) with 9 power
+  pins; 64 pins total, matching the coordinate-cluster split above.
 
 ---
 

--- a/docs/plugin/capability_inventory.md
+++ b/docs/plugin/capability_inventory.md
@@ -44,7 +44,7 @@ These are read-only tools. They must be used when the LLM is asked to add a comp
 | `set_symbol_property` | Update any property (value, footprint, datasheet, custom field) |
 | `list_symbol_properties` | Read all properties of one component |
 | `delete_symbol_property` | Remove a custom property |
-| `move_component` | Reposition a component to new coordinates |
+| `move_component` | Shift a component by a delta, optionally per unit |
 | `add_label_to_schematic` | Add a net label at a position |
 | `list_labels_in_schematic` | Enumerate all labels in a schematic |
 | `delete_label_from_schematic` | Remove a label by text and position |

--- a/docs/plugin/tool_contract.md
+++ b/docs/plugin/tool_contract.md
@@ -83,12 +83,22 @@ A typical LLM editing session follows this pattern:
   "net_count": 8,
   "component_types": {"R": 4, "C": 2, "U": 1},
   "components": {
-    "R1": {
-      "value": "10k",
-      "position": {"x": 100.0, "y": 50.0, "rotation": 0},
-      "pins": [
-        {"num": "1", "x": 101.27, "y": 50.0, "direction": "right", "net": "VCC"}
-      ]
+    "U2": {
+      "value": "motor driver",
+      "units": {
+        "1": {
+          "position": {"x": 101.6, "y": 93.8022, "rotation": 90},
+          "body_bbox": {"min_x": 96.52, "min_y": 89.2, "max_x": 142.24, "max_y": 98.4},
+          "pins": [
+            {"num": "14", "name": "PC11", "x": "96.52", "y": "172.54", "direction": "left", "net": "..."}
+          ]
+        },
+        "2": {
+          "position": {"x": 185.42, "y": 223.3422, "rotation": 90},
+          "body_bbox": {"min_x": 180.34, "min_y": 218.56, "max_x": 210.82, "max_y": 228.12},
+          "pins": [...]
+        }
+      }
     }
   },
   "power_nets": [{"name": "GND", "pin_count": 6}],
@@ -98,6 +108,18 @@ A typical LLM editing session follows this pattern:
 ```
 
 `direction` is the wire-exit direction in screen coordinates: `"right"`, `"down"`, `"left"`, or `"up"`.
+
+Components are nested per unit: `units` is keyed by unit number, and each
+unit carries its own `position` (anchor), `body_bbox` (world-space
+footprint), and `pins`. A single-unit component is nested under
+`units["1"]`. There is no merged top-level bbox — union the per-unit
+bboxes when you need a component's whole occupied region.
+
+`move_component` takes **deltas** (x/y shifts in mm, rotation increment)
+and accepts a `unit` number to move/rotate one unit individually
+(omitted = move all units together by the same delta, preserving their
+relative layout). Read the current anchor from `position` and subtract to
+express an absolute move as a delta.
 
 **When to use:** At the start of every session and after any structural edit to verify the result.
 
@@ -239,15 +261,16 @@ All tools in this group write a backup to `<schematic_path>.bak` before saving.
 
 ---
 
-#### `move_component(schematic_path, reference, x, y, rotation=None)`
+#### `move_component(schematic_path, reference, x, y, rotation=None, unit=None)`
 
-**Purpose:** Moves a component to a new position, optionally updating rotation. Coordinates are in mm and are snapped to the 1.27 mm grid.
+**Purpose:** Shifts a component by a delta, optionally updating rotation. `x`/`y` are **deltas** in mm (each snapped to the 1.27 mm grid, **+Y is down**); `rotation` is a **delta** in degrees applied as `old + rotation` per unit (0/90/180/270). Omitted axes are left unchanged. All units of the reference share the same shift; `unit=N` limits the move/rotate to that unit of a multi-unit symbol (no overlap-avoidance search).
 
 **Key parameters:**
-- `x`, `y` (`float`) — new position in mm.
-- `rotation` (`int | None`) — if `None`, preserves the existing rotation.
+- `x`, `y` (`float | None`) — delta in mm.
+- `rotation` (`int | None`) — delta in degrees (0/90/180/270).
+- `unit` (`int | None`) — optional unit to scope the move to.
 
-**Success response:** `{"success": true, "reference": "R1", "position": {"x": ..., "y": ..., "rotation": ...}}`
+**Success response:** `{"success": true, "reference": "R1", "unit": null, "position": {"x": ..., "y": ...}, "rotation": ..., "units_updated": 1, "body_bbox": {...}}` — `position`/`rotation` are the new **absolute** anchor and rotation of the first moved unit; `body_bbox` is the world-space union of the moved units after the move.
 
 ---
 

--- a/kcaa/resources/netlist_resources.py
+++ b/kcaa/resources/netlist_resources.py
@@ -7,7 +7,7 @@ import os
 from fastmcp import FastMCP
 
 from kcaa.utils.file_utils import get_project_files
-from kcaa.utils.netlist_parser import analyze_netlist, extract_netlist
+from kcaa.utils.netlist_parser import analyze_netlist, extract_netlist, iter_component_pins
 
 
 def register_netlist_resources(mcp: FastMCP) -> None:
@@ -210,12 +210,16 @@ def register_netlist_resources(mcp: FastMCP) -> None:
 
             report += "\n"
 
-            # Pins section
-            if "pins" in component_info:
+            # Pins section — pins are nested per unit (issue #89); list them flat,
+            # tagging the unit only for multi-unit components.
+            units = component_info.get("units") or {}
+            if units:
+                multi_unit = len(units) > 1
                 report += "## Pins\n\n"
 
-                for pin in component_info["pins"]:
-                    report += f"- **Pin {pin['num']}**: {pin['name']}\n"
+                for unit, pin in iter_component_pins(component_info):
+                    suffix = f" (unit {unit})" if multi_unit else ""
+                    report += f"- **Pin {pin['num']}{suffix}**: {pin['name']}\n"
 
                 report += "\n"
 

--- a/kcaa/tools/netlist_tools.py
+++ b/kcaa/tools/netlist_tools.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastmcp import Context, FastMCP
 
 from kcaa.utils.file_utils import get_project_files
-from kcaa.utils.netlist_parser import extract_netlist
+from kcaa.utils.netlist_parser import extract_netlist, iter_component_pins
 
 
 def register_netlist_tools(mcp: FastMCP) -> None:
@@ -101,10 +101,11 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         - ``position``: ``{x, y}`` placement anchor in mm (KiCad screen coords,
           **+Y is down**).
         - ``rotation``, ``mirror``, ``lib_id``, ``value``, ``footprint``.
-        - ``body_bbox``: ``{min_x, min_y, max_x, max_y}`` world-space bounding
-          box (union of every placed unit). Use this to check overlaps before
-          calling ``move_component`` / ``add_symbol_to_schematic``. May be
-          absent for graphics-less symbols (e.g. PWR_FLAG).
+        - each unit carries its own ``body_bbox``: ``{min_x, min_y, max_x,
+          max_y}`` world-space bounding box of that unit's footprint. Use it
+          to check overlaps before calling ``move_component`` /
+          ``add_symbol_to_schematic``. May be absent for graphics-less
+          symbols (e.g. PWR_FLAG).
         - ``pins``: list of ``{num, name, electrical, x, y, direction}``. ``x``/``y`` are world
           coordinates already accounting for placement and rotation;
           ``direction`` is the screen-space exit direction
@@ -238,17 +239,32 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                 ref: {
                     "value": cdata.get("value", ""),
                     "type": cdata.get("type", "component"),
-                    "position": cdata.get("position", {}),
-                    "pins": [
-                        {
-                            **pinfo,
-                            "net": pin_to_net.get(
-                                (ref, str(pinfo.get("num", pinfo.get("number", ""))))
+                    # Units are nested per reference (issue #89): each unit
+                    # keeps its own anchor/pins; every pin gains its net.
+                    "units": {
+                        unit_key: {
+                            **(
+                                {"position": unit_data.get("position")}
+                                if unit_data.get("position")
+                                else {}
                             ),
+                            **(
+                                {"body_bbox": unit_data["body_bbox"]}
+                                if "body_bbox" in unit_data
+                                else {}
+                            ),
+                            "pins": [
+                                {
+                                    **pin,
+                                    "net": pin_to_net.get(
+                                        (ref, str(pin.get("num", pin.get("number", ""))))
+                                    ),
+                                }
+                                for pin in unit_data.get("pins", [])
+                            ],
                         }
-                        for pinfo in cdata.get("pins", [])
-                    ],
-                    **({"body_bbox": cdata["body_bbox"]} if "body_bbox" in cdata else {}),
+                        for unit_key, unit_data in (cdata.get("units") or {}).items()
+                    },
                 }
                 for ref, cdata in raw_components.items()
             }
@@ -323,7 +339,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
                 pin_at: dict[Any, list] = _dd(list)
                 for ref, cdata in components.items():
-                    for pinfo in cdata.get("pins", []):
+                    for _unit, pinfo in iter_component_pins(cdata):
                         pin_at[rpt(pinfo["x"], pinfo["y"])].append(
                             {"ref": ref, "pin": str(pinfo.get("num", ""))}
                         )
@@ -547,27 +563,26 @@ def register_netlist_tools(mcp: FastMCP) -> None:
 
             # Categorize connections by pin function (if possible)
             pin_functions = {}
-            if "pins" in component_info:
-                for pin in component_info["pins"]:
-                    pin_num = pin.get("num")
-                    pin_name = pin.get("name", "")
+            for _unit, pin in iter_component_pins(component_info):
+                pin_num = pin.get("num")
+                pin_name = pin.get("name", "")
 
-                    # Try to categorize based on pin name
-                    pin_type = "unknown"
+                # Try to categorize based on pin name
+                pin_type = "unknown"
 
-                    if any(
-                        power_term in pin_name.upper()
-                        for power_term in ["VCC", "VDD", "VEE", "VSS", "GND", "PWR", "POWER"]
-                    ):
-                        pin_type = "power"
-                    elif any(io_term in pin_name.upper() for io_term in ["IO", "I/O", "GPIO"]):
-                        pin_type = "io"
-                    elif any(input_term in pin_name.upper() for input_term in ["IN", "INPUT"]):
-                        pin_type = "input"
-                    elif any(output_term in pin_name.upper() for output_term in ["OUT", "OUTPUT"]):
-                        pin_type = "output"
+                if any(
+                    power_term in pin_name.upper()
+                    for power_term in ["VCC", "VDD", "VEE", "VSS", "GND", "PWR", "POWER"]
+                ):
+                    pin_type = "power"
+                elif any(io_term in pin_name.upper() for io_term in ["IO", "I/O", "GPIO"]):
+                    pin_type = "io"
+                elif any(input_term in pin_name.upper() for input_term in ["IN", "INPUT"]):
+                    pin_type = "input"
+                elif any(output_term in pin_name.upper() for output_term in ["OUT", "OUTPUT"]):
+                    pin_type = "output"
 
-                    pin_functions[pin_num] = {"name": pin_name, "type": pin_type}
+                pin_functions[pin_num] = {"name": pin_name, "type": pin_type}
 
             # Build result
             result = {

--- a/kcaa/tools/placement_helpers.py
+++ b/kcaa/tools/placement_helpers.py
@@ -16,7 +16,7 @@ from typing import Any
 from fastmcp import FastMCP
 import sexpdata
 
-from kcaa.utils.netlist_parser import extract_netlist
+from kcaa.utils.netlist_parser import component_body_bbox, extract_netlist
 from kcaa.utils.symbol_geometry import (
     BBox,
     bboxes_overlap,
@@ -150,6 +150,7 @@ def _find_free_area_impl(
     for_symbol: str | None = None,
     rotation: int = 0,
     exclude_uuid: str | None = None,
+    exclude_refs: set[str] | None = None,
 ) -> dict[str, Any]:
     """Core implementation shared by the MCP tool and sheet auto-placement."""
     if not os.path.exists(schematic_path):
@@ -221,7 +222,9 @@ def _find_free_area_impl(
     for ref, comp in components.items():
         if comp.get("type") == "sheet":
             continue
-        bb_d = comp.get("body_bbox")
+        if exclude_refs and ref in exclude_refs:
+            continue
+        bb_d = component_body_bbox(comp)
         if not bb_d:
             continue
         try:

--- a/kcaa/tools/schematic_group_tools.py
+++ b/kcaa/tools/schematic_group_tools.py
@@ -142,9 +142,11 @@ def _get_sym_at(sym: Any) -> tuple[float, float, float]:
 
 
 def _get_sym_body_bbox(sym: Any, schematic_path: str) -> dict[str, float] | None:
-    """Return the body_bbox dict for a symbol's reference from the netlist.
+    """Return the union body_bbox of a symbol's reference from the netlist.
 
-    Returns None if the bbox cannot be determined.
+    The netlist stores one body_bbox per unit; the union is the occupied
+    region of the whole multi-unit symbol. Returns None if no unit has a
+    bbox.
     """
     try:
         ref = _get_sym_property(sym, "Reference")
@@ -155,7 +157,9 @@ def _get_sym_body_bbox(sym: Any, schematic_path: str) -> dict[str, float] | None
     netlist = extract_netlist(schematic_path)
     comp = (netlist.get("components") or {}).get(ref)
     if comp:
-        return comp.get("body_bbox")
+        from kcaa.utils.netlist_parser import component_body_bbox
+
+        return component_body_bbox(comp)
     return None
 
 

--- a/kcaa/tools/sheet_tools.py
+++ b/kcaa/tools/sheet_tools.py
@@ -69,7 +69,7 @@ def _collect_occupied_bboxes(
         _parse_paper_size,
         _sheet_symbol_bbox,
     )
-    from kcaa.utils.netlist_parser import extract_netlist
+    from kcaa.utils.netlist_parser import component_body_bbox, extract_netlist
     from kcaa.utils.symbol_geometry import BBox, inflate_bbox
 
     occupied: list = []
@@ -91,7 +91,7 @@ def _collect_occupied_bboxes(
             continue
         if comp.get("type") == "sheet":
             continue
-        bb_d = comp.get("body_bbox")
+        bb_d = component_body_bbox(comp)
         if not bb_d:
             continue
         try:

--- a/kcaa/tools/symbol_edit_tools.py
+++ b/kcaa/tools/symbol_edit_tools.py
@@ -1283,9 +1283,10 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
         if gap < 0 or not math.isfinite(gap):
             return {"error": f"gap must be a non-negative finite number (got {gap})"}
 
-        # Look up anchor's world bbox via netlist extraction.
+        # Look up anchor's world bbox via netlist extraction. The netlist keeps
+        # bboxes per unit; fuse them for the anchor's occupied region.
         try:
-            from kcaa.utils.netlist_parser import extract_netlist
+            from kcaa.utils.netlist_parser import component_body_bbox, extract_netlist
 
             netlist = extract_netlist(schematic_path)
         except Exception as exc:
@@ -1294,7 +1295,7 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
         anchor = comps.get(anchor_reference)
         if anchor is None:
             return {"error": f"Anchor reference {anchor_reference!r} not found"}
-        bb_d = anchor.get("body_bbox")
+        bb_d = component_body_bbox(anchor)
         if not bb_d:
             return {
                 "error": (
@@ -1928,18 +1929,29 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
         x: float | None = None,
         y: float | None = None,
         rotation: int | None = None,
+        unit: int | None = None,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
-        """Move and/or rotate a placed schematic component.
+        """Move and/or rotate a placed schematic component by a delta.
 
         At least one of ``x``, ``y``, ``rotation`` must be provided; omitted
-        values are left unchanged. Coordinates are mm in KiCad screen
-        convention (**+Y is down**) and are auto-snapped to the 1.27 mm
+        axes are left unchanged. ``x``/``y`` are **deltas** in mm (KiCad
+        screen convention, **+Y is down**), each auto-snapped to the 1.27 mm
         (50-mil) grid so pins remain on KiCad's standard schematic grid and
-        existing wires stay connected. Rotation is absolute (0/90/180/270°).
-        All units sharing the reference are moved together, and Reference /
-        Value field positions shift by the same delta. A backup
-        (.kicad_sch.bak) is written before saving.
+        existing wires stay connected. ``rotation`` is a **delta** in
+        degrees, restricted to 0/90/180/270 and applied per unit as
+        ``(old + rotation) % 360``. Read the current anchor from
+        ``extract_schematic_netlist`` and subtract to compute an absolute
+        move as a delta.
+
+        When ``unit`` is omitted, all units sharing the reference shift by
+        the same delta, preserving the units' relative layout (whole moves
+        may be nudged to the nearest free area when the target region is
+        occupied — see ``position_adjusted``). With ``unit=N`` only that
+        unit moves/rotates (equivalent to moving a single symbol; no
+        overlap-avoidance search). Reference / Value field positions shift
+        by the same delta as the moved unit(s). A backup (.kicad_sch.bak)
+        is written before saving.
 
         Tip: to move a component to sit relative to another, prefer
         ``place_symbol_relative`` (handles bbox + clearance for you). To find
@@ -1948,14 +1960,20 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
         Args:
             schematic_path: Path to the .kicad_sch file.
             reference: Reference designator (e.g. "R1") or a sheet name.
-            x: New X coordinate in mm (auto grid-snapped).
-            y: New Y coordinate in mm (auto grid-snapped).
-            rotation: New absolute rotation in degrees (0, 90, 180, or 270).
+            x: Delta X to apply in mm (auto grid-snapped).
+            y: Delta Y to apply in mm (auto grid-snapped).
+            rotation: Delta rotation in degrees; one of 0, 90, 180, or 270
+                (each moved unit becomes ``old + rotation``, normalized to
+                0-359).
+            unit: Which unit of a multi-unit symbol to move/rotate (positive
+                int, e.g. 1 or 2); omitted moves all units by the same delta.
 
         Returns:
-            dict with keys: success, reference, position ({x, y} after grid
-            snap), rotation, units_updated, body_bbox (world-space union of
-            unit bboxes after the move; ``None`` for graphics-less symbols).
+            dict with keys: success, reference, unit, position ({x, y} of
+            the first moved unit's anchor after the move), rotation
+            (absolute rotation of that unit), units_updated, body_bbox
+            (world-space union of the moved units' bboxes after the move;
+            ``None`` for graphics-less symbols).
         """
         if not schematic_path.endswith(".kicad_sch"):
             return {"error": f"Not a .kicad_sch file: {schematic_path!r}"}
@@ -1971,6 +1989,8 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
             return {"error": f"y must be a finite number (got {y!r})"}
         if rotation is not None and rotation not in (0, 90, 180, 270):
             return {"error": f"rotation must be 0, 90, 180, or 270 (got {rotation!r})"}
+        if unit is not None and (not isinstance(unit, int) or isinstance(unit, bool) or unit < 1):
+            return {"error": f"unit must be a positive integer (got {unit!r})"}
 
         try:
             sch = safe_schematic(schematic_path)
@@ -1982,14 +2002,27 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
             try:
                 for sym in sch.symbol:
                     try:
-                        if sym.property.Reference.value == reference:
-                            units.append(sym)
+                        if sym.property.Reference.value != reference:
+                            continue
                     except AttributeError:
                         continue
+                    if unit is not None:
+                        try:
+                            sym_unit = int(sym.unit.value)
+                        except (AttributeError, ValueError, TypeError):
+                            sym_unit = 1
+                        if sym_unit != unit:
+                            continue
+                    units.append(sym)
             except AttributeError:
                 pass
 
             if not units:
+                if unit is not None:
+                    return {
+                        "error": f"Reference {reference!r} has no unit {unit}",
+                        "success": False,
+                    }
                 from kcaa.tools.sheet_tools import (
                     _do_update_sheet_symbol,
                     _list_sheet_symbols_impl,
@@ -2006,13 +2039,35 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                 if sheet_info is not None:
                     if rotation is not None:
                         return {"error": "rotation is not supported for sheet symbols"}
+                    # _do_update_sheet_symbol is absolute-position; convert
+                    # the requested deltas against the sheet's current anchor.
+                    sheet_pos = sheet_info.get("position") or {}
+                    abs_x = abs_y = None
+                    if x is not None:
+                        if sheet_pos.get("x") is None:
+                            return {
+                                "error": (
+                                    f"Cannot apply delta x={x!r}: sheet {reference!r} "
+                                    "has no current position"
+                                )
+                            }
+                        abs_x = float(sheet_pos["x"]) + x
+                    if y is not None:
+                        if sheet_pos.get("y") is None:
+                            return {
+                                "error": (
+                                    f"Cannot apply delta y={y!r}: sheet {reference!r} "
+                                    "has no current position"
+                                )
+                            }
+                        abs_y = float(sheet_pos["y"]) + y
                     sheet_result = _do_update_sheet_symbol(
                         schematic_path=schematic_path,
                         sheet_identifier=reference,
                         sheet_name=None,
                         sheet_file=None,
-                        x=x,
-                        y=y,
+                        x=abs_x,
+                        y=abs_y,
                         width=None,
                         height=None,
                     )
@@ -2031,23 +2086,34 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                     }
                 return {"error": f"No symbol or sheet named {reference!r} found"}
 
-            # Compute the target position (grid-snapped), then nudge it to
-            # avoid overlap with other symbols/sheets if needed.
+            # Deltas are snapped to the 1.27 mm grid before application, so
+            # the resulting absolute anchor stays on-grid for on-grid
+            # symbols. Overlap avoidance runs in absolute coordinates
+            # (candidate = current anchor + snapped delta), then the final
+            # applied delta is whatever reaches the chosen absolute spot.
             first_at = units[0].at.value
-            raw_new_x = _align_to_grid(x) if x is not None else float(first_at[0])
-            raw_new_y = _align_to_grid(y) if y is not None else float(first_at[1])
+            aligned_dx = _align_to_grid(x) if x is not None else 0.0
+            aligned_dy = _align_to_grid(y) if y is not None else 0.0
+            raw_new_x = float(first_at[0]) + aligned_dx
+            raw_new_y = float(first_at[1]) + aligned_dy
             final_new_x = raw_new_x
             final_new_y = raw_new_y
-            position_adjusted = False
-            if x is not None or y is not None:
+            overlap_adjusted = False
+            grid_snapped = (x is not None and abs(aligned_dx - x) > 1e-6) or (
+                y is not None and abs(aligned_dy - y) > 1e-6
+            )
+            # Whole-component moves may nudge to free space; per-unit moves
+            # are precise operations on the unit's own footprint, so the
+            # union-bbox search does not apply.
+            if (x is not None or y is not None) and unit is None:
                 try:
                     from kcaa.tools.placement_helpers import _find_free_area_impl
                     from kcaa.tools.sheet_tools import _has_position_conflict
-                    from kcaa.utils.netlist_parser import extract_netlist
+                    from kcaa.utils.netlist_parser import component_body_bbox, extract_netlist
 
                     netlist = extract_netlist(schematic_path)
                     comp_info = (netlist.get("components") or {}).get(reference)
-                    bb_d = comp_info.get("body_bbox") if comp_info else None
+                    bb_d = component_body_bbox(comp_info) if comp_info else None
                     if bb_d:
                         bbox_w = float(bb_d["max_x"]) - float(bb_d["min_x"])
                         bbox_h = float(bb_d["max_y"]) - float(bb_d["min_y"])
@@ -2080,6 +2146,7 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                             bbox_w,
                             bbox_h,
                             exclude_uuid=sym_uuid,
+                            exclude_refs={reference},
                         )
                         if has_conflict:
                             log.info(
@@ -2098,6 +2165,7 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                                 prefer_near={"x": raw_new_x, "y": raw_new_y},
                                 max_candidates=1,
                                 exclude_uuid=sym_uuid,
+                                exclude_refs={reference},
                             )
                             cand = (free.get("candidates") or [{}])[0]
                             origin = cand.get("origin")
@@ -2114,7 +2182,7 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                                 if abs(adj_x - raw_new_x) > 1e-6 or abs(adj_y - raw_new_y) > 1e-6:
                                     final_new_x = _align_to_grid(adj_x)
                                     final_new_y = _align_to_grid(adj_y)
-                                    position_adjusted = True
+                                    overlap_adjusted = True
                                     log.info(
                                         "move_component: adjusted to nearest free (%s, %s) "
                                         "from requested (%s, %s) (ref=%s)",
@@ -2133,13 +2201,22 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                     )
                     pass
 
+            # Every scoped unit shifts by the same final delta (grid-snapped request,
+            # possibly adjusted to free space). Rotation is a per-unit delta,
+            # so each unit ends at (old + rotation) % 360 — relative unit
+            # orientations survive whole-component moves.
+            anchor_at2 = units[0].at.value
+            delta_x = final_new_x - float(anchor_at2[0])
+            delta_y = final_new_y - float(anchor_at2[1])
+
             for sym in units:
                 at = sym.at.value
                 old_x = at[0]
                 old_y = at[1]
-                new_x = final_new_x if (x is not None) else old_x
-                new_y = final_new_y if (y is not None) else old_y
-                new_rot = rotation if rotation is not None else (at[2] if len(at) > 2 else 0)
+                new_x = old_x + delta_x
+                new_y = old_y + delta_y
+                old_rot = at[2] if len(at) > 2 else 0
+                new_rot = (old_rot + rotation) % 360 if rotation is not None else old_rot
                 dx = new_x - old_x
                 dy = new_y - old_y
                 sym.at.value = [new_x, new_y, new_rot]
@@ -2228,9 +2305,11 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                     body_bbox = _placed_world_bbox(lib_raw, placements)
             except Exception:
                 body_bbox = None
+            position_adjusted = overlap_adjusted or grid_snapped
             out: dict[str, Any] = {
                 "success": True,
                 "reference": reference,
+                "unit": unit,
                 "position": {"x": final_at[0], "y": final_at[1]},
                 "rotation": final_at[2] if len(final_at) > 2 else 0,
                 "units_updated": len(units),
@@ -2239,7 +2318,7 @@ def register_symbol_edit_tools(mcp: FastMCP) -> None:
                 "file_modified": schematic_path,
                 "backup_path": schematic_path + ".bak",
             }
-            if position_adjusted:
+            if overlap_adjusted:
                 out["requested_position"] = {"x": raw_new_x, "y": raw_new_y}
                 out["note"] = "Position adjusted to nearest free area to avoid overlap."
             return out

--- a/kcaa/utils/netlist_parser.py
+++ b/kcaa/utils/netlist_parser.py
@@ -3,6 +3,7 @@ KiCad schematic netlist extraction utilities.
 """
 
 from collections import defaultdict
+from collections.abc import Iterator
 import contextlib
 import os
 import re
@@ -47,6 +48,61 @@ def _normalize_iterable(value: Any) -> list[Any]:
     except TypeError:
         return [value]
     return [value[i] for i in range(length)]
+
+
+def iter_component_pins(comp: dict[str, Any]) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Yield ``(unit, pin)`` for every pin of every unit in a component.
+
+    ``units`` (added for issue #89) nests pins per unit; callers that need
+    a flat pin view (netlist tracing, reports) iterate this instead of
+    reading a top-level ``pins`` list.
+    """
+    for unit_key, unit_data in (comp.get("units") or {}).items():
+        for pin in unit_data.get("pins", []):
+            yield unit_key, pin
+
+
+def first_unit_position(comp: dict[str, Any]) -> dict[str, Any]:
+    """Anchor of the lowest-numbered unit, as a deterministic summary.
+
+    Single-unit consumers (power symbols, placement fallbacks) previously
+    read a top-level ``position``; with units nested per reference the
+    anchor of unit 1 (or the first unit present) is the equivalent.
+    """
+    units = comp.get("units") or {}
+    first = units.get("1") or next(iter(units.values()), None) or {}
+    pos = first.get("position") if isinstance(first, dict) else None
+    return pos if isinstance(pos, dict) else {}
+
+
+def component_body_bbox(comp: dict[str, Any]) -> dict[str, float] | None:
+    """World-space union bbox covering every unit of a component.
+
+    The netlist schema keeps one ``body_bbox`` per unit, nested under
+    ``units[unit]`` (the merged top-level bbox was removed — the union of
+    two far-apart units is meaningless for per-unit reasoning). Consumers
+    that need the component's whole occupied region (overlap avoidance,
+    group membership) fuse the unit bboxes here. Returns ``None`` when no
+    unit has a bbox (e.g. graphics-less symbols like PWR_FLAG).
+    """
+    boxes: list[BBox] = []
+    for unit_data in (comp.get("units") or {}).values():
+        bb = unit_data.get("body_bbox") if isinstance(unit_data, dict) else None
+        if not bb:
+            continue
+        try:
+            boxes.append(
+                BBox(
+                    float(bb["min_x"]),
+                    float(bb["min_y"]),
+                    float(bb["max_x"]),
+                    float(bb["max_y"]),
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    merged = union_bboxes(boxes)
+    return merged.to_dict() if merged is not None else None
 
 
 class SchematicParser:
@@ -127,7 +183,17 @@ class SchematicParser:
         return result
 
     def _extract_components(self) -> None:
-        """Extract component information from schematic."""
+        """Extract component information from schematic.
+
+        skip/schematic yields one Symbol per placed unit, so a multi-unit
+        symbol appears as several symbols sharing one reference.  Each unit
+        is nested under that reference in ``units[unit]`` with its own
+        anchor, pins, and world ``body_bbox``; there is no ambiguous
+        top-level ``position``/flat ``pins`` and unit membership never has
+        to be guessed from coordinates (issue #89).  There is no merged
+        top-level bbox — the union of far-apart units is meaningless, so
+        each unit reports its own footprint.
+        """
         print("Extracting components")
         try:
             symbols = self._sch.symbol
@@ -164,21 +230,21 @@ class SchematicParser:
             lib_bbox_cache[lib_id] = bboxes
             return bboxes
 
-        # World bboxes accumulated per reference so multi-unit symbols
-        # report the union of every placed unit's footprint.
-        world_bbox_per_ref: dict[str, list[BBox]] = defaultdict(list)
+        # World bboxes accumulated per (reference, unit) — each unit keeps
+        # its own footprint bbox under units[unit]["body_bbox"].
+        world_bbox_per_unit: dict[tuple[str, str], list[BBox]] = defaultdict(list)
 
         for sym in symbols:
             comp: dict[str, Any] = {}
 
             # Reference is required; skip entries that don't have one
             try:
-                comp["reference"] = sym.property.Reference.value
+                ref = sym.property.Reference.value
             except AttributeError:
                 continue
-            ref = comp["reference"]
             if not ref:
                 continue
+            comp["reference"] = ref
 
             with contextlib.suppress(AttributeError):
                 comp["lib_id"] = sym.lib_id.value
@@ -189,20 +255,21 @@ class SchematicParser:
             with contextlib.suppress(AttributeError):
                 comp["footprint"] = sym.property.Footprint.value
 
-            # sym.at.value -> [x, y, angle]
+            # sym.at.value -> [x, y, angle]; the anchor of THIS unit.
             sym_x = sym_y = sym_rot = None
             try:
                 at_val = sym.at.value
                 sym_x = float(at_val[0])
                 sym_y = float(at_val[1])
                 sym_rot = float(at_val[2]) if len(at_val) > 2 else 0.0
-                comp["position"] = {
-                    "x": sym_x,
-                    "y": sym_y,
-                    "rotation": sym_rot,
-                }
             except (AttributeError, IndexError, TypeError):
                 pass
+
+            # Unit number of this placed instance; symbols without an
+            # explicit `unit` field are unit 1.
+            unit_no = 1
+            with contextlib.suppress(AttributeError, ValueError, TypeError):
+                unit_no = int(sym.unit.value)
 
             # Mirror flag (rare; "x" or "y") so the world bbox is correct
             # even when the user has flipped a placed instance in KiCad.
@@ -215,9 +282,6 @@ class SchematicParser:
 
             # Per-unit world bbox: look up this unit's lib bbox, transform.
             if comp.get("lib_id") and sym_x is not None and sym_y is not None:
-                unit_no = 1
-                with contextlib.suppress(AttributeError, ValueError, TypeError):
-                    unit_no = int(sym.unit.value)
                 bboxes = _lib_unit_bboxes(comp["lib_id"])
                 lib_bb = bboxes.get(unit_no) or bboxes.get(1)
                 if lib_bb is not None:
@@ -229,9 +293,9 @@ class SchematicParser:
                         rot_int,
                         mirror_val,
                     )
-                    world_bbox_per_ref[ref].append(world_bb)
+                    world_bbox_per_unit[(ref, str(unit_no))].append(world_bb)
 
-            # Collect pin positions via shared helper (handles the skip bug
+            # Pins of this unit via the shared helper (handles the skip bug
             # for single-pin symbols: power nets, PWR_FLAG, TestPoint, etc.)
             pins_summary: list[dict[str, str]] = []
             for pin in sym_pin_world_coords(sym):
@@ -246,35 +310,47 @@ class SchematicParser:
                     }
                 )
 
+            unit_entry: dict[str, Any] = {}
+            if sym_x is not None and sym_y is not None:
+                unit_entry["position"] = {"x": sym_x, "y": sym_y, "rotation": sym_rot}
             if pins_summary:
-                comp["pins"] = pins_summary
+                unit_entry["pins"] = pins_summary
 
             prev = self.component_info.get(ref)
             if prev is not None:
-                # Multi-unit symbol: keep the first unit's entry and merge
-                # every later unit's pins into it.  skip/schematic yields one
-                # Symbol per unit, so without merging only the last unit's
-                # pins would survive (U2 lost its 9 power pins).
-                # NOTE: comp["position"]/comp["rotation"] belong to the
-                # first unit skip yields, which is not necessarily unit 1
-                # (U2's entry carries unit 2's anchor).  The merged pins list
-                # covers all units and body_bbox is the union of all units.
-                prev_pins = prev.setdefault("pins", [])
-                seen = {(p["num"], p["x"], p["y"]) for p in prev_pins}
-                for pin in comp.get("pins", []):
-                    key = (pin["num"], pin["x"], pin["y"])
-                    if key not in seen:
-                        seen.add(key)
-                        prev_pins.append(pin)
+                # Multi-unit symbol: this is another placed unit of the same
+                # reference — nest it under the existing entry.
+                prev_units = prev.setdefault("units", {})
+                unit_key = str(unit_no)
+                if unit_key in prev_units:
+                    # Defensive merge if a unit number repeats: keep the
+                    # first anchor, append pins not already present.
+                    existing = prev_units[unit_key]
+                    seen = {(p["num"], p["x"], p["y"]) for p in existing.get("pins", [])}
+                    for pin in pins_summary:
+                        key = (pin["num"], pin["x"], pin["y"])
+                        if key not in seen:
+                            seen.add(key)
+                            existing.setdefault("pins", []).append(pin)
+                else:
+                    prev_units[unit_key] = unit_entry
+                # Deterministic output: unit "1" first regardless of the
+                # order skip yields units.
+                prev["units"] = dict(sorted(prev_units.items(), key=lambda kv: int(kv[0])))
             else:
+                comp["units"] = {str(unit_no): unit_entry}
                 self.components.append(comp)
                 self.component_info[ref] = comp
 
-        # Attach the union world bbox to each component info entry.
-        for ref, bbs in world_bbox_per_ref.items():
+        # Attach each unit's world bbox; units with no graphics (e.g.
+        # PWR_FLAG) simply have none.
+        for (ref, unit_key), bbs in world_bbox_per_unit.items():
             merged = union_bboxes(bbs)
-            if merged is not None and ref in self.component_info:
-                self.component_info[ref]["body_bbox"] = merged.to_dict()
+            if merged is None or ref not in self.component_info:
+                continue
+            unit_entry = (self.component_info[ref].get("units") or {}).get(unit_key)
+            if unit_entry:
+                unit_entry["body_bbox"] = merged.to_dict()
 
         print(f"Extracted {len(self.components)} components")
 
@@ -360,16 +436,22 @@ class SchematicParser:
                     }
                 )
 
+            # Sheets are opaque single-unit placeholders: nest their anchor
+            # and pins under units["1"] so every component entry shares one
+            # schema.
+            sheet_unit: dict[str, Any] = {}
+            if pins:
+                sheet_unit["pins"] = pins
+            if sheet_x is not None and sheet_y is not None:
+                sheet_unit["position"] = {"x": sheet_x, "y": sheet_y}
             comp: dict[str, Any] = {
                 "reference": unique_reference,
                 "value": str(sheet_file or ""),
                 "type": "sheet",
-                "pins": pins,
+                "units": {"1": sheet_unit},
             }
-            if sheet_x is not None and sheet_y is not None:
-                comp["position"] = {"x": sheet_x, "y": sheet_y}
             if None not in (sheet_x, sheet_y, sheet_width, sheet_height):
-                comp["body_bbox"] = {
+                sheet_unit["body_bbox"] = {
                     "min_x": sheet_x,
                     "min_y": sheet_y,
                     "max_x": sheet_x + sheet_width,
@@ -504,7 +586,7 @@ class SchematicParser:
                 self.power_symbols.append(
                     {
                         "type": comp["lib_id"].split(":", 1)[1],
-                        "position": comp.get("position", {}),
+                        "position": first_unit_position(comp),
                     }
                 )
         print(f"Extracted {len(self.power_symbols)} power symbols")
@@ -577,7 +659,7 @@ class SchematicParser:
         for ref, comp in self.component_info.items():
             if ref.startswith("#"):
                 continue
-            for pin_data in comp.get("pins", []):
+            for _unit, pin_data in iter_component_pins(comp):
                 pin_number = str(pin_data.get("num", pin_data.get("number", "")))
                 if not pin_number:
                     continue
@@ -605,7 +687,7 @@ class SchematicParser:
         for comp in self.component_info.values():
             if comp.get("type") != "sheet":
                 continue
-            for pin_data in comp.get("pins", []):
+            for _unit, pin_data in iter_component_pins(comp):
                 pin_name = str(
                     pin_data.get("name") or pin_data.get("number") or pin_data.get("num")
                 )
@@ -619,12 +701,12 @@ class SchematicParser:
         for ref, comp in self.component_info.items():
             if comp.get("lib_id", "").startswith("power:"):
                 power_name = comp["lib_id"].split(":", 1)[1]
-                pin_coords = comp.get("pins", [])
+                pin_coords = [p for _unit, p in iter_component_pins(comp)]
                 if pin_coords:
                     for pin_data in pin_coords:
                         name_point(pt(pin_data["x"], pin_data["y"]), power_name)
                 else:
-                    pos = comp.get("position", {})
+                    pos = first_unit_position(comp)
                     if pos:
                         name_point(pt(pos.get("x", 0), pos.get("y", 0)), power_name)
 
@@ -693,7 +775,7 @@ class SchematicParser:
 
         anchored: set[tuple] = set()
         for cdata in self.component_info.values():
-            for pin in cdata.get("pins", []):
+            for _unit, pin in iter_component_pins(cdata):
                 anchored.add(rpt(pin["x"], pin["y"]))
         for label in self.labels + self.global_labels + self.hierarchical_labels:
             pos = label["position"]

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -734,6 +734,13 @@ _PROMPT_SCHEMATIC = """\
   0°=unrotated, 90°=tilt left, 180°=flipped, 270°=tilt right.
 - The schematic grid is **1.27 mm (50 mil)**. add_symbol_to_schematic and
   move_component snap automatically; rotation is restricted to 0/90/180/270.
+- move_component takes **deltas**: x/y are mm to shift by, rotation is an
+  incremental angle added to the component's current rotation. Read the
+  current anchor from extract_schematic_netlist and subtract to express an
+  absolute move as a delta; position/rotation in the result are the new
+  absolute values of the first moved unit. Omitting `unit` moves every
+  unit of a multi-unit symbol together; pass `unit=N` to move/rotate one
+  unit individually.
 - Default sheet is **A4 (297 x 210 mm)**. At the start of each request
   that involves spatial changes, call get_schematic_sheet_info once to
   confirm the actual paper size and to learn the recommended drawing area

--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -734,13 +734,6 @@ _PROMPT_SCHEMATIC = """\
   0°=unrotated, 90°=tilt left, 180°=flipped, 270°=tilt right.
 - The schematic grid is **1.27 mm (50 mil)**. add_symbol_to_schematic and
   move_component snap automatically; rotation is restricted to 0/90/180/270.
-- move_component takes **deltas**: x/y are mm to shift by, rotation is an
-  incremental angle added to the component's current rotation. Read the
-  current anchor from extract_schematic_netlist and subtract to express an
-  absolute move as a delta; position/rotation in the result are the new
-  absolute values of the first moved unit. Omitting `unit` moves every
-  unit of a multi-unit symbol together; pass `unit=N` to move/rotate one
-  unit individually.
 - Default sheet is **A4 (297 x 210 mm)**. At the start of each request
   that involves spatial changes, call get_schematic_sheet_info once to
   confirm the actual paper size and to learn the recommended drawing area

--- a/kicad_plugin/skills/schematic_placement.md
+++ b/kicad_plugin/skills/schematic_placement.md
@@ -6,8 +6,9 @@ description: "Symbol placement workflow, find_free_area, bbox geometry, spacing 
 # Geometry you get for free
 - get_symbol and get_symbol_pins return body_bbox + per-unit bboxes in
   library coordinates so you can size new placements before inserting.
-- extract_schematic_netlist returns body_bbox per placed component in
-  schematic (Y-down) world coordinates. Use it as your occupancy map.
+- extract_schematic_netlist returns a body_bbox per placed **unit** in
+  schematic (Y-down) world coordinates. Union every unit's bbox to get a
+  component's occupied region and use that as your occupancy map.
 - add_symbol_to_schematic, place_symbol_relative and move_component all
   return the resulting body_bbox so you usually do NOT need to re-extract
   the netlist after a successful placement.

--- a/kicad_plugin/skills/schematic_placement.md
+++ b/kicad_plugin/skills/schematic_placement.md
@@ -30,6 +30,20 @@ description: "Symbol placement workflow, find_free_area, bbox geometry, spacing 
 3. After moves/inserts, prefer using the returned body_bbox; only call
    extract_schematic_netlist again if you need to refresh net info.
 
+# Moving / rotating components
+- move_component takes **deltas**: `x`/`y` are mm to shift by (each snapped
+  to the 1.27 mm grid), `rotation` is an increment applied per unit as
+  `(old + rotation) % 360` (restricted to 0/90/180/270). Read the current
+  anchor from extract_schematic_netlist and subtract to express an
+  absolute move as a delta; `position`/`rotation` in the result are the
+  new **absolute** values of the first moved unit.
+- Omitting `unit` moves **every** unit of a multi-unit symbol together by
+  the same shift, preserving relative layout. Pass `unit=N` to move/rotate
+  one unit individually (no overlap-avoidance search).
+- Whole-move deltas may be nudged to the nearest free area when the target
+  region is occupied: `position_adjusted` is then `True` and
+  `requested_position` holds the grid-snapped target.
+
 # Spacing & layout rules
 - Keep at least one grid step (1.27 mm) of clearance between symbol body
   bboxes; 2.54 mm or more is preferred so Reference/Value labels do not

--- a/tests/unit/tools/test_netlist_tools.py
+++ b/tests/unit/tools/test_netlist_tools.py
@@ -73,27 +73,39 @@ SAMPLE_NETLIST = {
     "components": {
         "R1": {
             "value": "10k",
-            "position": {"x": 100, "y": 50},
-            "pins": [
-                {"num": "1", "x": 95, "y": 50, "direction": "left"},
-                {"num": "2", "x": 105, "y": 50, "direction": "right"},
-            ],
+            "units": {
+                "1": {
+                    "position": {"x": 100, "y": 50, "rotation": 0},
+                    "pins": [
+                        {"num": "1", "x": 95, "y": 50, "direction": "left"},
+                        {"num": "2", "x": 105, "y": 50, "direction": "right"},
+                    ],
+                },
+            },
         },
         "R2": {
             "value": "4.7k",
-            "position": {"x": 150, "y": 50},
-            "pins": [
-                {"num": "1", "x": 145, "y": 50, "direction": "left"},
-                {"num": "2", "x": 155, "y": 50, "direction": "right"},
-            ],
+            "units": {
+                "1": {
+                    "position": {"x": 150, "y": 50, "rotation": 0},
+                    "pins": [
+                        {"num": "1", "x": 145, "y": 50, "direction": "left"},
+                        {"num": "2", "x": 155, "y": 50, "direction": "right"},
+                    ],
+                },
+            },
         },
         "C1": {
             "value": "100nF",
-            "position": {"x": 200, "y": 100},
-            "pins": [
-                {"num": "1", "x": 195, "y": 100, "direction": "left"},
-                {"num": "2", "x": 205, "y": 100, "direction": "right"},
-            ],
+            "units": {
+                "1": {
+                    "position": {"x": 200, "y": 100, "rotation": 0},
+                    "pins": [
+                        {"num": "1", "x": 195, "y": 100, "direction": "left"},
+                        {"num": "2", "x": 205, "y": 100, "direction": "right"},
+                    ],
+                },
+            },
         },
     },
     "nets": {
@@ -259,8 +271,8 @@ class TestExtractSchematicNetlist:
             "max_x": 76.2,
             "max_y": 76.2,
         }.items():
-            assert sheet["body_bbox"][key] == pytest.approx(expected)
-        assert sheet["pins"] == [
+            assert sheet["units"]["1"]["body_bbox"][key] == pytest.approx(expected)
+        assert sheet["units"]["1"]["pins"] == [
             {
                 "num": "VCC",
                 "number": "VCC",
@@ -309,7 +321,7 @@ class TestExtractSchematicNetlist:
     @patch("kcaa.tools.netlist_tools.extract_netlist", return_value=SAMPLE_NETLIST)
     def test_pin_to_net_mapping(self, mock_extract, mock_exists):
         result = _run(self.fn("/some/design.kicad_sch", ctx=None))
-        r1_pins = result["analysis"]["components"]["R1"]["pins"]
+        r1_pins = result["analysis"]["components"]["R1"]["units"]["1"]["pins"]
         pin_nets = {p["num"]: p["net"] for p in r1_pins}
         assert pin_nets["2"] == "GND"
         assert pin_nets["1"] == "Net-(R1-Pad1)"
@@ -469,14 +481,48 @@ class TestFindComponentConnections:
                 **SAMPLE_NETLIST["components"],
                 "U1": {
                     "value": "ATmega328",
-                    "position": {"x": 300, "y": 200},
-                    "pins": [
-                        {"num": "1", "x": 295, "y": 200, "direction": "left", "name": "VCC"},
-                        {"num": "2", "x": 305, "y": 200, "direction": "right", "name": "GND"},
-                        {"num": "3", "x": 295, "y": 210, "direction": "left", "name": "INPUT"},
-                        {"num": "4", "x": 305, "y": 210, "direction": "right", "name": "OUTPUT"},
-                        {"num": "5", "x": 295, "y": 220, "direction": "left", "name": "GPIO0"},
-                    ],
+                    "units": {
+                        "1": {
+                            "position": {"x": 300, "y": 200},
+                            "pins": [
+                                {
+                                    "num": "1",
+                                    "x": 295,
+                                    "y": 200,
+                                    "direction": "left",
+                                    "name": "VCC",
+                                },
+                                {
+                                    "num": "2",
+                                    "x": 305,
+                                    "y": 200,
+                                    "direction": "right",
+                                    "name": "GND",
+                                },
+                                {
+                                    "num": "3",
+                                    "x": 295,
+                                    "y": 210,
+                                    "direction": "left",
+                                    "name": "INPUT",
+                                },
+                                {
+                                    "num": "4",
+                                    "x": 305,
+                                    "y": 210,
+                                    "direction": "right",
+                                    "name": "OUTPUT",
+                                },
+                                {
+                                    "num": "5",
+                                    "x": 295,
+                                    "y": 220,
+                                    "direction": "left",
+                                    "name": "GPIO0",
+                                },
+                            ],
+                        }
+                    },
                 },
             },
             "nets": {
@@ -508,8 +554,12 @@ class TestFindComponentConnections:
             "components": {
                 "R1": {
                     "value": "10k",
-                    "position": {"x": 100, "y": 50},
-                    "pins": [{"num": "1", "x": 95, "y": 50, "direction": "left"}],
+                    "units": {
+                        "1": {
+                            "position": {"x": 100, "y": 50},
+                            "pins": [{"num": "1", "x": 95, "y": 50, "direction": "left"}],
+                        }
+                    },
                 },
             },
             "nets": {},

--- a/tests/unit/tools/test_placement_helpers.py
+++ b/tests/unit/tools/test_placement_helpers.py
@@ -525,14 +525,15 @@ class TestPlaceSymbolRelative:
                 comps["move_component"](
                     schematic_path=tmp_sch,
                     reference=ref,
-                    x=90.0,
-                    y=90.0,
+                    x=30.0,  # delta, grid-snapped
+                    y=30.0,
                 )
             )
         assert moved["success"], moved
         bb = moved["body_bbox"]
         assert bb is not None
-        # The bbox should be near (90, 90).
+        # Added at ~(60, 60) plus a 30 mm delta: the bbox should sit near
+        # (90, 90).
         cx = (bb["min_x"] + bb["max_x"]) / 2.0
         cy = (bb["min_y"] + bb["max_y"]) / 2.0
         assert abs(cx - 90.0) < 5.0
@@ -567,13 +568,15 @@ class TestPlaceSymbolRelative:
                 )
             )
         assert moved["success"], moved
-        # Read back the .kicad_sch and verify the placed symbol's `at` is
-        # at the nearest grid point to (90.10, 90.10), i.e. 71*1.27=90.17.
+        # Read back the .kicad_sch and verify the delta was snapped to the
+        # 1.27 mm grid (90.10 -> 71*1.27 = 90.17) so the resulting `at`
+        # stays grid-aligned.
         from kcaa.utils.netlist_parser import extract_netlist
 
         netlist = extract_netlist(tmp_sch)
         comp = netlist["components"][ref]
-        x_pos, y_pos = comp["position"]["x"], comp["position"]["y"]
+        unit_pos = comp["units"]["1"]["position"]
+        x_pos, y_pos = unit_pos["x"], unit_pos["y"]
         # Each coordinate must be an exact multiple of 1.27.
         assert abs(round(x_pos / 1.27) * 1.27 - x_pos) < 1e-6
         assert abs(round(y_pos / 1.27) * 1.27 - y_pos) < 1e-6

--- a/tests/unit/tools/test_symbol_edit_tools.py
+++ b/tests/unit/tools/test_symbol_edit_tools.py
@@ -29,6 +29,8 @@ import skip
 SCHEMATIC_PATH = str(Path(__file__).parent / "fixtures/tools_test.kicad_sch")
 SHEET_SCHEMATIC_PATH = str(Path(__file__).parent / "fixtures/sheet_netlist_test.kicad_sch")
 TEST_SYM_PATH = str(Path(__file__).parent / "fixtures/test_symbols.kicad_sym")
+# U1 = myLib:DUAL with units 1 (100,100,90°) and 2 (120,100,0°).
+MULTI_UNIT_PATH = str(Path(__file__).parent.parent / "utils/fixtures/multi_unit.kicad_sch")
 
 # The symbol and library names used across tests.
 _LIB_NAME = "Device"
@@ -106,6 +108,19 @@ def tools():
 def tmp_sch():
     """Yield a temp copy of the schematic, then clean up."""
     path = _make_temp_copy()
+    yield path
+    for p in [path, path + ".bak"]:
+        if os.path.exists(p):
+            os.unlink(p)
+
+
+@pytest.fixture()
+def tmp_multi_sch():
+    """Fresh temp copy of the multi-unit fixture (U1, two units)."""
+    path = tempfile.NamedTemporaryFile(
+        suffix=".kicad_sch", delete=False, dir=tempfile.gettempdir()
+    ).name
+    shutil.copy(MULTI_UNIT_PATH, path)
     yield path
     for p in [path, path + ".bak"]:
         if os.path.exists(p):
@@ -1099,35 +1114,39 @@ class TestMoveComponent:
         pytest.fail("R1 not found in written schematic")
 
     def test_move_xy_only(self, tools, tmp_sch):
-        """move_component with only x/y should update position but not rotation."""
+        """move_component with only x/y deltas should translate but not rotate."""
         sch_orig = skip.Schematic(tmp_sch)
-        orig_rot = None
+        orig_x = orig_y = orig_rot = None
         for sym in sch_orig.symbol:
             try:
                 if sym.property.Reference.value == "R1":
+                    orig_x, orig_y = sym.at.value[0], sym.at.value[1]
                     orig_rot = sym.at.value[2] if len(sym.at.value) > 2 else 0
                     break
             except AttributeError:
                 continue
+        assert orig_x is not None, "R1 not found in fixture"
 
+        dx = 55.88  # grid-aligned: 44 * 1.27
+        dy = 66.04  # grid-aligned: 52 * 1.27
         result = asyncio.run(
             tools["move_component"](
                 schematic_path=tmp_sch,
                 reference="R1",
-                x=55.88,  # grid-aligned: 44 * 1.27
-                y=66.04,  # grid-aligned: 52 * 1.27
+                x=dx,
+                y=dy,
             )
         )
         assert result.get("success") is True, result
-        assert abs(result["position"]["x"] - 55.88) < 0.001
-        assert abs(result["position"]["y"] - 66.04) < 0.001
+        assert abs(result["position"]["x"] - (orig_x + dx)) < 0.001
+        assert abs(result["position"]["y"] - (orig_y + dy)) < 0.001
 
         sch = skip.Schematic(tmp_sch)
         for sym in sch.symbol:
             try:
                 if sym.property.Reference.value == "R1":
-                    assert abs(sym.at.value[0] - 55.88) < 0.001, "x not updated"
-                    assert abs(sym.at.value[1] - 66.04) < 0.001, "y not updated"
+                    assert abs(sym.at.value[0] - (orig_x + dx)) < 0.001, "x not updated"
+                    assert abs(sym.at.value[1] - (orig_y + dy)) < 0.001, "y not updated"
                     if orig_rot is not None:
                         assert sym.at.value[2] == orig_rot, "rotation should not change"
                     return
@@ -1136,28 +1155,42 @@ class TestMoveComponent:
         pytest.fail("R1 not found in written schematic")
 
     def test_move_xy_and_rotation(self, tools, tmp_sch):
-        """move_component with x, y, and rotation should update all three."""
+        """move_component with x, y, and rotation deltas should update all three."""
+        sch_orig = skip.Schematic(tmp_sch)
+        orig_x = orig_y = orig_rot = None
+        for sym in sch_orig.symbol:
+            try:
+                if sym.property.Reference.value == "R1":
+                    orig_x, orig_y = sym.at.value[0], sym.at.value[1]
+                    orig_rot = sym.at.value[2] if len(sym.at.value) > 2 else 0
+                    break
+            except AttributeError:
+                continue
+        assert orig_x is not None and orig_rot is not None, "R1 not found in fixture"
+
+        dx = 12.7  # 10 * 1.27 — lands in free space, clear of the title block
+        dy = 25.4  # 20 * 1.27
         result = asyncio.run(
             tools["move_component"](
                 schematic_path=tmp_sch,
                 reference="R1",
-                x=76.20,  # 60 * 1.27
-                y=88.90,  # 70 * 1.27
+                x=dx,
+                y=dy,
                 rotation=180,
             )
         )
         assert result.get("success") is True, result
-        assert abs(result["position"]["x"] - 76.20) < 0.001
-        assert abs(result["position"]["y"] - 88.90) < 0.001
-        assert result["rotation"] == 180
+        assert abs(result["position"]["x"] - (orig_x + dx)) < 0.001
+        assert abs(result["position"]["y"] - (orig_y + dy)) < 0.001
+        assert result["rotation"] == (orig_rot + 180) % 360
 
         sch = skip.Schematic(tmp_sch)
         for sym in sch.symbol:
             try:
                 if sym.property.Reference.value == "R1":
-                    assert abs(sym.at.value[0] - 76.20) < 0.001
-                    assert abs(sym.at.value[1] - 88.90) < 0.001
-                    assert sym.at.value[2] == 180
+                    assert abs(sym.at.value[0] - (orig_x + dx)) < 0.001
+                    assert abs(sym.at.value[1] - (orig_y + dy)) < 0.001
+                    assert sym.at.value[2] == (orig_rot + 180) % 360
                     return
             except AttributeError:
                 continue
@@ -1172,8 +1205,9 @@ class TestMoveComponent:
         from kcaa.tools.sheet_tools import _align_to_grid
         from kcaa.utils.netlist_parser import extract_netlist
 
+        # R2 is at (100, 100) — a delta landing R1 there guarantees overlap.
         target_x = 100.0
-        target_y = 100.0  # R2 is at (100, 100) — guaranteed overlap.
+        target_y = 100.0
 
         # Read R1's current at position and UUID from the fixture.
         sch = skip.Schematic(tmp_sch)
@@ -1200,9 +1234,15 @@ class TestMoveComponent:
         assert r1_uuid is not None, "R1 UUID not found"
         assert r1_at_x is not None, "R1 position not found"
 
-        # Get R1's body_bbox dimensions.
+        # Get R1's body_bbox dimensions (per-unit schema; R1 is unit 1).
         netlist = extract_netlist(tmp_sch)
-        bb_d = (netlist.get("components") or {}).get("R1", {}).get("body_bbox")
+        bb_d = (
+            (netlist.get("components") or {})
+            .get("R1", {})
+            .get("units", {})
+            .get("1", {})
+            .get("body_bbox")
+        )
         assert bb_d is not None, "R1 body_bbox not in netlist"
         bbox_w = float(bb_d["max_x"]) - float(bb_d["min_x"])
         bbox_h = float(bb_d["max_y"]) - float(bb_d["min_y"])
@@ -1229,12 +1269,16 @@ class TestMoveComponent:
         expected_x = _align_to_grid(cand_x - off_x)
         expected_y = _align_to_grid(cand_y - off_y)
 
+        # move_component takes deltas; derive them so the snapped target lands
+        # on R2's spot.
+        delta_x = snapped_tx - r1_at_x
+        delta_y = snapped_ty - r1_at_y
         result = asyncio.run(
             tools["move_component"](
                 schematic_path=tmp_sch,
                 reference="R1",
-                x=target_x,
-                y=target_y,
+                x=delta_x,
+                y=delta_y,
             )
         )
         assert result["success"] is True, result
@@ -1242,35 +1286,41 @@ class TestMoveComponent:
             f"Expected adjustment, got position={result.get('position')}"
         )
         # requested_position reflects the grid-snapped target, not raw input.
-        assert result["requested_position"] == {
-            "x": snapped_tx,
-            "y": snapped_ty,
-        }
+        assert result["requested_position"] == pytest.approx({"x": snapped_tx, "y": snapped_ty})
         assert result["position"]["x"] == pytest.approx(expected_x)
         assert result["position"]["y"] == pytest.approx(expected_y)
         assert result["note"] == "Position adjusted to nearest free area to avoid overlap."
 
     def test_move_no_overlap_keeps_exact_position(self, tools, tmp_sch):
-        """When the target position is free, move_component uses it as-is."""
-        from kcaa.tools.sheet_tools import _align_to_grid
+        """When the delta lands in free space, move_component applies it as-is."""
+        sch_orig = skip.Schematic(tmp_sch)
+        orig_x = orig_y = None
+        for sym in sch_orig.symbol:
+            try:
+                if sym.property.Reference.value == "R1":
+                    orig_x, orig_y = sym.at.value[0], sym.at.value[1]
+                    break
+            except AttributeError:
+                continue
+        assert orig_x is not None, "R1 not found in fixture"
 
-        target_x = 55.88  # 44 * 1.27 — grid-aligned
-        target_y = 10.16  # 8 * 1.27 — far from the component cluster (~Y=100).
+        dx = 55.88  # 44 * 1.27 — grid-aligned
+        dy = 10.16  # 8 * 1.27 — lands far from the component cluster (~Y=100).
 
         result = asyncio.run(
             tools["move_component"](
                 schematic_path=tmp_sch,
                 reference="R1",
-                x=target_x,
-                y=target_y,
+                x=dx,
+                y=dy,
             )
         )
         assert result["success"] is True, result
         assert result.get("position_adjusted") is False, (
             f"Expected no adjustment at free position, got note={result.get('note')}"
         )
-        assert abs(result["position"]["x"] - _align_to_grid(target_x)) < 0.001
-        assert abs(result["position"]["y"] - _align_to_grid(target_y)) < 0.001
+        assert abs(result["position"]["x"] - (orig_x + dx)) < 0.001
+        assert abs(result["position"]["y"] - (orig_y + dy)) < 0.001
 
     def test_move_creates_backup(self, tools, tmp_sch):
         """A .bak file should appear next to the schematic after moving."""
@@ -1426,12 +1476,14 @@ class TestMoveComponent:
         assert "error" in result
 
     def test_moves_sheet_by_name(self, tools, tmp_sheet_sch):
+        """x/y are deltas here too: the sheet shifts, not moves to an
+        absolute spot. Fixture starts the sheet at (50.8, 50.8)."""
         result = asyncio.run(
             tools["move_component"](
                 schematic_path=tmp_sheet_sch,
                 reference="Power",
-                x=120.0,
-                y=80.0,
+                x=68.58,  # 54 * 1.27
+                y=29.21,  # 23 * 1.27
             )
         )
 
@@ -1522,6 +1574,132 @@ def _make_skip_symbol(ref: str, x: float, y: float, uid: str) -> str:
         f' (path "/fake" (reference "{ref}") (unit 1))))\n'
         f"  )\n"
     )
+
+
+class TestMoveComponentMultiUnit:
+    """move_component with unit scoping and multi-unit whole moves (issue #89)."""
+
+    @staticmethod
+    def _u1_units(path: str) -> dict:
+        """Return U1's nested units from extract_netlist for verification."""
+        from kcaa.utils.netlist_parser import extract_netlist
+
+        nl = extract_netlist(path)
+        comp = nl["components"]["U1"]
+        return {
+            int(unit_key): {
+                "position": unit_data.get("position"),
+                "pins": {
+                    p["num"]: (float(p["x"]), float(p["y"]), p["direction"])
+                    for p in unit_data.get("pins", [])
+                },
+            }
+            for unit_key, unit_data in comp["units"].items()
+        }
+
+    def test_whole_move_preserves_unit_offsets(self, tools, tmp_multi_sch):
+        """Whole-component delta move translates every unit by the same delta,
+        preserving relative unit layout and rotations."""
+        dx = 127.0  # 100 * 1.27 — grid-aligned
+        dy = 63.5  # 50 * 1.27 — grid-aligned
+        result = asyncio.run(
+            tools["move_component"](
+                schematic_path=tmp_multi_sch,
+                reference="U1",
+                x=dx,
+                y=dy,
+            )
+        )
+        assert result.get("success") is True, result
+        assert result["unit"] is None
+        assert result["units_updated"] == 2
+        assert result["position_adjusted"] is False, result
+        units = self._u1_units(tmp_multi_sch)
+        u1, u2 = units[1], units[2]
+        # unit 1 lands on old + delta…
+        assert (u1["position"]["x"], u1["position"]["y"]) == pytest.approx((100.0 + dx, 100.0 + dy))
+        assert u1["position"]["rotation"] == 90
+        # …and unit 2 keeps its relative +20 mm x offset, rotation untouched.
+        assert (u2["position"]["x"], u2["position"]["y"]) == pytest.approx((120.0 + dx, 100.0 + dy))
+        assert (u2["position"]["x"] - u1["position"]["x"]) == pytest.approx(20.0)
+        assert u2["position"]["rotation"] == 0
+
+    def test_unit_scoped_move_touches_only_that_unit(self, tools, tmp_multi_sch):
+        """unit=N applies the delta to only that unit, leaving the others untouched."""
+        dx = 101.6  # 80 * 1.27 — grid-aligned
+        dy = 19.05  # 15 * 1.27 — grid-aligned
+        result = asyncio.run(
+            tools["move_component"](
+                schematic_path=tmp_multi_sch,
+                reference="U1",
+                x=dx,
+                y=dy,
+                unit=2,
+            )
+        )
+        assert result.get("success") is True, result
+        assert result["unit"] == 2
+        assert result["units_updated"] == 1
+        units = self._u1_units(tmp_multi_sch)
+        assert (units[2]["position"]["x"], units[2]["position"]["y"]) == pytest.approx(
+            (120.0 + dx, 100.0 + dy)
+        )
+        assert units[2]["position"]["rotation"] == 0
+        assert units[2]["pins"]["3"] == pytest.approx((120.0 + dx, 100.0 + dy - 2.54, "up"))
+        # unit 1 anchor and pin world coordinates are untouched
+        assert (units[1]["position"]["x"], units[1]["position"]["y"]) == pytest.approx(
+            (100.0, 100.0)
+        )
+        assert units[1]["position"]["rotation"] == 90
+        assert units[1]["pins"]["1"] == pytest.approx((97.46, 100.0, "left"))
+
+    def test_unit_scoped_rotation_recomputes_pins(self, tools, tmp_multi_sch):
+        """Delta-rotating one unit about its own anchor moves that unit's pins."""
+        result = asyncio.run(
+            tools["move_component"](
+                schematic_path=tmp_multi_sch,
+                reference="U1",
+                rotation=90,
+                unit=2,
+            )
+        )
+        assert result["success"] is True, result
+        assert result["rotation"] == 90
+        units = self._u1_units(tmp_multi_sch)
+        # unit 2: 0° + 90° delta -> 90°; pins rotate CCW about the anchor.
+        assert units[2]["position"]["rotation"] == 90
+        assert (units[2]["position"]["x"], units[2]["position"]["y"]) == pytest.approx(
+            (120.0, 100.0)
+        )
+        assert units[2]["pins"]["3"] == pytest.approx((117.46, 100.0, "left"))
+        assert units[2]["pins"]["4"] == pytest.approx((122.54, 100.0, "right"))
+        # unit 1 untouched (still 90°, pins unchanged)
+        assert units[1]["position"]["rotation"] == 90
+        assert units[1]["pins"]["1"] == pytest.approx((97.46, 100.0, "left"))
+
+    def test_unit_validation_errors(self, tools, tmp_multi_sch):
+        """Nonexistent or non-positive unit numbers are rejected."""
+        r = asyncio.run(
+            tools["move_component"](
+                schematic_path=tmp_multi_sch,
+                reference="U1",
+                x=5.0,
+                unit=3,
+            )
+        )
+        assert "error" in r
+        assert "no unit 3" in r["error"]
+
+        r = asyncio.run(
+            tools["move_component"](
+                schematic_path=tmp_multi_sch,
+                reference="U1",
+                x=5.0,
+                unit=0,
+            )
+        )
+        assert "error" in r
+        assert "positive integer" in r["error"]
 
 
 class TestNextReferenceCrossFile:

--- a/tests/unit/utils/test_netlist_multi_unit.py
+++ b/tests/unit/utils/test_netlist_multi_unit.py
@@ -1,8 +1,9 @@
-"""Tests for multi-unit symbol pin merging in SchematicParser.
+"""Tests for multi-unit symbol handling in SchematicParser.
 
-skip/schematic yields one Symbol per unit under the same reference; without
-merging, only the last unit's pins survive (the U2 case in
-docs/skip_library_notes.md §6 lost its 9 power pins).
+skip/schematic yields one Symbol per unit under the same reference; each
+unit is nested under that reference in ``units[unit]`` with its own anchor
+and pins, so unit membership never has to be guessed from coordinates
+(issue #89).
 """
 
 import os
@@ -20,30 +21,86 @@ def parsed():
 
 
 class TestMultiUnitMerge:
-    def test_all_units_merged_into_one_entry(self, parsed):
+    def test_units_nested_under_reference(self, parsed):
         comp = parsed["components"].get("U1")
         assert comp is not None, "U1 not found in parsed components"
-        pins = comp.get("pins", [])
-        assert len(pins) == 4, f"expected 4 pins across both units, got {len(pins)}"
-        by_num = {p["num"]: p for p in pins}
-        assert set(by_num) == {"1", "2", "3", "4"}
+        units = comp["units"]
+        assert set(units) == {"1", "2"}, f"expected units 1 and 2, got {set(units)}"
+
+    def test_no_flat_pins_or_position(self, parsed):
+        """The ambiguous top-level position/pins are gone (issue #89)."""
+        comp = parsed["components"]["U1"]
+        assert "pins" not in comp
+        assert "position" not in comp
+        # No merged top-level bbox either — each unit reports its own.
+        assert "body_bbox" not in comp
+
+    def test_body_bbox_per_unit(self, parsed):
+        """Each unit has its own world bbox spanning its pins; no top-level union."""
+        comp = parsed["components"]["U1"]
+        assert "body_bbox" not in comp
+        u1 = comp["units"]["1"]["body_bbox"]
+        # Unit 1 placed at 90°: pins at x 97.46..102.54, both on y=100.
+        assert u1["min_x"] == pytest.approx(97.46)
+        assert u1["max_x"] == pytest.approx(102.54)
+        assert u1["min_y"] <= 100.0 <= u1["max_y"]
+        u2 = comp["units"]["2"]["body_bbox"]
+        # Unit 2 at 0°: pins stacked vertically at x=120.
+        assert u2["min_x"] <= 120.0 <= u2["max_x"]
+        assert u2["min_y"] == pytest.approx(97.46)
+        assert u2["max_y"] == pytest.approx(102.54)
+
+    def test_single_unit_bbox_nested(self, parsed):
+        """R1's world bbox lives under units["1"] (single-unit component)."""
+        comp = parsed["components"]["R1"]
+        assert "body_bbox" not in comp
+        u1 = comp["units"]["1"]["body_bbox"]
+        assert u1["min_x"] < u1["max_x"]
+        assert u1["min_y"] < u1["max_y"]
 
     def test_unit1_positions_rotated_ccw(self, parsed):
         """Unit 1 @ (100, 100, 90°): lib (0, +2.54) rotates to (-2.54, 0)."""
-        by_num = {p["num"]: p for p in parsed["components"]["U1"]["pins"]}
+        u1 = parsed["components"]["U1"]["units"]["1"]
+        assert (
+            u1["position"]["x"],
+            u1["position"]["y"],
+            u1["position"]["rotation"],
+        ) == pytest.approx((100.0, 100.0, 90.0))
+        by_num = {p["num"]: p for p in u1["pins"]}
+        assert set(by_num) == {"1", "2"}
         x, y = float(by_num["1"]["x"]), float(by_num["1"]["y"])
         assert (x, y) == pytest.approx((97.46, 100.0))
+        x4, y4 = float(by_num["2"]["x"]), float(by_num["2"]["y"])
+        assert (x4, y4) == pytest.approx((102.54, 100.0))
 
     def test_unit2_positions_unrotated(self, parsed):
         """Unit 2 @ (120, 100, 0°): lib (0, -2.54) stays put (Y-flipped)."""
-        by_num = {p["num"]: p for p in parsed["components"]["U1"]["pins"]}
+        u2 = parsed["components"]["U1"]["units"]["2"]
+        assert (
+            u2["position"]["x"],
+            u2["position"]["y"],
+            u2["position"]["rotation"],
+        ) == pytest.approx((120.0, 100.0, 0.0))
+        by_num = {p["num"]: p for p in u2["pins"]}
+        assert set(by_num) == {"3", "4"}
         x, y = float(by_num["4"]["x"]), float(by_num["4"]["y"])
         assert (x, y) == pytest.approx((120.0, 102.54))
 
     def test_directions_across_units(self, parsed):
         """Pin 1 (unit 1, placed 90°) exits left; pin 4 (unit 2, 0°) exits down."""
-        by_num = {p["num"]: p for p in parsed["components"]["U1"]["pins"]}
-        assert by_num["1"]["direction"] == "left"
-        assert by_num["2"]["direction"] == "right"
-        assert by_num["3"]["direction"] == "up"
-        assert by_num["4"]["direction"] == "down"
+        comp = parsed["components"]["U1"]
+        u1 = {p["num"]: p for p in comp["units"]["1"]["pins"]}
+        u2 = {p["num"]: p for p in comp["units"]["2"]["pins"]}
+        assert u1["1"]["direction"] == "left"
+        assert u1["2"]["direction"] == "right"
+        assert u2["3"]["direction"] == "up"
+        assert u2["4"]["direction"] == "down"
+
+    def test_single_unit_component_nested(self, parsed):
+        """Single-unit components nest under units["1"] too."""
+        comp = parsed["components"]["R1"]
+        units = comp["units"]
+        assert set(units) == {"1"}
+        u1 = units["1"]
+        assert (u1["position"]["x"], u1["position"]["y"]) == pytest.approx((161.29, 105.41))
+        assert {p["num"] for p in u1["pins"]} == {"1", "2"}

--- a/tests/unit/utils/test_netlist_parser.py
+++ b/tests/unit/utils/test_netlist_parser.py
@@ -22,8 +22,14 @@ def _all_pins(parsed: dict) -> list:
     """Return a flat list of every pin dict across all components."""
     pins = []
     for comp in parsed["components"].values():
-        pins.extend(comp.get("pins", []))
+        for unit in (comp.get("units") or {}).values():
+            pins.extend(unit.get("pins", []))
     return pins
+
+
+def _pins_of(comp: dict) -> list:
+    """Pins of a component's unit 1 (fixture components are single-unit)."""
+    return comp["units"]["1"].get("pins", [])
 
 
 @pytest.fixture(scope="module")
@@ -54,7 +60,7 @@ class TestNetlistPinDirection:
         """R1 (R_Small) has exactly 2 pins; both must carry a 'direction' key."""
         r1 = parsed["components"].get("R1")
         assert r1 is not None, "R1 not found in parsed components"
-        pins = r1.get("pins", [])
+        pins = _pins_of(r1)
         assert len(pins) == 2, f"Expected 2 pins for R1, got {len(pins)}"
         for pin in pins:
             assert "direction" in pin
@@ -63,7 +69,7 @@ class TestNetlistPinDirection:
         """C1 (capacitor) has exactly 2 pins; both must carry a 'direction' key."""
         c1 = parsed["components"].get("C1")
         assert c1 is not None, "C1 not found in parsed components"
-        pins = c1.get("pins", [])
+        pins = _pins_of(c1)
         assert len(pins) == 2, f"Expected 2 pins for C1, got {len(pins)}"
         for pin in pins:
             assert "direction" in pin
@@ -75,7 +81,7 @@ class TestNetlistPinDirection:
         """
         r1 = parsed["components"].get("R1")
         assert r1 is not None, "R1 not found in parsed components"
-        by_num = {pin["num"]: pin for pin in r1.get("pins", [])}
+        by_num = {pin["num"]: pin for pin in _pins_of(r1)}
         assert by_num["1"]["direction"] == "up", (
             f"R1 pin 1 direction expected 'up', got {by_num['1']['direction']!r}"
         )
@@ -90,7 +96,7 @@ class TestNetlistPinDirection:
         """
         c1 = parsed["components"].get("C1")
         assert c1 is not None, "C1 not found in parsed components"
-        by_num = {pin["num"]: pin for pin in c1.get("pins", [])}
+        by_num = {pin["num"]: pin for pin in _pins_of(c1)}
         assert by_num["1"]["direction"] == "up", (
             f"C1 pin 1 direction expected 'up', got {by_num['1']['direction']!r}"
         )


### PR DESCRIPTION
## Summary

Multi-unit symbols (e.g. `U2` on the real `two_ax_PCB` board) were merged
into one `components[ref]` entry whose flat pin list carried no unit
attribution and whose `position` belonged to whichever unit skip yields
first — **not necessarily unit 1**. Each placed unit is now nested under
its reference:

```json
"components[ref]": {
  "units": {
    "1": {"position": {"x", "y", "rotation"}, "body_bbox": {...}, "pins": [...]},
    "2": {...}
  }
}
```

## Changes

**Netlist schema (issue #89)**
- `components[ref].units[unit]` = that unit's `position`, `body_bbox`
  (own world-space footprint), and `pins`. The ambiguous top-level
  `position`, flat `pins`, and the merged union `body_bbox` are gone —
  a union of far-apart units is meaningless for per-unit reasoning.
- Sheets are opaque single-unit placeholders under `units["1"]`;
  single-unit components nest under `units["1"]` too (one schema).
- Helpers: `iter_component_pins()` (flatten pins), `first_unit_position()`
  (deterministic anchor), `component_body_bbox()` (fuse unit bboxes for
  overlap avoidance / group membership). Analysis tool reports, netlist
  resources, `_collect_occupied_bboxes`, `_find_free_area_impl`,
  `place_symbol_relative` all migrated.

**move_component now takes deltas**
- `x`/`y` are shifts in mm (snapped to the 1.27 mm grid); `rotation` is an
  increment applied per unit as `(old + rotation) % 360`, so relative
  unit layout/orientations survive whole-component moves.
- `unit=N` moves/rotates one unit individually (equivalent to moving a
  single symbol).
- The overlap-avoidance search excludes the moved reference itself, so a
  unit's stale position never blocks its own move; the sheet fallback
  converts the delta against the sheet's current anchor.

## Validation

- Full unit suite: **1160 passed, 17 skipped** (coverage gate ok).
- Real board `two_ax_PCB.kicad_sch` U2: `units["1"]` @ (101.6, 93.8022,
  90°) with 55 pins and bbox x∈[96.52, 142.24]; `units["2"]` @ (185.42,
  223.3422, 90°) with 9 power pins; 64 pins total, matching the
  coordinate-cluster split in the issue.
- `TestMoveComponentMultiUnit`: whole delta move preserves offset +
  rotations; unit-scoped move/rotate touches only that unit (pins
  recomputed); validation errors for `unit=0`/missing units.

Closes #89