### PR TITLE
fix(plugin): never downgrade active project to None on probe failure

### DIFF
--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -167,10 +167,6 @@ if _WX_AVAILABLE:
             # switching projects can re-offer that project's saved sessions
             # (same flow as startup auto-restore). Started by _init_llm_client.
             self._active_project: str | None = None
-            # Project-switch confirmation: first differing reading is held
-            # here and only acted on when the next tick agrees.
-            self._watch_candidate: str | None = None
-            self._watch_candidate_seen: bool = False
             self._project_watch_timer = wx.Timer(self)
             # Version-based dirty tracking: _conv_version bumps on every
             # conversation mutation; saves skip the write when the last
@@ -599,7 +595,6 @@ if _WX_AVAILABLE:
                             project,
                         )
                         self._active_project = project
-                        self._watch_candidate_seen = False
                         self._autoload_session()
                 except Exception:
                     log.debug("project re-sync on panel show failed", exc_info=True)
@@ -2442,7 +2437,6 @@ if _WX_AVAILABLE:
                 "project watch started: active=%r",
                 self._active_project,
             )
-            self._watch_candidate_seen = False
             self._project_watch_timer.Start(
                 1000
             )  # 1 s poll: project switch is noticed quickly once a board signal is available
@@ -2456,10 +2450,10 @@ if _WX_AVAILABLE:
             instead of lingering; the panel opened in the new project
             auto-restores the right session on first display.
 
-            The project signal flaps during project load (GetBoard() stays
-            empty until the board is up, and the window-title fallback is
-            equally transient), so a switch is only acted on after two
-            consecutive identical readings.
+            A switch is acted on as soon as the probe returns a different
+            non-None project.  None readings (mid-switch GetBoard() empty,
+            window-title fallback missing) are deliberately ignored so the
+            last valid project is never downgraded.
             """
             if not self.IsShown():
                 # Panel dismissed: stay silent — no session dialogs from a
@@ -2485,36 +2479,13 @@ if _WX_AVAILABLE:
                 )
                 return
             if project == self._active_project:
-                self._watch_candidate_seen = False
-                return
-            if not self._watch_candidate_seen:
-                log.debug(
-                    "project watch: first reading %r differs from active=%r; waiting for confirmation",
-                    project,
-                    self._active_project,
-                )
-                # First differing reading: remember it and wait for a second
-                # identical one before acting.
-                self._watch_candidate_seen = True
-                self._watch_candidate = project
-                return
-            if project != self._watch_candidate:
-                log.debug(
-                    "project watch: flopping %r -> %r, re-armed",
-                    self._watch_candidate,
-                    project,
-                )
-                # Still flapping between values (project loading in
-                # background): re-arm with the latest reading.
-                self._watch_candidate = project
                 return
             log.info(
-                "Project switch confirmed: %s -> %s; switching session",
+                "Project switch detected: %s -> %s; switching session",
                 self._active_project,
                 project,
             )
             self._active_project = project
-            self._watch_candidate_seen = False
             # Keep this panel open and re-run the startup restore flow for
             # the new project: matching current.json is restored in place,
             # otherwise the new project's sessions are offered.  Never

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -2401,26 +2401,17 @@ if _WX_AVAILABLE:
 
                 proj = collect_context().get("active_project")
                 if proj:
-                    log.debug("project via collect_context: %s", proj)
                     return proj
-                windows = wx.GetTopLevelWindows()
-                log.debug(
-                    "project via collect_context: None — trying %d top-level window title(s)",
-                    len(windows),
-                )
-                for w in windows:
+                for w in wx.GetTopLevelWindows():
                     title = w.GetTitle()
                     if not title:
-                        log.debug("window title empty (class=%s)", type(w).__name__)
                         continue
                     p = project_path_from_title(title)
                     if p:
                         log.debug("project from window title %r -> %s", title, p)
                         return p
-                    log.debug("window title %r did not yield a project", title)
             except Exception:
                 log.debug("_collect_active_project failed", exc_info=True)
-            log.debug("_collect_active_project returning None")
             return None
 
         def _start_project_watch(self) -> None:

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -586,7 +586,18 @@ if _WX_AVAILABLE:
             elif event.IsShown():
                 try:
                     project = self._collect_active_project()
-                    if project != self._active_project and not self._busy:
+                    log.debug(
+                        "panel show: probe=%r active=%r busy=%r",
+                        project,
+                        self._active_project,
+                        self._busy,
+                    )
+                    if project is not None and project != self._active_project and not self._busy:
+                        log.info(
+                            "panel show: project re-sync %r -> %r; re-running restore flow",
+                            self._active_project,
+                            project,
+                        )
                         self._active_project = project
                         self._watch_candidate_seen = False
                         self._autoload_session()
@@ -2269,6 +2280,13 @@ if _WX_AVAILABLE:
                 ts = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
                 filename = f"session_{ts}.json"
                 self._current_session_file = filename
+            log.info(
+                "save session: file=%s stamp=%r (conv_version=%d saved=%d)",
+                filename,
+                self._active_project,
+                self._conv_version,
+                self._saved_conv_version,
+            )
             payload = _sstore.make_payload(
                 self._conv_entries,
                 (
@@ -2388,17 +2406,26 @@ if _WX_AVAILABLE:
 
                 proj = collect_context().get("active_project")
                 if proj:
+                    log.debug("project via collect_context: %s", proj)
                     return proj
-                for w in wx.GetTopLevelWindows():
+                windows = wx.GetTopLevelWindows()
+                log.debug(
+                    "project via collect_context: None — trying %d top-level window title(s)",
+                    len(windows),
+                )
+                for w in windows:
                     title = w.GetTitle()
                     if not title:
+                        log.debug("window title empty (class=%s)", type(w).__name__)
                         continue
                     p = project_path_from_title(title)
                     if p:
                         log.debug("project from window title %r -> %s", title, p)
                         return p
+                    log.debug("window title %r did not yield a project", title)
             except Exception:
                 log.debug("_collect_active_project failed", exc_info=True)
+            log.debug("_collect_active_project returning None")
             return None
 
         def _start_project_watch(self) -> None:
@@ -2411,6 +2438,10 @@ if _WX_AVAILABLE:
             if not self._project_watch_timer:
                 return
             self._active_project = self._collect_active_project()
+            log.info(
+                "project watch started: active=%r",
+                self._active_project,
+            )
             self._watch_candidate_seen = False
             self._project_watch_timer.Start(
                 1000
@@ -2437,18 +2468,42 @@ if _WX_AVAILABLE:
                 # applied exactly once, when the user looks at the panel.
                 return
             if self._busy:
+                log.debug(
+                    "project watch: busy — skip project poll (active=%r)",
+                    self._active_project,
+                )
                 return
             project = self._collect_active_project()
+            if project is None:
+                # Probing failed (GetBoard empty / no window-title match) —
+                # e.g. mid-project-switch.  Never downgrade a known project
+                # to None: keep the last valid value so session saves keep
+                # their project stamp.
+                log.debug(
+                    "project watch: probe returned None — keeping active=%r",
+                    self._active_project,
+                )
+                return
             if project == self._active_project:
                 self._watch_candidate_seen = False
                 return
             if not self._watch_candidate_seen:
+                log.debug(
+                    "project watch: first reading %r differs from active=%r; waiting for confirmation",
+                    project,
+                    self._active_project,
+                )
                 # First differing reading: remember it and wait for a second
                 # identical one before acting.
                 self._watch_candidate_seen = True
                 self._watch_candidate = project
                 return
             if project != self._watch_candidate:
+                log.debug(
+                    "project watch: flopping %r -> %r, re-armed",
+                    self._watch_candidate,
+                    project,
+                )
                 # Still flapping between values (project loading in
                 # background): re-arm with the latest reading.
                 self._watch_candidate = project


### PR DESCRIPTION
## Problem
Sessions saved after switching KiCad projects get `"project_path": null`, breaking project-aware auto-restore.

## Root cause (verified with instrumentation)
The 1 s project watch used a two-tick confirmation protocol: a switch was only acted on after two consecutive identical readings. During a project switch `collect_context()` transiently returns `None` (empty `GetBoard()` + window-title fallback misses), and two consecutive `None` readings **overwrote the valid `_active_project` with `None`**:

```
12:21:51 first reading None differs from active='/home/user1/pcb/test-route/test-route.kicad_pro'; waiting for confirmation
12:21:52 Project switch confirmed: /home/user1/pcb/test-route/test-route.kicad_pro -> None; switching session
12:21:57 first reading '/home/user1/pcb/matrix-bit-card/matrix-bit-card.kicad_pro' differs from active=None; waiting for confirmation
12:21:58 Project switch confirmed: None -> /home/user1/pcb/matrix-bit-card/matrix-bit-card.kicad_pro; switching session
```

While an LLM turn is in flight the watch skips polling (`if self._busy: return`), so `_active_project` stayed `None` for the whole turn and the turn-end save stamped the session `project_path: None`.

The confirmation protocol existed to guard against project-signal *flapping*, but instrumented logs showed it never triggered (zero flopping readings) — it only ever acted on stable values, and its only real effect was the None downgrade.

## Change
- **Drop the two-tick confirmation protocol** (`_watch_candidate` / `_watch_candidate_seen`): switch directly on the first non-None differing reading.
- **Never downgrade to None**: `_on_project_watch_tick` and the panel-show re-sync keep the current `_active_project` when the probe returns `None`.
- Adds debug/info logging for the probe chain and watch state to make this diagnosable.

Closes #110