### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kcaa"
-version = "0.2.1"
+version = "0.2.2"
 description = "Model Context Protocol (MCP) server for KiCad electronic design automation (EDA) files"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Bump `pyproject.toml` version 0.2.1 → 0.2.2 (patch).

Contents of this release since 0.2.1: fixes and docs only across the
recent merged PRs (#86, #87, #92, #95, #96, #98) — mirror axis / pin
world-coordinate fixes, netlist connectivity (pin contact, power
symbols, mid-wire anchors), multi-unit nesting, LLM client fixes, PCB
angle docs. No new features, so a patch bump follows semantic
versioning.

Single-file change; hooks pass.