### PR TITLE
chore: release develop into main (plugin bugfixes #107, #111)

### DIFF
--- a/kicad_plugin/llm_client.py
+++ b/kicad_plugin/llm_client.py
@@ -350,7 +350,7 @@ def _subprocess_env() -> dict[str, str]:
 # Used when in-process SSL is unavailable so streaming still works with the
 # same per-read socket timeout as the in-process path.
 # Protocol (one JSON payload per line, whitespace-separated kind prefix):
-#   SSE-DATA  {"content": "..."}  text delta -> on_text_delta
+#   SSE-DATA  {"content": "..."}  text delta -> on_stream_event
 #   SSE-DONE  {"finish_reason": ..., "message": {...}}
 #   SSE-ERROR {"kind": "exception", "error": "..."} |
 #             {"status": <http_code>, "body": "..."} |
@@ -595,7 +595,7 @@ def _subprocess_sse_stream(
     payload: bytes,
     timeout: float,
     fmt: str,
-    on_text_delta: Callable[[str], None] | None,
+    on_stream_event: Callable[[dict], None] | None,
 ) -> dict[str, Any]:
     """Stream an HTTP SSE response through the plugin-venv Python subprocess.
 
@@ -643,6 +643,12 @@ def _subprocess_sse_stream(
         proc.kill()
         return {"error": f"HTTPS request failed: {e}"}
 
+    if on_stream_event is not None:
+        try:
+            on_stream_event({"type": "text_start"})
+        except Exception as e:  # noqa: BLE001 -- UI callback errors must not kill the turn
+            log.error("Subprocess stream event callback error: %s", e)
+
     done: dict[str, Any] | None = None
     error_result: dict[str, Any] | None = None
     for raw in proc.stdout:
@@ -653,11 +659,11 @@ def _subprocess_sse_stream(
                 content = json.loads(body).get("content") or ""
             except json.JSONDecodeError:
                 continue
-            if content and on_text_delta is not None:
+            if content and on_stream_event is not None:
                 try:
-                    on_text_delta(content)
+                    on_stream_event({"type": "text_chunk", "content": content})
                 except Exception as e:  # noqa: BLE001 -- UI callback errors must not kill the turn
-                    log.debug("Subprocess text delta callback error: %s", e)
+                    log.error("Subprocess text delta callback error: %s", e)
         elif kind == "SSE-DONE" and body:
             try:
                 done = json.loads(body)
@@ -702,6 +708,12 @@ def _subprocess_sse_stream(
         message["tool_calls"] = done_message["tool_calls"]
     if done_message.get("reasoning_content"):
         message["reasoning_content"] = done_message["reasoning_content"]
+    if on_stream_event is not None:
+        try:
+            on_stream_event({"type": "text_end"})
+        except Exception as e:  # noqa: BLE001 -- UI callback errors must not kill the turn
+            log.error("Subprocess stream event callback error: %s", e)
+
     return {"finish_reason": done.get("finish_reason", "stop"), "message": message}
 
 
@@ -1545,7 +1557,7 @@ class LLMClient:
         try:
             on_tool_call(tool_name, args, result)
         except Exception as e:
-            log.debug("UI callback error in _emit_tool_callback: %s", e)  # must not break the loop
+            log.error("UI callback error in _emit_tool_callback: %s", e)  # must not break the loop
 
     def _execute_tool_with_policy(
         self,
@@ -1648,7 +1660,7 @@ class LLMClient:
         user_message: str,
         context_block: str,
         on_tool_call: Callable[[str, dict, Any], None] | None = None,
-        on_text_delta: Callable[[str], None] | None = None,
+        on_stream_event: Callable[[dict], None] | None = None,
         images: list[dict[str, Any]] | None = None,
     ) -> str:
         """
@@ -1659,8 +1671,8 @@ class LLMClient:
             context_block: Rendered KiCad context from context_bridge.
             on_tool_call:  Optional callback(tool_name, arguments, result) fired
                            after each tool execution — use this to update the UI.
-            on_text_delta: Optional callback(chunk) fired for each text chunk
-                           when streaming is active.
+            on_stream_event: Optional callback(evt) fired for each streaming
+                           lifecycle event: text_start / text_chunk / text_end.
             images:        Optional list of dicts {"media_type": "image/png",
                            "data": "<base64>"} attached to this user message.
 
@@ -1687,7 +1699,7 @@ class LLMClient:
 
         try:
             for _ in range(20):  # max 20 iterations (guard against infinite loops)
-                response = self._call_llm(system, tools, on_text_delta=on_text_delta)
+                response = self._call_llm(system, tools, on_stream_event=on_stream_event)
 
                 if response.get("error"):
                     reply = f"[LLM error] {response['error']}"
@@ -1819,7 +1831,7 @@ class LLMClient:
             for t in tools_raw
         ]
 
-    def _call_llm(self, system: str, tools: list[dict], on_text_delta=None) -> dict[str, Any]:
+    def _call_llm(self, system: str, tools: list[dict], on_stream_event=None) -> dict[str, Any]:
         """Dispatch to the configured LLM provider."""
         provider = self._settings.llm_provider
         tool_names = [t.get("function", {}).get("name", "?") for t in tools]
@@ -1839,15 +1851,15 @@ class LLMClient:
         max_retries = 5
         for attempt in range(max_retries):
             if provider == "ollama":
-                if on_text_delta is not None:
-                    response = self._stream_ollama(system, tools, on_text_delta)
+                if on_stream_event is not None:
+                    response = self._stream_ollama(system, tools, on_stream_event)
                 else:
                     response = self._call_ollama(system, tools)
-            elif on_text_delta is not None:
+            elif on_stream_event is not None:
                 if provider == "anthropic":
-                    response = self._stream_anthropic(system, tools, on_text_delta)
+                    response = self._stream_anthropic(system, tools, on_stream_event)
                 else:
-                    response = self._stream_openai(system, tools, on_text_delta)
+                    response = self._stream_openai(system, tools, on_stream_event)
             elif provider == "anthropic":
                 response = self._call_anthropic(system, tools)
             else:
@@ -1948,14 +1960,14 @@ class LLMClient:
                     )
         return blocks
 
-    def _stream_openai(self, system: str, tools: list[dict], on_text_delta) -> dict[str, Any]:
+    def _stream_openai(self, system: str, tools: list[dict], on_stream_event) -> dict[str, Any]:
         """Call OpenAI-compatible API with streaming enabled.
 
         Uses in-process urllib for true SSE streaming when SSL is available;
         otherwise relays the SSE stream through the plugin-venv Python
         subprocess (_subprocess_sse_stream).  Both paths stream — there is no
         non-streaming fallback here; _call_openai is used only by callers
-        that do not provide on_text_delta (e.g. history compaction).
+        that do not provide on_stream_event (e.g. history compaction).
         """
         global _current_reasoning
         _current_reasoning = []
@@ -1988,6 +2000,8 @@ class LLMClient:
                 with _urlopen_with_plugin_ca_retry(req, timeout=300) as resp:
                     _in_process_ssl = True
                     text_parts = []
+                    if on_stream_event is not None:
+                        on_stream_event({"type": "text_start"})
                     tool_calls_by_index: dict[int, dict] = {}
                     finish_reason = "stop"
 
@@ -2019,9 +2033,9 @@ class LLMClient:
                         if content:
                             text_parts.append(content)
                             try:
-                                on_text_delta(content)
+                                on_stream_event({"type": "text_chunk", "content": content})
                             except Exception as e:
-                                log.debug("Text delta callback error in streaming: %s", e)
+                                log.error("Text delta callback error in streaming: %s", e)
 
                         reasoning = delta.get("reasoning_content")
                         if reasoning:
@@ -2050,6 +2064,8 @@ class LLMClient:
                         message["tool_calls"] = tool_calls
                     if _current_reasoning:
                         message["reasoning_content"] = "".join(_current_reasoning)
+                    if on_stream_event is not None:
+                        on_stream_event({"type": "text_end"})
                     return {"finish_reason": finish_reason, "message": message}
 
             except urllib.error.HTTPError as e:
@@ -2064,7 +2080,7 @@ class LLMClient:
 
         # In-process SSL unavailable: stream via the plugin-venv Python subprocess.
         return _subprocess_sse_stream(
-            url, headers, payload, timeout=300, fmt="openai", on_text_delta=on_text_delta
+            url, headers, payload, timeout=300, fmt="openai", on_stream_event=on_stream_event
         )
 
     def _ollama_messages(self) -> list[dict[str, Any]]:
@@ -2097,7 +2113,7 @@ class LLMClient:
             out.append(converted)
         return out
 
-    def _stream_ollama(self, system: str, tools: list[dict], on_text_delta) -> dict[str, Any]:
+    def _stream_ollama(self, system: str, tools: list[dict], on_stream_event) -> dict[str, Any]:
         """Call Ollama native API with streaming enabled.
 
         Uses the Ollama /api/chat endpoint with ``stream: true``.
@@ -2127,6 +2143,8 @@ class LLMClient:
         try:
             with urllib.request.urlopen(req, timeout=300) as resp:  # nosec B310 -- localhost only
                 text_parts = []
+                if on_stream_event is not None:
+                    on_stream_event({"type": "text_start"})
                 tool_calls_by_index: dict[int, dict] = {}
                 finish_reason = "stop"
 
@@ -2151,9 +2169,9 @@ class LLMClient:
                     if content:
                         text_parts.append(content)
                         try:
-                            on_text_delta(content)
+                            on_stream_event({"type": "text_chunk", "content": content})
                         except Exception as e:
-                            log.debug("Text delta callback error in Ollama streaming: %s", e)
+                            log.error("Text delta callback error in Ollama streaming: %s", e)
 
                     for tc_delta in msg.get("tool_calls") or []:
                         idx = tc_delta.get("index", 0)
@@ -2176,6 +2194,8 @@ class LLMClient:
                 message: dict[str, Any] = {"content": "".join(text_parts)}
                 if tool_calls:
                     message["tool_calls"] = tool_calls
+                if on_stream_event is not None:
+                    on_stream_event({"type": "text_end"})
                 return {"finish_reason": finish_reason, "message": message}
 
         except urllib.error.URLError as e:
@@ -2183,14 +2203,14 @@ class LLMClient:
         except Exception as e:
             return {"error": f"Ollama streaming request failed: {e}"}
 
-    def _stream_anthropic(self, system: str, tools: list[dict], on_text_delta) -> dict[str, Any]:
+    def _stream_anthropic(self, system: str, tools: list[dict], on_stream_event) -> dict[str, Any]:
         """Call Anthropic API with streaming enabled.
 
         Uses in-process urllib for true SSE streaming when SSL is available;
         otherwise relays the SSE stream through the plugin-venv Python
         subprocess (_subprocess_sse_stream, fmt="anthropic").  Both paths
         stream — there is no non-streaming fallback here; _call_anthropic is
-        used only by callers without on_text_delta (e.g. history compaction).
+        used only by callers without on_stream_event (e.g. history compaction).
         """
         global _in_process_ssl
         import urllib.error
@@ -2233,6 +2253,8 @@ class LLMClient:
             try:
                 with _urlopen_with_plugin_ca_retry(req, timeout=300) as resp:
                     _in_process_ssl = True
+                    if on_stream_event is not None:
+                        on_stream_event({"type": "text_start"})
                     text_blocks: dict[int, str] = {}
                     tool_blocks: dict[int, dict] = {}
                     stop_reason = "end_turn"
@@ -2278,9 +2300,9 @@ class LLMClient:
                                 text_blocks[idx] = text_blocks.get(idx, "") + chunk
                                 if chunk:
                                     try:
-                                        on_text_delta(chunk)
+                                        on_stream_event({"type": "text_chunk", "content": chunk})
                                     except Exception as e:
-                                        log.debug("Anthropic text delta callback error: %s", e)
+                                        log.error("Anthropic text delta callback error: %s", e)
                             elif dtype == "input_json_delta":
                                 partial = delta.get("partial_json", "")
                                 if idx in tool_blocks:
@@ -2322,6 +2344,8 @@ class LLMClient:
                     finish = "tool_calls" if tool_calls else "stop"
                     if stop_reason == "max_tokens":
                         finish = "stop"
+                    if on_stream_event is not None:
+                        on_stream_event({"type": "text_end"})
                     return {"finish_reason": finish, "message": message_out}
 
             except urllib.error.HTTPError as e:
@@ -2336,7 +2360,7 @@ class LLMClient:
 
         # In-process SSL unavailable: stream via the plugin-venv Python subprocess.
         return _subprocess_sse_stream(
-            url, headers, encoded, timeout=300, fmt="anthropic", on_text_delta=on_text_delta
+            url, headers, encoded, timeout=300, fmt="anthropic", on_stream_event=on_stream_event
         )
 
     def _anthropic_headers(self) -> dict[str, str]:

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -19,6 +19,8 @@ import os
 import threading
 from typing import Any
 
+from .stream_events import apply_stream_event, make_ai_entry
+
 log = logging.getLogger(__name__)
 
 try:
@@ -97,8 +99,18 @@ if _WX_AVAILABLE:
             self._busy = False
             # threading.Event for cancelling an in-progress LLM turn
             self._cancel_event: threading.Event | None = None
-            # Thread-safe buffer for streamed text chunks; drained by _stream_timer
-            self._stream_buffer: collections.deque = collections.deque()
+            # FIFO of stream-lifecycle events produced by the background LLM
+            # thread (text_start/text_chunk/text_end/tool_call/turn_end).
+            # The 50 ms _stream_timer is the ONLY consumer; it drains the
+            # queue in order and renders once per tick.
+            self._stream_events: collections.deque = collections.deque()
+            # Generation of the active turn.  Every event carries the
+            # generation it was emitted under; the consumer drops events of
+            # older turns (a cancelled turn's leftover text and turn_end).
+            self._event_gen: int = 0
+            # True once any text chunk of the active turn was consumed
+            # (replaces the old was_streamed / ai_turn_started tracking).
+            self._turn_had_text: bool = False
             # Set to True when at least one tool call happens during a turn
             self._tool_calls_made: bool = False
             # Set to True when any tool modifies a .kicad_sch file this turn
@@ -160,6 +172,12 @@ if _WX_AVAILABLE:
             self._watch_candidate: str | None = None
             self._watch_candidate_seen: bool = False
             self._project_watch_timer = wx.Timer(self)
+            # Version-based dirty tracking: _conv_version bumps on every
+            # conversation mutation; saves skip the write when the last
+            # successful save already covered the current version (a plain
+            # close must not rewrite — and re-stamp — the session file).
+            self._conv_version: int = 0
+            self._saved_conv_version: int = 0
 
             self._build_ui()
             self._start_server()
@@ -609,7 +627,7 @@ if _WX_AVAILABLE:
                 kipy_found = os.path.isdir(win_site)
             kipy_ok = kipy_found
             if not kipy_ok:
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "status",
                         "text": (
@@ -658,7 +676,7 @@ if _WX_AVAILABLE:
         def _on_ipc_socket_checked(self, socket_exists: bool, checked_path: str) -> None:
             """Callback invoked on the UI thread after the async IPC socket check."""
             if not socket_exists:
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "status",
                         "text": (
@@ -773,16 +791,10 @@ if _WX_AVAILABLE:
                 }
             )
             _user_entry = self._conv_entries[-1]
+            self._conv_version += 1
             self._attached_files.clear()
             self._refresh_attachments_bar()
             self._follow_output_to_bottom = True
-            # Persist on every user message: creates the file on the first
-            # message (so current.json exists before the AI responds) and makes
-            # the session durable immediately (also upgrading legacy v1 files
-            # to v2, since the user has now modified the session).
-            err = self._save_session_to_disk()
-            if err:
-                log.warning("Could not save session: %s", err)
             self._render_conversation(force_scroll_to_bottom=True)
             self._busy = True
             self._cancel_event = threading.Event()
@@ -793,27 +805,34 @@ if _WX_AVAILABLE:
             ctx = collect_context()
             context_block = context_to_system_prompt_block(ctx)
 
-            # Reset streaming state and start the flush timer
-            self._stream_buffer.clear()
+            # Reset streaming state and start the flush timer.  A new turn
+            # bumps the generation: events still in flight from a cancelled
+            # previous turn are then ignored by the consumer (see
+            # _on_stream_flush), while their tool cards still land.
+            self._stream_events.clear()
             self._pending_ai_text = ""
             self._stream_delta_chars = 0
             self._tool_calls_made = False
             self._schematic_edited = False
             self._pcb_edited = False
+            self._turn_had_text = False
+            self._event_gen += 1
             self._stream_timer.Start(50)  # flush every 50 ms → ~20 fps
 
-            state = {"ai_turn_started": False}
+            gen = self._event_gen
 
-            def _on_delta(chunk: str) -> None:
-                # Called from background thread — just push to buffer; timer handles UI
-                if self._cancel_event and self._cancel_event.is_set():
-                    if not state.get("cancel_dropped"):
-                        state["cancel_dropped"] = True
-                        log.debug("chat: dropping streamed chunks after cancel")
+            def _emit(evt: dict) -> None:
+                # Sole producer (background thread): every lifecycle event
+                # carries this turn's generation; FIFO order == occurrence
+                # order by construction.  Drop events if the panel has moved
+                # on (New Session / Clear bumped _event_gen) so a cancelled
+                # turn whose thread keeps streaming cannot grow the deque
+                # unbounded.
+                if gen != self._event_gen:
                     return
-                state["ai_turn_started"] = True
-                self._stream_delta_chars += len(chunk)
-                self._stream_buffer.append(chunk)
+                evt = dict(evt)
+                evt["_gen"] = gen
+                self._stream_events.append(evt)
 
             def _run():
                 log.info("Background _run: started")
@@ -851,21 +870,20 @@ if _WX_AVAILABLE:
                     reply = self._llm_client.run(
                         text_with_pdf,
                         context_block,
-                        on_tool_call=lambda name, args, result: wx.CallAfter(
-                            self._on_tool_call, name, args, result
+                        on_tool_call=lambda name, args, result: _emit(
+                            {"type": "tool_call", "name": name, "args": args, "result": result}
                         ),
-                        on_text_delta=_on_delta,
+                        on_stream_event=_emit,
                         images=images,
                     )
                 except Exception as e:
                     log.exception("LLM request failed")
                     reply = f"[Error] {e}"
-                log.info(
-                    "Background _run: finished (reply_len=%d, streamed=%s)",
-                    len(reply),
-                    state["ai_turn_started"],
-                )
-                wx.CallAfter(self._on_reply, reply, ctx, was_streamed=state["ai_turn_started"])
+                log.info("Background _run: finished (reply_len=%d)", len(reply))
+                # turn_end is the queue's final event: emitted after the
+                # reload_kicad / tool callbacks, so the consumer orders it
+                # strictly after the last text of the turn.
+                _emit({"type": "turn_end", "reply": reply, "ctx": ctx})
 
             threading.Thread(target=_run, daemon=True).start()
 
@@ -1377,57 +1395,110 @@ if _WX_AVAILABLE:
                 return f"[Error] {err}"
             return result.stdout or ""
 
-        def _on_reply(self, reply: str, ctx: dict, was_streamed: bool = False) -> None:
-            # Stop the flush timer and drain any remaining chunks
-            self._stream_timer.Stop()
-            self._on_stream_flush(None)
+        def _on_stream_flush(self, event) -> None:
+            """Consume the unified stream-event queue (main thread, 50 ms timer).
 
+            Sole consumer: drains ALL queued events in FIFO order (occurrence
+            order is guaranteed by the single background producer) and applies
+            each via the wx-free state machine in stream_events, then performs
+            one merged render per tick.  A ``text_end`` is therefore always
+            applied before the ``tool_call`` / ``turn_end`` events that follow
+            it — the race where an end-of-turn notification (``reload_kicad``)
+            finalised a draft that was still being filled through the old
+            50 ms text pipeline is structurally impossible.  Draft
+            finalisation is driven by the explicit ``text_end`` marker, never
+            by heuristics about pending text.
+
+            Output paths are unchanged: only the input pipeline moved into
+            the queue.  Non-stream events (status bar, project switch,
+            session load) still go through wx directly.
+            """
+
+            if not self._stream_events:
+                return
+            events = []
+            while self._stream_events:
+                try:
+                    events.append(self._stream_events.popleft())
+                except IndexError:
+                    break
+
+            draft_changed = False
+            entries_changed = False
+            turn_ended = False
+            turn_ctx: dict = {}
+            for evt in events:
+                etype = evt.get("type")
+                if evt.get("_gen", -1) != self._event_gen:
+                    # Stale turn (cancelled or replaced by a newer send or
+                    # session reset): drop its text and turn-end; its tool
+                    # cards still land (pre-refactor behaviour — the old
+                    # _on_tool_call always reached the UI).
+                    if etype != "tool_call":
+                        continue
+
+                st = apply_stream_event(
+                    pending=self._pending_ai_text,
+                    entries=self._conv_entries,
+                    tool_seq=self._tool_seq,
+                    tool_calls_made=self._tool_calls_made,
+                    turn_had_text=self._turn_had_text,
+                    delta_chars=self._stream_delta_chars,
+                    cancelled=self._cancel_event is not None and self._cancel_event.is_set(),
+                    evt=evt,
+                    timestamp=lambda: datetime.datetime.now().strftime("%H:%M:%S"),
+                )
+                self._pending_ai_text = st.pending
+                self._tool_seq = st.tool_seq
+                self._tool_calls_made = st.tool_calls_made
+                self._turn_had_text = st.turn_had_text
+                self._stream_delta_chars = st.delta_chars
+                draft_changed |= st.draft_changed
+                entries_changed |= st.entries_changed
+                if st.entries_changed:
+                    self._conv_version += 1
+                if etype == "turn_end":
+                    turn_ended = True
+                    turn_ctx = evt.get("ctx") or {}
+                if etype == "tool_call" and evt.get("name"):
+                    self._mark_tool_dirty(evt["name"])
+
+            # One merged render pass per tick: incremental stream update for
+            # the draft, then a full conversation render for new entries.
+            if draft_changed:
+                if self._use_webview:
+                    if self._shell_loaded and not self._stream_wrapper_visible:
+                        self._show_stream_wrapper()
+                    if not self._incremental_stream_update():
+                        # Deferred (lock busy / shell not loaded) or update
+                        # failed: _run_script already recorded _render_pending,
+                        # so a full rebuild will replay (and the next flush
+                        # re-shows stream text).
+                        log.warning(
+                            "chat: stream flush deferred render (pending=%d chars)",
+                            len(self._pending_ai_text),
+                        )
+                else:
+                    self._render_conversation(force_scroll_to_bottom=self._follow_output_to_bottom)
+            if entries_changed or turn_ended:
+                self._render_conversation(force_scroll_to_bottom=self._follow_output_to_bottom)
+
+            if turn_ended:
+                self._finish_turn(turn_ctx)
+
+        def _finish_turn(self, ctx: dict) -> None:
+            """Close out a finished turn: hide preview, reset state, save.
+
+            Takes over the tail of the old _on_reply — everything that is not
+            part of the pure event state machine in stream_events.
+            """
             log.info(
-                "chat: _on_reply was_streamed=%s reply_len=%d pending_len=%d "
-                "buffer_left=%d delta_chars=%d",
-                was_streamed,
-                len(reply),
+                "chat: turn finished pending_len=%d delta_chars=%d",
                 len(self._pending_ai_text),
-                len(self._stream_buffer),
                 getattr(self, "_stream_delta_chars", 0),
             )
-
-            # Hide streaming preview before appending the final entry
             if self._use_webview:
                 self._hide_stream_wrapper()
-
-            if not was_streamed:
-                entry = {
-                    "type": "ai",
-                    "text": reply,
-                    "timestamp": datetime.datetime.now().strftime("%H:%M:%S"),
-                }
-                self._conv_entries.append(entry)
-                if self._use_webview and self._shell_loaded:
-                    self._append_entry_js(entry, force_scroll_to_bottom=True)
-                else:
-                    self._render_conversation(force_scroll_to_bottom=True)
-            else:
-                # Finalise any remaining streamed text as a proper AI entry
-                if self._pending_ai_text:
-                    entry = {
-                        "type": "ai",
-                        "text": self._pending_ai_text,
-                        "timestamp": datetime.datetime.now().strftime("%H:%M:%S"),
-                    }
-                    log.info(
-                        "chat: finalising streamed entry text_len=%d tail=%r",
-                        len(entry["text"]),
-                        entry["text"][-80:],
-                    )
-                    self._conv_entries.append(entry)
-                    self._pending_ai_text = ""
-                    if self._use_webview and self._shell_loaded:
-                        self._append_entry_js(entry, force_scroll_to_bottom=True)
-                    else:
-                        self._render_conversation(force_scroll_to_bottom=True)
-            # Any deferral during the turn is flushed by the lock holder's
-            # release (_run_script), so no turn-end safety net is needed.
             self._busy = False
             self._cancel_event = None
             self._toggle_send_stop(busy=False)
@@ -1435,44 +1506,14 @@ if _WX_AVAILABLE:
             if self._tool_calls_made:
                 self._auto_refresh(ctx)
             self._follow_output_to_bottom = False
+            if not self._stream_events:
+                self._stream_timer.Stop()
             # Persist the completed turn so disk always holds the full
-            # conversation, including the streamed AI reply. On-exit autosave
-            # then only refreshes — no data depends on it.
+            # conversation.  Teardown persistence (Bug A) covers an
+            # in-flight close; this write covers the complete turn.
             err = self._save_session_to_disk()
             if err:
                 log.warning("Could not save session after reply: %s", err)
-
-        def _on_stream_flush(self, event) -> None:
-            """Drain the streaming buffer into the pending AI text (main thread, timer-driven)."""
-            if not self._stream_buffer:
-                return
-            parts = []
-            while self._stream_buffer:
-                try:
-                    parts.append(self._stream_buffer.popleft())
-                except IndexError:
-                    break
-            if not parts:
-                return
-            self._pending_ai_text += "".join(parts)
-
-            if self._use_webview:
-                # Show stream wrapper on first chunk
-                if self._shell_loaded and not self._stream_wrapper_visible:
-                    self._show_stream_wrapper()
-                # Incremental DOM update — should always succeed with shell loaded
-                if self._incremental_stream_update():
-                    return
-                # Deferred (lock busy / shell not loaded) or update failed:
-                # _run_script already recorded _render_pending, so a full
-                # rebuild will replay (and the next flush re-shows stream
-                # text).  Nothing to bookkeep here.
-                log.warning(
-                    "chat: stream flush deferred render (pending=%d chars)",
-                    len(self._pending_ai_text),
-                )
-            else:
-                self._render_conversation(force_scroll_to_bottom=self._follow_output_to_bottom)
 
         def _incremental_stream_update(self) -> bool:
             """Update streaming AI text via _updateStream JS call.
@@ -1521,7 +1562,7 @@ if _WX_AVAILABLE:
                     "WebView shell failed to load after %d retries — giving up",
                     self._shell_retry_count,
                 )
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "status",
                         "text": (
@@ -1536,7 +1577,7 @@ if _WX_AVAILABLE:
             log.warning(
                 "WebView watchdog: shell load timed out (>5s), retry %d/3", self._shell_retry_count
             )
-            self._conv_entries.append(
+            self._append_entry(
                 {
                     "type": "status",
                     "text": (
@@ -1548,40 +1589,8 @@ if _WX_AVAILABLE:
             )
             wx.CallAfter(self._load_shell)
 
-        def _on_tool_call(self, name: str, args: dict, result: Any) -> None:
-            log.info(
-                "_on_tool_call: %s (shell_loaded=%s, entries=%d)",
-                name,
-                self._shell_loaded,
-                len(self._conv_entries),
-            )
-            # If there is pending streamed text that preceded this tool call,
-            # finalise it as an AI entry now so the timeline order is correct.
-            if self._pending_ai_text:
-                log.debug(
-                    "chat: mid-turn finalise of streamed text len=%d",
-                    len(self._pending_ai_text),
-                )
-                self._conv_entries.append({"type": "ai", "text": self._pending_ai_text})
-                self._pending_ai_text = ""
-            # Append as a permanent timeline entry so tool calls appear in
-            # chronological order alongside user and AI messages.
-            # Store full data — truncation for UI display happens at render time
-            # to preserve session data integrity.
-            self._tool_seq += 1
-            self._conv_entries.append(
-                {
-                    "type": "tool_call",
-                    "name": name,
-                    "args": args,
-                    "result": result,
-                    "_seq": self._tool_seq,
-                }
-            )
-            # Full update needed to clear pending-ai-text and show new entries
-            self._render_conversation(force_scroll_to_bottom=self._follow_output_to_bottom)
-            self._tool_calls_made = True
-            # Use tool_registry to determine if tool modified PCB/schematic files
+        def _mark_tool_dirty(self, name: str) -> None:
+            """Track whether a tool call modified the PCB/schematic on disk."""
             try:
                 from ..tool_registry import get_tool_policy
 
@@ -1595,6 +1604,17 @@ if _WX_AVAILABLE:
             elif policy and policy.path_arg == "schematic_path" and policy.mark_dirty:
                 self._schematic_edited = True
 
+        def _append_entry(self, entry: dict) -> None:
+            """Append a conversation entry and mark the conversation dirty.
+
+            Every status / autoroute-log append goes through here so the
+            version-based save gate (``_save_session_to_disk``) cannot skip a
+            write that should persist them.  AI / user entries that already
+            bump ``_conv_version`` at their call site may append directly.
+            """
+            self._conv_entries.append(entry)
+            self._conv_version += 1
+
         def _auto_refresh(self, ctx: dict) -> None:
             """Refresh the KiCad view automatically after tool calls."""
             if self._pcb_edited:
@@ -1602,7 +1622,7 @@ if _WX_AVAILABLE:
                     import pcbnew
 
                     pcbnew.Refresh()
-                    self._conv_entries.append(
+                    self._append_entry(
                         {
                             "type": "status",
                             "text": "⟳ Board view refreshed.",
@@ -1613,7 +1633,7 @@ if _WX_AVAILABLE:
                 except ImportError:
                     pass  # outside KiCad — silently skip
                 except Exception as e:
-                    self._conv_entries.append(
+                    self._append_entry(
                         {
                             "type": "status",
                             "text": f"⚠ Auto-refresh failed: {e}",
@@ -1623,7 +1643,7 @@ if _WX_AVAILABLE:
                     self._render_conversation(force_scroll_to_bottom=self._follow_output_to_bottom)
                     return
             if self._schematic_edited:
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "status",
                         "text": "ℹ Schematic updated on disk — use File → Revert in the Schematic Editor to see the changes.",
@@ -1636,30 +1656,44 @@ if _WX_AVAILABLE:
             """Stop button: cancel the in-progress LLM turn."""
             if not self._busy or self._cancel_event is None:
                 return
-            log.info("_on_stop: cancelling LLM turn")
-            self._cancel_event.set()
-            # Drain stream buffer and finalise whatever text has arrived
-            self._stream_timer.Stop()
-            self._on_stream_flush(None)
+            # Drain any text chunks the producer already enqueued since the
+            # last timer tick before cancelling — otherwise the archived
+            # partial silently loses the tail received in the last tick
+            # window (the same truncation class Bug B fixes).  Only fold
+            # text_* of this turn; tool_call/turn_end are left for the timer.
+            gen = self._event_gen
+            for evt in list(self._stream_events):
+                if evt.get("_gen") != gen:
+                    continue
+                if evt.get("type") == "text_chunk":
+                    self._pending_ai_text += evt.get("content") or ""
+                    self._turn_had_text = True
+                    self._stream_delta_chars += len(evt.get("content") or "")
+            self._cancel_event.set()  # consumer drops subsequent text_* of this turn
             if self._use_webview:
                 self._hide_stream_wrapper()
+            # Finalise whatever text the consumer already moved into the draft.
+            # The queue keeps draining afterwards: later text events are
+            # dropped (cancel is set), tool cards still land, and the turn_end
+            # event clears the cancel flag when it arrives.
             if self._pending_ai_text:
-                entry = {
-                    "type": "ai",
-                    "text": self._pending_ai_text,
-                    "timestamp": datetime.datetime.now().strftime("%H:%M:%S"),
-                }
+                entry = make_ai_entry(
+                    self._pending_ai_text,
+                    datetime.datetime.now().strftime("%H:%M:%S"),
+                )
                 self._conv_entries.append(entry)
                 self._pending_ai_text = ""
+                self._conv_version += 1
                 if self._use_webview and self._shell_loaded:
                     self._append_entry_js(entry, force_scroll_to_bottom=True)
                 else:
                     self._render_conversation(force_scroll_to_bottom=True)
             self._busy = False
-            self._cancel_event = None
             self._toggle_send_stop(busy=False)
             # Persist what has been finalised so far — the turn was cancelled
-            # mid-flight and on-exit autosave is best-effort only.
+            # mid-flight and on-exit autosave is best-effort only.  Note the
+            # cancel event is intentionally left SET here; _finish_turn (via
+            # the turn_end event) resets it once the turn is truly drained.
             err = self._save_session_to_disk()
             if err:
                 log.warning("Could not save session after stop: %s", err)
@@ -1676,7 +1710,7 @@ if _WX_AVAILABLE:
             # Messages are blocked while the backend is down.
             self._server_ready = False
             self._sync_send_button_state()
-            self._conv_entries.append(
+            self._append_entry(
                 {
                     "type": "status",
                     "text": "↺ Restarting MCP backend…",
@@ -1693,7 +1727,7 @@ if _WX_AVAILABLE:
 
         def _on_restart_done(self, ok: bool) -> None:
             if ok:
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "status",
                         "text": "✅ Backend restarted successfully.",
@@ -1707,7 +1741,7 @@ if _WX_AVAILABLE:
                 self._init_llm_client()
                 self._on_server_started(True)
             else:
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "status",
                         "text": "❌ Backend failed to restart.",
@@ -1896,7 +1930,7 @@ if _WX_AVAILABLE:
                 board = None
 
             if board is None:
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "status",
                         "text": "⚠ No board is currently open. Open a .kicad_pcb file before running Auto Route.",
@@ -2007,7 +2041,7 @@ if _WX_AVAILABLE:
                 _pcbnew.ExportSpecctraDSN(board, dsn_path)
             except Exception as exc:
                 shutil.rmtree(tmp_dir, ignore_errors=True)
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "autoroute_log",
                         "success": False,
@@ -2021,7 +2055,7 @@ if _WX_AVAILABLE:
 
             if not os.path.isfile(dsn_path):
                 shutil.rmtree(tmp_dir, ignore_errors=True)
-                self._conv_entries.append(
+                self._append_entry(
                     {
                         "type": "autoroute_log",
                         "success": False,
@@ -2038,7 +2072,7 @@ if _WX_AVAILABLE:
             self._set_status("⏳ Auto-routing in progress…", self._C_WARN)
             self.Layout()
 
-            self._conv_entries.append(
+            self._append_entry(
                 {
                     "type": "status",
                     "text": "⏳ Auto Route started — running FreeRouting in background…",
@@ -2138,7 +2172,7 @@ if _WX_AVAILABLE:
                 )
 
             # ---- Append collapsible log entry ----
-            self._conv_entries.append(
+            self._append_entry(
                 {
                     "type": "autoroute_log",
                     "success": success,
@@ -2181,8 +2215,12 @@ if _WX_AVAILABLE:
 
             # Clear conversation and LLM history for the new session.
             self._stream_timer.Stop()
-            self._stream_buffer.clear()
+            self._stream_events.clear()
+            self._event_gen += 1
+            self._turn_had_text = False
+            self._stream_delta_chars = 0
             self._conv_entries.clear()
+            self._conv_version += 1
             self._pending_ai_text = ""
             self._current_session_file = None
             self._render_conversation()
@@ -2205,7 +2243,10 @@ if _WX_AVAILABLE:
 
             Sessions are stamped with the currently open KiCad project
             (schema v2), so a session never silently leaks into a different
-            project.  The stamp reflects the project active at save time.
+            project.  The stamp is the project watch's last-confirmed project
+            (``_active_project``), not a live probe: at teardown KiCad is
+            already exiting and ``pcbnew``/window-title probes return None,
+            which would clobber the session's project ownership (issue #108).
 
             If ``_current_session_file`` is already set the existing file is
             overwritten; otherwise a new timestamped file is created and
@@ -2214,6 +2255,13 @@ if _WX_AVAILABLE:
             Returns an error string on failure, None on success.
             """
             from .. import session_store as _sstore
+
+            # No conversation changes since the last successful save — skip
+            # the write entirely (and do not touch current.json).  A teardown
+            # save on a plain close is then a no-op instead of rewriting the
+            # file with a fresh timestamp / project stamp.
+            if self._conv_version == self._saved_conv_version:
+                return None
 
             if self._current_session_file:
                 filename = self._current_session_file
@@ -2228,12 +2276,13 @@ if _WX_AVAILABLE:
                     if self._llm_client
                     else []
                 ),
-                self._collect_active_project(),
+                self._active_project,
             )
             err = _sstore.save_session(self._settings.config_dir, filename, payload)
             if err:
                 return err
             _sstore.update_current_link(self._settings.config_dir, filename)
+            self._saved_conv_version = self._conv_version
             return None
 
         def _on_load_session(self, event) -> None:
@@ -2297,11 +2346,23 @@ if _WX_AVAILABLE:
                 wx.MessageBox(f"Could not load session:\n{err}", "Error", wx.OK | wx.ICON_ERROR)
                 return False
 
-            # Restore state
+            # Restore state.  Bump the generation so events still in flight
+            # from a previous turn are dropped by the consumer; if a turn was
+            # unexpectedly busy, leave it cancelled and clear the UI state.
             self._stream_timer.Stop()
-            self._stream_buffer.clear()
+            self._stream_events.clear()
+            self._event_gen += 1
+            self._turn_had_text = False
+            self._stream_delta_chars = 0
             self._pending_ai_text = ""
             self._conv_entries = data.get("conv_entries", [])
+            # Loaded content already matches this file on disk: mark it as
+            # saved so a plain close (no user edits) does not rewrite it.
+            self._saved_conv_version = self._conv_version
+            if self._busy:
+                self._busy = False
+                self._cancel_event = None
+                self._toggle_send_stop(busy=False)
             if self._llm_client:
                 self._llm_client.set_history(data.get("llm_history", []))
             # Track which file is now active; point current.json at it.
@@ -2462,12 +2523,50 @@ if _WX_AVAILABLE:
                 )
                 return
             self._stream_timer.Stop()
-            self._stream_buffer.clear()
+            self._stream_events.clear()
+            self._event_gen += 1
+            self._turn_had_text = False
+            self._stream_delta_chars = 0
             self._conv_entries.clear()
+            self._conv_version += 1
             self._pending_ai_text = ""
             self._render_conversation()
             if self._llm_client:
                 self._llm_client.reset()
+
+        def _finalise_and_save_on_teardown(self) -> None:
+            """Persist the draft + conversation before the panel goes away.
+
+            Bug A: the old code only saved at send / turn-end / stop, so an
+            in-flight turn's answer was lost when KiCad closed mid-turn.
+            Everything the stream consumer already moved into the draft or
+            the archive is finalised and written to disk here.
+            """
+            # Drain any text chunks the producer already enqueued since the
+            # last timer tick — the timer cannot fire between here and
+            # Destroy(), so without this fold the saved answer would lose the
+            # tail received in the last tick window (Bug A's guarantee).
+            gen = self._event_gen
+            for evt in list(self._stream_events):
+                if evt.get("_gen") != gen:
+                    continue
+                if evt.get("type") == "text_chunk":
+                    self._pending_ai_text += evt.get("content") or ""
+                    self._turn_had_text = True
+                    self._stream_delta_chars += len(evt.get("content") or "")
+            if self._pending_ai_text:
+                self._conv_entries.append(
+                    make_ai_entry(
+                        self._pending_ai_text,
+                        datetime.datetime.now().strftime("%H:%M:%S"),
+                    )
+                )
+                self._pending_ai_text = ""
+                self._conv_version += 1
+            if any(e["type"] in ("user", "ai") for e in self._conv_entries):
+                err = self._save_session_to_disk()
+                if err:
+                    log.warning("Could not save session on teardown: %s", err)
 
         def _on_close(self, event) -> None:
             """Panel close: user X hides; watchdog force-close tears down.
@@ -2489,6 +2588,7 @@ if _WX_AVAILABLE:
                 # An in-flight turn ends with the panel: ask it to stop
                 # writing before we tear down.
                 self._cancel_event.set()
+            self._finalise_and_save_on_teardown()
             self._server_mgr.stop()
             self.Destroy()
 
@@ -2514,6 +2614,7 @@ if _WX_AVAILABLE:
             if event.GetEventObject() is self:
                 if self._project_watch_timer is not None:
                     self._project_watch_timer.Stop()
+                self._finalise_and_save_on_teardown()
                 self._server_mgr.stop()
             event.Skip()
 
@@ -2563,6 +2664,7 @@ if _WX_AVAILABLE:
                 return
 
             self._conv_entries = conv
+            self._saved_conv_version = self._conv_version
             self._current_session_file = os.path.basename(path)
             if self._llm_client:
                 self._llm_client.set_history(history)
@@ -2729,7 +2831,7 @@ if _WX_AVAILABLE:
             self._js_running = False
             self._stream_wrapper_visible = False
             self._page_watchdog.Stop()
-            self._conv_entries.append(
+            self._append_entry(
                 {
                     "type": "status",
                     "text": f"⚠ WebView error: {description}. Retrying…",

--- a/kicad_plugin/ui/panel.py
+++ b/kicad_plugin/ui/panel.py
@@ -167,10 +167,6 @@ if _WX_AVAILABLE:
             # switching projects can re-offer that project's saved sessions
             # (same flow as startup auto-restore). Started by _init_llm_client.
             self._active_project: str | None = None
-            # Project-switch confirmation: first differing reading is held
-            # here and only acted on when the next tick agrees.
-            self._watch_candidate: str | None = None
-            self._watch_candidate_seen: bool = False
             self._project_watch_timer = wx.Timer(self)
             # Version-based dirty tracking: _conv_version bumps on every
             # conversation mutation; saves skip the write when the last
@@ -586,9 +582,19 @@ if _WX_AVAILABLE:
             elif event.IsShown():
                 try:
                     project = self._collect_active_project()
-                    if project != self._active_project and not self._busy:
+                    log.debug(
+                        "panel show: probe=%r active=%r busy=%r",
+                        project,
+                        self._active_project,
+                        self._busy,
+                    )
+                    if project is not None and project != self._active_project and not self._busy:
+                        log.info(
+                            "panel show: project re-sync %r -> %r; re-running restore flow",
+                            self._active_project,
+                            project,
+                        )
                         self._active_project = project
-                        self._watch_candidate_seen = False
                         self._autoload_session()
                 except Exception:
                     log.debug("project re-sync on panel show failed", exc_info=True)
@@ -2269,6 +2275,13 @@ if _WX_AVAILABLE:
                 ts = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
                 filename = f"session_{ts}.json"
                 self._current_session_file = filename
+            log.info(
+                "save session: file=%s stamp=%r (conv_version=%d saved=%d)",
+                filename,
+                self._active_project,
+                self._conv_version,
+                self._saved_conv_version,
+            )
             payload = _sstore.make_payload(
                 self._conv_entries,
                 (
@@ -2411,7 +2424,10 @@ if _WX_AVAILABLE:
             if not self._project_watch_timer:
                 return
             self._active_project = self._collect_active_project()
-            self._watch_candidate_seen = False
+            log.info(
+                "project watch started: active=%r",
+                self._active_project,
+            )
             self._project_watch_timer.Start(
                 1000
             )  # 1 s poll: project switch is noticed quickly once a board signal is available
@@ -2425,10 +2441,10 @@ if _WX_AVAILABLE:
             instead of lingering; the panel opened in the new project
             auto-restores the right session on first display.
 
-            The project signal flaps during project load (GetBoard() stays
-            empty until the board is up, and the window-title fallback is
-            equally transient), so a switch is only acted on after two
-            consecutive identical readings.
+            A switch is acted on as soon as the probe returns a different
+            non-None project.  None readings (mid-switch GetBoard() empty,
+            window-title fallback missing) are deliberately ignored so the
+            last valid project is never downgraded.
             """
             if not self.IsShown():
                 # Panel dismissed: stay silent — no session dialogs from a
@@ -2437,29 +2453,30 @@ if _WX_AVAILABLE:
                 # applied exactly once, when the user looks at the panel.
                 return
             if self._busy:
+                log.debug(
+                    "project watch: busy — skip project poll (active=%r)",
+                    self._active_project,
+                )
                 return
             project = self._collect_active_project()
+            if project is None:
+                # Probing failed (GetBoard empty / no window-title match) —
+                # e.g. mid-project-switch.  Never downgrade a known project
+                # to None: keep the last valid value so session saves keep
+                # their project stamp.
+                log.debug(
+                    "project watch: probe returned None — keeping active=%r",
+                    self._active_project,
+                )
+                return
             if project == self._active_project:
-                self._watch_candidate_seen = False
-                return
-            if not self._watch_candidate_seen:
-                # First differing reading: remember it and wait for a second
-                # identical one before acting.
-                self._watch_candidate_seen = True
-                self._watch_candidate = project
-                return
-            if project != self._watch_candidate:
-                # Still flapping between values (project loading in
-                # background): re-arm with the latest reading.
-                self._watch_candidate = project
                 return
             log.info(
-                "Project switch confirmed: %s -> %s; switching session",
+                "Project switch detected: %s -> %s; switching session",
                 self._active_project,
                 project,
             )
             self._active_project = project
-            self._watch_candidate_seen = False
             # Keep this panel open and re-run the startup restore flow for
             # the new project: matching current.json is restored in place,
             # otherwise the new project's sessions are offered.  Never

--- a/kicad_plugin/ui/stream_events.py
+++ b/kicad_plugin/ui/stream_events.py
@@ -1,0 +1,139 @@
+"""Unified stream-lifecycle event queue core (wx-free).
+
+The background LLM thread is the *sole producer* of turn-internal events
+(text_start / text_chunk / text_end / tool_call / turn_end) and enqueues
+them in occurrence order into a FIFO deque owned by the panel; the panel's
+50 ms timer is the *sole consumer*, which drains the deque and applies each
+event through :func:`apply_stream_event`, then renders once.
+
+Because the FIFO order is the only source of truth, a ``text_end`` is always
+applied before the ``tool_call`` / ``turn_end`` events that follow it.  The
+race where an end-of-turn notification (``reload_kicad``) finalised a draft
+that was still being filled by the 50 ms text pipeline is therefore
+structurally impossible, and draft finalisation is driven by the explicit
+``text_end`` marker instead of by heuristics about pending text.
+
+This module intentionally imports nothing from wx / webview / IO so the
+state machine can be unit-tested without a display.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+# Event payloads, produced in this order by the background thread:
+#   {"type": "text_start"}                              ordering marker (no-op)
+#   {"type": "text_chunk", "content": str}              streamed content
+#   {"type": "text_end"}                                response text complete -> finalise draft
+#   {"type": "tool_call", "name": str, "args": dict, "result": Any, "_seq": int}
+#   {"type": "turn_end", "reply": str}                  turn complete (takes over _on_reply)
+#
+# The panel tags every event with the generation of the turn it belongs to
+# (``_gen``) and drops events of older turns before calling apply_stream_event.
+
+AI_ENTRY_TYPES = ("user", "ai")
+
+
+def make_ai_entry(text: str, timestamp: str) -> dict[str, Any]:
+    """Build a permanent AI conversation entry (rendering format unchanged)."""
+    return {"type": "ai", "text": text, "timestamp": timestamp}
+
+
+@dataclass
+class TurnState:
+    """Scalar turn state after applying one event."""
+
+    pending: str = ""
+    tool_seq: int = 0
+    tool_calls_made: bool = False
+    turn_had_text: bool = False
+    delta_chars: int = 0
+    # Mutation flags for the caller's single merged render pass.
+    draft_changed: bool = False
+    entries_changed: bool = False
+
+
+def apply_stream_event(
+    *,
+    pending: str,
+    entries: list,
+    tool_seq: int,
+    tool_calls_made: bool,
+    turn_had_text: bool,
+    delta_chars: int,
+    cancelled: bool,
+    evt: dict[str, Any],
+    timestamp: Callable[[], str],
+) -> TurnState:
+    """Apply one lifecycle event to the turn state (pure; ``entries`` mutated).
+
+    Cancellation: text events are dropped once ``cancelled`` is set (the
+    draft keeps whatever was already consumed, the turn-end finalises it);
+    ``tool_call`` cards are still inserted so the user sees what the agent
+    was doing; ``turn_end`` still closes the turn out.
+
+    Returns the full updated scalar state plus mutation flags.
+    """
+    base = TurnState(
+        pending=pending,
+        tool_seq=tool_seq,
+        tool_calls_made=tool_calls_made,
+        turn_had_text=turn_had_text,
+        delta_chars=delta_chars,
+    )
+
+    etype = evt.get("type")
+    if etype == "text_start":
+        return base  # ordering marker only
+
+    if etype == "text_chunk":
+        if cancelled:
+            return base
+        content = evt.get("content") or ""
+        base.pending = pending + content
+        base.turn_had_text = True
+        base.delta_chars = delta_chars + len(content)
+        base.draft_changed = True
+        return base
+
+    if etype == "text_end":
+        if cancelled or not pending:
+            return base
+        entries.append(make_ai_entry(pending, timestamp()))
+        base.pending = ""
+        base.entries_changed = True
+        return base
+
+    if etype == "tool_call":
+        base.tool_seq = tool_seq + 1
+        entries.append(
+            {
+                "type": "tool_call",
+                "name": evt.get("name", "?"),
+                "args": evt.get("args"),
+                "result": evt.get("result"),
+                "_seq": base.tool_seq,
+            }
+        )
+        base.tool_calls_made = True
+        base.entries_changed = True
+        return base
+
+    if etype == "turn_end":
+        if pending:  # defensive: text_end normally finalises the draft first
+            entries.append(make_ai_entry(pending, timestamp()))
+            base.pending = ""
+            base.entries_changed = True
+        reply = evt.get("reply") or ""
+        if not turn_had_text and reply:
+            # Non-streamed turn (LLM/framework error, iteration cap, or a
+            # cancelled turn whose text never reached the draft): the reply
+            # is the only answer text this turn produced.  Mirrors the old
+            # ``was_streamed=False`` branch of _on_reply.
+            entries.append(make_ai_entry(reply, timestamp()))
+            base.entries_changed = True
+        return base
+
+    return base  # unknown event type — ignore

--- a/tests/unit/plugin/test_llm_client.py
+++ b/tests/unit/plugin/test_llm_client.py
@@ -18,6 +18,16 @@ from kicad_plugin.llm_client import LLMClient, _subprocess_sse_stream
 from kicad_plugin.tool_registry import TOOL_POLICIES
 
 
+def _on_event_collect(chunks):
+    """Build an on_stream_event callback that records text chunks in order."""
+
+    def _on_stream_event(evt):
+        if evt.get("type") == "text_chunk":
+            chunks.append(evt["content"])
+
+    return _on_stream_event
+
+
 class _SSETestServer(ThreadingHTTPServer):
     """Threaded localhost server that answers POST with an SSE body."""
 
@@ -1125,7 +1135,7 @@ class TestStreaming:
         ]
         mock_resp = self._make_sse_response(sse_lines)
         with patch("urllib.request.urlopen", return_value=mock_resp) as m:
-            client._stream_anthropic("sys", [], on_text_delta=lambda c: None)
+            client._stream_anthropic("sys", [], on_stream_event=lambda evt: None)
 
         payload = json.loads(m.call_args[0][0].data)
         assert payload["max_tokens"] == llm_client._ANTHROPIC_DEFAULT_MAX_TOKENS
@@ -1141,11 +1151,34 @@ class TestStreaming:
         chunks = []
         mock_resp = self._make_sse_response(sse_lines)
         with patch("urllib.request.urlopen", return_value=mock_resp):
-            result = client._stream_openai("sys", [], on_text_delta=chunks.append)
+            result = client._stream_openai("sys", [], on_stream_event=_on_event_collect(chunks))
 
         assert chunks == ["Hello", " world"]
         assert result["message"]["content"] == "Hello world"
         assert result["finish_reason"] == "stop"
+
+    def test_stream_openai_emits_text_boundary_events(self):
+        """text_start precedes the chunks and text_end follows the last one —
+        the ordering guarantee the panel consumer relies on (Bug B)."""
+        client = _make_client()
+        sse_lines = [
+            'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+            'data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}',
+            "data: [DONE]",
+        ]
+        events = []
+        mock_resp = self._make_sse_response(sse_lines)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = client._stream_openai("sys", [], on_stream_event=events.append)
+
+        assert result["message"]["content"] == "Hello world"
+        assert [e["type"] for e in events] == [
+            "text_start",
+            "text_chunk",
+            "text_chunk",
+            "text_end",
+        ]
+        assert events[-1]["type"] == "text_end"
 
     def test_stream_openai_skips_empty_choices_chunk(self):
         """Mid-stream empty choices chunks (usage/keepalive) must not abort
@@ -1161,7 +1194,7 @@ class TestStreaming:
         chunks = []
         mock_resp = self._make_sse_response(sse_lines)
         with patch("urllib.request.urlopen", return_value=mock_resp):
-            result = client._stream_openai("sys", [], on_text_delta=chunks.append)
+            result = client._stream_openai("sys", [], on_stream_event=_on_event_collect(chunks))
 
         assert chunks == ["Checking"]
         tc = result["message"]["tool_calls"]
@@ -1193,7 +1226,7 @@ class TestStreaming:
             patch.object(llm_client, "_in_process_ssl", None),
             patch("urllib.request.urlopen", side_effect=err),
         ):
-            result = client._stream_openai("sys", [], on_text_delta=lambda c: None)
+            result = client._stream_openai("sys", [], on_stream_event=lambda evt: None)
 
         assert result["error"] == (
             'HTTP 400: {"code":"InvalidParameter","message":"Request body format invalid"}'
@@ -1211,7 +1244,7 @@ class TestStreaming:
         chunks = []
         mock_resp = self._make_sse_response(sse_lines)
         with patch("urllib.request.urlopen", return_value=mock_resp):
-            result = client._stream_openai("sys", [], on_text_delta=chunks.append)
+            result = client._stream_openai("sys", [], on_stream_event=_on_event_collect(chunks))
 
         assert chunks == []
         tc = result["message"]["tool_calls"]
@@ -1235,7 +1268,7 @@ class TestStreaming:
             patch.object(llm_client, "_in_process_ssl", None),
             patch("urllib.request.urlopen", side_effect=err),
         ):
-            result = client._stream_anthropic("sys", [], on_text_delta=lambda c: None)
+            result = client._stream_anthropic("sys", [], on_stream_event=lambda evt: None)
 
         assert result["error"] == (
             'HTTP 400: {"code":"InvalidParameter","message":"Request body format invalid"}'
@@ -1264,7 +1297,7 @@ class TestStreaming:
         chunks = []
         mock_resp = self._make_sse_response(sse_lines)
         with patch("urllib.request.urlopen", return_value=mock_resp):
-            result = client._stream_anthropic("sys", [], on_text_delta=chunks.append)
+            result = client._stream_anthropic("sys", [], on_stream_event=_on_event_collect(chunks))
 
         assert chunks == ["Hello", " AI"]
         assert result["message"]["content"] == "Hello AI"
@@ -1289,7 +1322,7 @@ class TestStreaming:
         chunks = []
         mock_resp = self._make_sse_response(sse_lines)
         with patch("urllib.request.urlopen", return_value=mock_resp):
-            result = client._stream_anthropic("sys", [], on_text_delta=chunks.append)
+            result = client._stream_anthropic("sys", [], on_stream_event=_on_event_collect(chunks))
 
         assert chunks == []
         tc = result["message"]["tool_calls"]
@@ -1328,7 +1361,7 @@ class TestStreaming:
                 return_value=subprocess_result,
             ) as mock_stream,
         ):
-            result = client._stream_openai("sys", [], on_text_delta=chunks.append)
+            result = client._stream_openai("sys", [], on_stream_event=_on_event_collect(chunks))
 
         mock_stream.assert_called_once()
         call_kwargs = mock_stream.call_args.kwargs
@@ -1365,7 +1398,7 @@ class TestStreaming:
                 return_value=subprocess_result,
             ) as mock_stream,
         ):
-            result = client._stream_anthropic("sys", [], on_text_delta=chunks.append)
+            result = client._stream_anthropic("sys", [], on_stream_event=_on_event_collect(chunks))
 
         mock_stream.assert_called_once()
         call_kwargs = mock_stream.call_args.kwargs
@@ -1373,22 +1406,48 @@ class TestStreaming:
         assert call_kwargs["timeout"] == 300
         assert result["message"]["tool_calls"] == [{"id": "tu1"}]
 
-    def test_run_passes_on_text_delta_to_call_llm(self):
+    def test_stream_anthropic_emits_text_boundary_events(self):
+        client = _make_client()
+        client._settings.llm_provider = "anthropic"
+        sse_lines = [
+            "event: content_block_start",
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" AI"}}',
+            "event: message_delta",
+            'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+        ]
+        events = []
+        mock_resp = self._make_sse_response(sse_lines)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = client._stream_anthropic("sys", [], on_stream_event=events.append)
+
+        assert result["message"]["content"] == "Hello AI"
+        assert [e["type"] for e in events] == [
+            "text_start",
+            "text_chunk",
+            "text_chunk",
+            "text_end",
+        ]
+
+    def test_run_passes_on_stream_event_to_call_llm(self):
         client = _make_client()
         final_response = {
             "finish_reason": "stop",
             "message": {"content": "done", "tool_calls": []},
         }
-        on_delta = MagicMock()
+        on_event = MagicMock()
         client._call_llm = MagicMock(return_value=final_response)
         client._fetch_tool_definitions = MagicMock(return_value=[])
 
-        result = client.run("hello", context_block="", on_text_delta=on_delta)
+        result = client.run("hello", context_block="", on_stream_event=on_event)
 
         assert result == "done"
-        # _call_llm must have been called with on_text_delta=on_delta
+        # _call_llm must have been called with on_stream_event=on_event
         call_kwargs = client._call_llm.call_args
-        assert call_kwargs.kwargs.get("on_text_delta") is on_delta
+        assert call_kwargs.kwargs.get("on_stream_event") is on_event
 
 
 class TestSubprocessSSEStream:
@@ -1417,7 +1476,7 @@ class TestSubprocessSSEStream:
                     payload=b'{"model":"t","stream":true}',
                     timeout=30,
                     fmt=fmt,
-                    on_text_delta=chunks.append,
+                    on_stream_event=_on_event_collect(chunks),
                 )
         finally:
             server.shutdown()
@@ -1505,8 +1564,10 @@ class TestSubprocessSSEStream:
         server = _SSETestServer(lines)
         seen = []
 
-        def boom(chunk):
-            seen.append(chunk)
+        def boom(evt):
+            content = evt.get("content")
+            if content:
+                seen.append(content)
             raise ValueError("ui hiccup")
 
         try:
@@ -1526,7 +1587,7 @@ class TestSubprocessSSEStream:
                     payload=b"{}",
                     timeout=30,
                     fmt="openai",
-                    on_text_delta=boom,
+                    on_stream_event=boom,
                 )
         finally:
             server.shutdown()

--- a/tests/unit/plugin/test_stream_events.py
+++ b/tests/unit/plugin/test_stream_events.py
@@ -1,0 +1,188 @@
+"""Unit tests for the wx-free stream-lifecycle event state machine."""
+
+from kicad_plugin.ui.stream_events import apply_stream_event, make_ai_entry
+
+
+def _ts() -> str:
+    return "00:00:00"
+
+
+def _state(**overrides):
+    state = {
+        "pending": "",
+        "entries": [],
+        "tool_seq": 0,
+        "tool_calls_made": False,
+        "turn_had_text": False,
+        "delta_chars": 0,
+        "cancelled": False,
+    }
+    state.update(overrides)
+    return state
+
+
+def _apply(state, evt):
+    """Apply one event against the current scalar state (mimics the panel consumer)."""
+    st = apply_stream_event(
+        pending=state["pending"],
+        entries=state["entries"],
+        tool_seq=state["tool_seq"],
+        tool_calls_made=state["tool_calls_made"],
+        turn_had_text=state["turn_had_text"],
+        delta_chars=state["delta_chars"],
+        cancelled=state["cancelled"],
+        evt=evt,
+        timestamp=_ts,
+    )
+    state.update(
+        pending=st.pending,
+        tool_seq=st.tool_seq,
+        tool_calls_made=st.tool_calls_made,
+        turn_had_text=st.turn_had_text,
+        delta_chars=st.delta_chars,
+    )
+    return st
+
+
+def test_text_chunks_accumulate_into_draft():
+    s = _state()
+    st = _apply(s, {"type": "text_start"})
+    assert st.draft_changed is False  # ordering marker only
+
+    st = _apply(s, {"type": "text_chunk", "content": "Hello"})
+    assert s["pending"] == "Hello"
+    assert st.draft_changed is True
+    assert st.entries_changed is False
+    assert s["turn_had_text"] is True
+    assert s["delta_chars"] == 5
+
+    _apply(s, {"type": "text_chunk", "content": " world"})
+    assert s["pending"] == "Hello world"
+    assert s["entries"] == []
+
+
+def test_text_end_finalises_draft_as_ai_entry():
+    s = _state()
+    _apply(s, {"type": "text_chunk", "content": "full answer"})
+    st = _apply(s, {"type": "text_end"})
+
+    assert st.entries_changed is True
+    assert s["pending"] == ""
+    assert s["entries"] == [{"type": "ai", "text": "full answer", "timestamp": "00:00:00"}]
+
+
+def test_text_end_with_empty_draft_is_noop():
+    s = _state()
+    st = _apply(s, {"type": "text_end"})
+    assert st.entries_changed is False
+    assert s["entries"] == []
+
+
+def test_bug_b_reload_card_no_longer_truncates_final_answer():
+    """End-of-turn ``reload_kicad`` is enqueued strictly after ``text_end``, so
+    the FULL answer is archived before the card.
+
+    Regression test for the real incident: answers of 1105/1611/1009/844 chars
+    ended up as final entries of only 14/1/6/0 chars because the reload
+    notification finalised a draft whose last ~50 ms were still in transit.
+    With the FIFO queue that tail cannot exist here: text_end is applied
+    before the card, so the final AI entry must equal the full reply.
+    """
+    answer = "x" * 1105  # same size as the documented Bug B turn
+    s = _state()
+    for i in range(0, len(answer), 10):  # chunk the stream like an SSE pump
+        _apply(s, {"type": "text_chunk", "content": answer[i : i + 10]})
+    _apply(s, {"type": "text_end"})
+    _apply(
+        s,
+        {
+            "type": "tool_call",
+            "name": "reload_kicad",
+            "args": {"paths": ["/tmp/board.kicad_pcb"]},
+            "result": {"success": True},
+        },
+    )
+    _apply(s, {"type": "turn_end", "reply": answer})
+
+    assert [e["type"] for e in s["entries"]] == ["ai", "tool_call"]
+    text_entry = s["entries"][0]
+    assert text_entry["text"] == answer  # complete — not a 14-char tail
+    assert len(text_entry["text"]) == 1105
+    # Nothing is archived after the reload card (no second/late AI entry).
+    assert [e for e in s["entries"] if e["type"] == "ai"] == [text_entry]
+    assert s["pending"] == ""  # draft fully consumed
+
+
+def test_cancel_drops_later_text_but_keeps_tool_cards():
+    s = _state()
+    _apply(s, {"type": "text_chunk", "content": "partial answer"})
+
+    s["cancelled"] = True
+    st = _apply(s, {"type": "text_chunk", "content": " more"})
+    assert s["pending"] == "partial answer"  # dropped, not appended
+    assert st.draft_changed is False
+
+    _apply(s, {"type": "text_end"})  # skipped while cancelled
+    assert s["entries"] == []
+
+    # Tool cards still land after cancel.
+    _apply(s, {"type": "tool_call", "name": "get_net", "args": {}, "result": {"success": True}})
+    assert s["entries"][-1]["type"] == "tool_call"
+
+    # The partial draft is still pending (text_end was skipped), so turn_end
+    # finalises it defensively and does NOT append the full reply.
+    _apply(s, {"type": "turn_end", "reply": "full reply"})
+    assert [e["type"] for e in s["entries"]] == ["tool_call", "ai"]
+    assert s["entries"][-1]["text"] == "partial answer"
+
+
+def test_turn_end_reply_fallback_when_never_streamed():
+    """An error turn streams no text; the reply becomes the entry (the old
+    ``was_streamed=False`` path)."""
+    s = _state()
+    st = _apply(s, {"type": "turn_end", "reply": "[LLM error] API down"})
+
+    assert st.entries_changed is True
+    assert s["entries"] == [{"type": "ai", "text": "[LLM error] API down", "timestamp": "00:00:00"}]
+
+
+def test_turn_end_defensive_finalise_of_leftover_draft():
+    """turn_end finalises a draft that somehow survived (no text_end seen)."""
+    s = _state()
+    _apply(s, {"type": "text_chunk", "content": "before"})
+    st = _apply(s, {"type": "turn_end", "reply": "before"})
+
+    assert st.entries_changed is True
+    assert s["pending"] == ""
+    assert s["entries"] == [{"type": "ai", "text": "before", "timestamp": "00:00:00"}]
+
+
+def test_tool_call_entries_carry_seq_and_mark_tool_use():
+    s = _state()
+    _apply(
+        s,
+        {
+            "type": "tool_call",
+            "name": "edit_track",
+            "args": {"x": 1},
+            "result": {"success": True},
+        },
+    )
+    _apply(
+        s,
+        {
+            "type": "tool_call",
+            "name": "reload_kicad",
+            "args": {"paths": []},
+            "result": {"success": True},
+        },
+    )
+
+    assert s["tool_calls_made"] is True
+    assert [e["_seq"] for e in s["entries"]] == [1, 2]
+    assert [e["name"] for e in s["entries"]] == ["edit_track", "reload_kicad"]
+
+
+def test_make_ai_entry_shape():
+    entry = make_ai_entry("answer text", "12:34:56")
+    assert entry == {"type": "ai", "text": "answer text", "timestamp": "12:34:56"}

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "kcaa"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## What
Merge `develop` into `main`, shipping the two merged plugin fixes:

- **#107 — make LLM answer stream lossless via unified event queue** (`307de29`): fixes lost/truncated final answers on in-flight close and `reload_kicad`
- **#111 — never downgrade active project to None on probe failure** (`f41781e`): fixes sessions saved with `project_path: null` after switching projects

## Files
- `kicad_plugin/llm_client.py`, `kicad_plugin/ui/panel.py`, `kicad_plugin/ui/stream_events.py`
- tests: `test_llm_client.py`, `test_stream_events.py`
- `uv.lock`

## Notes
Pure upstream merge — no new commits. Both PRs already reviewed and merged into `develop` via their own PRs.