### PR TITLE
fix(wire): avoid label/junction anchors when routing wires

### DIFF
--- a/kcaa/tools/wire_edit_tools.py
+++ b/kcaa/tools/wire_edit_tools.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from fastmcp import Context, FastMCP
 
+from kcaa.utils.netlist_parser import _normalize_iterable
 from kcaa.utils.schematic_sexp_utils import save_schematic
 from kcaa.utils.skip_compat import safe_schematic
 from kcaa.utils.skip_helpers import sym_pin_world_coords
@@ -1325,10 +1326,14 @@ def _collect_anchor_points(sch: Any) -> list[tuple[float, float]]:
     already covered by ``_collect_all_pin_positions`` (power symbols expose
     a pin at the tip) and are not duplicated here.
 
+    Sheet-symbol pins (the parent-side ports of hierarchical subsheets)
+    are collected too: they sit on the sheet-symbol edge and a wire
+    crossing one joins the subsheet's net, the same silent-merge hazard.
+
     Route endpoints that coincide with an anchor (e.g. the user routed
-    explicitly to a net-label position) stay allowed: the collision gates
-    use a strict segment-interior check and exclude the overall route
-    start/end.
+    explicitly to a net-label position or a sheet-symbol pin) stay
+    allowed: the collision gates use a strict segment-interior check and
+    exclude the overall route start/end.
 
     Returns:
         List of (x, y) anchor positions in schematic world coordinates.
@@ -1357,6 +1362,30 @@ def _collect_anchor_points(sch: Any) -> list[tuple[float, float]]:
         for j in sch.junction:
             coords = j.at.value
             anchors.append((float(coords[0]), float(coords[1])))
+    except (AttributeError, IndexError, TypeError, ValueError):
+        pass
+    try:
+        # Sheet-symbol pins are positioned relative to the sheet origin and
+        # rotate with the sheet symbol (KiCad semantic; ``sch.symbol`` does
+        # not contain sheet symbols, so they need their own walk).
+        for sheet in _normalize_iterable(getattr(sch, "sheet", None)):
+            try:
+                sat = list(sheet.at)
+                sx = float(sat[0])
+                sy = float(sat[1])
+                angle = float(sat[2]) if len(sat) > 2 else 0.0
+            except (AttributeError, IndexError, TypeError, ValueError):
+                continue
+            cos_a = math.cos(math.radians(angle))
+            sin_a = math.sin(math.radians(angle))
+            for pin in _normalize_iterable(getattr(sheet, "pin", None)):
+                try:
+                    pat = list(pin.at)
+                    px = float(pat[0])
+                    py = float(pat[1])
+                except (AttributeError, IndexError, TypeError, ValueError):
+                    continue
+                anchors.append((sx + px * cos_a - py * sin_a, sy + px * sin_a + py * cos_a))
     except (AttributeError, IndexError, TypeError, ValueError):
         pass
     return anchors

--- a/kcaa/tools/wire_edit_tools.py
+++ b/kcaa/tools/wire_edit_tools.py
@@ -1314,6 +1314,54 @@ def _collect_all_pin_positions(sch: Any) -> list[tuple[float, float]]:
     return positions
 
 
+def _collect_anchor_points(sch: Any) -> list[tuple[float, float]]:
+    """Return schematic anchor points a wire must not pass through.
+
+    A local/global/hierarchical label or an existing junction dot anchored
+    anywhere on a wire segment joins that segment's net in KiCad (enforced
+    in ``netlist_parser._build_netlist`` Step 2c, issue #100 fix).  A
+    routed wire crossing such an anchor would silently merge nets, so the
+    anchors are folded into the router obstacle set.  Power-symbol tips are
+    already covered by ``_collect_all_pin_positions`` (power symbols expose
+    a pin at the tip) and are not duplicated here.
+
+    Route endpoints that coincide with an anchor (e.g. the user routed
+    explicitly to a net-label position) stay allowed: the collision gates
+    use a strict segment-interior check and exclude the overall route
+    start/end.
+
+    Returns:
+        List of (x, y) anchor positions in schematic world coordinates.
+    """
+    anchors: list[tuple[float, float]] = []
+    try:
+        # Label wrappers differ: local/global expose an ``_elements`` list
+        # (LabelCollection), hierarchical_label is a single ParsedValue node
+        # — mirror ``_iter_schematic_labels`` and treat a node as a list of
+        # one.
+        for attr_name in ("label", "global_label", "hierarchical_label"):
+            coll = getattr(sch, attr_name, None)
+            if coll is None:
+                continue
+            elements = getattr(coll, "_elements", None)
+            labels = elements if isinstance(elements, list) else [coll]
+            for label in labels:
+                try:
+                    at = label.at.value
+                    anchors.append((float(at[0]), float(at[1])))
+                except (AttributeError, IndexError, TypeError, ValueError):
+                    continue
+    except AttributeError:
+        pass
+    try:
+        for j in sch.junction:
+            coords = j.at.value
+            anchors.append((float(coords[0]), float(coords[1])))
+    except (AttributeError, IndexError, TypeError, ValueError):
+        pass
+    return anchors
+
+
 def _collect_all_pin_data(sch: Any) -> list[tuple[float, float, float]]:
     """Return the absolute schematic position and exit angle of every pin.
 
@@ -1623,7 +1671,7 @@ def register_wire_edit_tools(mcp: FastMCP) -> None:
 
         try:
             all_pin_data = _collect_all_pin_data(sch)
-            obstacles = [(x, y) for x, y, _ in all_pin_data]
+            obstacles = [(x, y) for x, y, _ in all_pin_data] + _collect_anchor_points(sch)
             existing_wires = _collect_existing_wires(sch)
             tol = _PIN_COLLISION_TOL
 
@@ -1937,7 +1985,7 @@ def register_wire_edit_tools(mcp: FastMCP) -> None:
             # the router correctly reject any inner-route candidate that would
             # pass *through* the end pin, which would otherwise produce a
             # self-overlapping backtrack wire.
-            obstacles = _collect_all_pin_positions(sch)
+            obstacles = _collect_all_pin_positions(sch) + _collect_anchor_points(sch)
             existing_wires = _collect_existing_wires(sch)
 
             # Smart routing: follow pin exit directions, avoid all other pins

--- a/tests/unit/tools/test_wire_tools.py
+++ b/tests/unit/tools/test_wire_tools.py
@@ -832,6 +832,40 @@ class TestWireRoutingAvoidsAnchors:
             )
         )
 
+    def _append_sheet(self, sch_path, x, y, angle, pins):
+        """Append a (sheet ...) symbol node with pins to a schematic file.
+
+        Pins are (name, px, py) offsets relative to the sheet origin.
+        """
+        import uuid
+
+        lines = [
+            f"  (sheet (at {x} {y} {angle}) (size 50.8 50.8)",
+            "    (stroke (width 0) (type dash) (color 0 0 0 0))",
+            "    (fill (type none))",
+            f'    (uuid "{uuid.uuid4()}")',
+            '    (property "Sheet name" "SUB" (at 0 0 0) (show_name no) (do_not_autoplace yes) (effects (font (size 1.27 1.27)) (justify left)))',
+            '    (property "Sheet file" "sub.kicad_sch" (at 0 0 0) (show_name no) (do_not_autoplace yes) (effects (font (size 1.27 1.27)) (justify left)))',
+        ]
+        for name, px, py in pins:
+            lines.append(
+                f'    (pin "{name}" input (at {px} {py} 0) (uuid "{uuid.uuid4()}") (effects (font (size 1.27 1.27)) (justify left)))'
+            )
+        lines.extend(
+            [
+                "    (instances",
+                '      (project "test"',
+                f'        (path "/00000000-0000-0000-0000-000000000000/{uuid.uuid4()}" (page "1"))',
+                "      )",
+                "    )",
+                "  )",
+            ]
+        )
+        text = Path(sch_path).read_text().rstrip()
+        assert text.endswith(")")
+        text = text[:-1]  # drop the root close paren; re-add after the sheet
+        Path(sch_path).write_text(text + "\n" + "\n".join(lines) + "\n)")
+
     @staticmethod
     def _wires_through(sch_path, px, py, tol=0.01):
         """Return True if any saved wire has (px, py) on its interior."""
@@ -864,6 +898,49 @@ class TestWireRoutingAvoidsAnchors:
             assert any(abs(ax - ex) < 1e-6 and abs(ay - ey) < 1e-6 for ax, ay in anchors), (
                 f"anchor ({ex}, {ey}) not collected from {anchors}"
             )
+
+    def test_collect_anchor_points_covers_sheet_pins(self, tools, tmp_sch):
+        """Sheet-symbol pins are collected at world coordinates: sheet origin
+        plus the pin offset, rotated by the sheet-symbol angle."""
+        from kcaa.tools.wire_edit_tools import _collect_anchor_points
+
+        self._append_sheet(tmp_sch, 100.0, 102.54, 0, [("MID", 10.0, 0.0)])
+        self._append_sheet(tmp_sch, 200.0, 50.0, 180, [("ROT", 0.0, 10.0)])
+        sch = skip.Schematic(tmp_sch)
+
+        anchors = list(_collect_anchor_points(sch))
+        expected = [
+            (110.0, 102.54),  # MID at origin (100, 102.54) + offset (10, 0)
+            (200.0, 40.0),  # ROT at origin (200, 50) + offset rotated 180° -> (0, -10)
+        ]
+        for ex, ey in expected:
+            assert any(abs(ax - ex) < 1e-6 and abs(ay - ey) < 1e-6 for ax, ay in anchors), (
+                f"sheet anchor ({ex}, {ey}) not collected from {anchors}"
+            )
+
+    def test_route_crossing_sheet_pin_anchor_detours(self, tools, tmp_sch):
+        """Straight path from R2.pin2 to R3.pin2 (y=102.54) crosses a sheet
+        symbol pin anchored at (110, 102.54); the router must detour."""
+        self._append_sheet(tmp_sch, 100.0, 102.54, 0, [("MID", 10.0, 0.0)])
+        result = self._connect_pins(tools, tmp_sch)
+
+        assert "error" in result or result.get("success") is True, result
+        if "error" not in result:
+            assert not self._wires_through(tmp_sch, 110.0, 102.54), (
+                "route crossed the sheet pin anchor — KiCad would merge its net"
+            )
+
+    def test_route_to_sheet_pin_anchor_endpoint_allowed(self, tools, tmp_sch):
+        """Routing explicitly TO a sheet-symbol pin anchor stays allowed."""
+        self._append_sheet(tmp_sch, 100.0, 102.54, 0, [("TARGET", 10.0, 0.0)])
+        result = self._connect_points(tools, tmp_sch, 100.0, 102.54, 110.0, 102.54)
+
+        assert result.get("success") is True, result
+        sch = skip.Schematic(tmp_sch)
+        assert any(
+            abs(float(w.end.value[0]) - 110.0) < 1e-6 and abs(float(w.end.value[1]) - 102.54) < 1e-6
+            for w in sch.wire
+        ), "wire does not terminate at the sheet pin anchor endpoint"
 
     def test_route_crossing_label_anchor_detours(self, tools, tmp_sch):
         """Straight path from R2.pin2 to R3.pin2 (y=102.54) crosses a label at

--- a/tests/unit/tools/test_wire_tools.py
+++ b/tests/unit/tools/test_wire_tools.py
@@ -795,6 +795,101 @@ class TestConnectPinsWithWire:
 # ---------------------------------------------------------------------------
 
 
+class TestWireRoutingAvoidsAnchors:
+    """Routes must not cross label/junction anchor points (silent net-merge bug)."""
+
+    def _connect_pins(self, tools, sch_path):
+        return asyncio.run(
+            tools["connect_pins_with_wire"](
+                schematic_path=sch_path,
+                from_ref="R2",
+                from_pin="2",
+                to_ref="R3",
+                to_pin="2",
+            )
+        )
+
+    def _connect_points(self, tools, sch_path, sx, sy, ex, ey):
+        return asyncio.run(
+            tools["connect_points_with_wire"](
+                schematic_path=sch_path,
+                start_x=sx,
+                start_y=sy,
+                end_x=ex,
+                end_y=ey,
+            )
+        )
+
+    def _add_label(self, tools, sch_path, text, x, y, label_type="global"):
+        return asyncio.run(
+            tools["add_label_to_schematic"](
+                schematic_path=sch_path,
+                text=text,
+                x=x,
+                y=y,
+                angle=0,
+                label_type=label_type,
+            )
+        )
+
+    @staticmethod
+    def _wires_through(sch_path, px, py, tol=0.01):
+        """Return True if any saved wire has (px, py) on its interior."""
+        from kcaa.tools.wire_edit_tools import _point_on_open_segment
+
+        sch = skip.Schematic(sch_path)
+        for w in sch.wire:
+            ax = float(w.start.value[0])
+            ay = float(w.start.value[1])
+            bx = float(w.end.value[0])
+            by = float(w.end.value[1])
+            if _point_on_open_segment(px, py, ax, ay, bx, by, tol):
+                return True
+        return False
+
+    def test_collect_anchor_points_covers_labels_and_junctions(self, tools, tmp_sch):
+        """Local/global/hierarchical labels and junctions are all collected."""
+        from kcaa.tools.wire_edit_tools import _collect_anchor_points
+
+        self._add_label(tools, tmp_sch, "L1", 130.0, 102.54, label_type="local")
+        self._add_label(tools, tmp_sch, "G1", 140.0, 102.54, label_type="global")
+        self._add_label(tools, tmp_sch, "H1", 150.0, 102.54, label_type="hierarchical")
+        sch = skip.Schematic(tmp_sch)
+        j = sch.junction.new()
+        j.at.value = [160.0, 102.54]
+
+        anchors = list(_collect_anchor_points(sch))
+        expected = [(130.0, 102.54), (140.0, 102.54), (150.0, 102.54), (160.0, 102.54)]
+        for ex, ey in expected:
+            assert any(abs(ax - ex) < 1e-6 and abs(ay - ey) < 1e-6 for ax, ay in anchors), (
+                f"anchor ({ex}, {ey}) not collected from {anchors}"
+            )
+
+    def test_route_crossing_label_anchor_detours(self, tools, tmp_sch):
+        """Straight path from R2.pin2 to R3.pin2 (y=102.54) crosses a label at
+        (110, 102.54); the router must reject that candidate and detour."""
+        self._add_label(tools, tmp_sch, "MID", 110.0, 102.54)
+        result = self._connect_pins(tools, tmp_sch)
+
+        assert "error" in result or result.get("success") is True, result
+        if "error" not in result:
+            assert not self._wires_through(tmp_sch, 110.0, 102.54), (
+                "route crossed the label anchor — KiCad would merge its net"
+            )
+
+    def test_route_to_label_anchor_endpoint_allowed(self, tools, tmp_sch):
+        """Routing explicitly TO a label anchor (deliberate endpoint) stays allowed."""
+        self._add_label(tools, tmp_sch, "TARGET", 115.0, 102.54)
+        result = self._connect_points(tools, tmp_sch, 100.0, 102.54, 115.0, 102.54)
+
+        assert result.get("success") is True, result
+        sch = skip.Schematic(tmp_sch)
+        assert any(
+            abs(float(w.end.value[0]) - 115.0) < 1e-6 and abs(float(w.end.value[1]) - 102.54) < 1e-6
+            for w in sch.wire
+        ), "wire does not terminate at the label anchor endpoint"
+
+
 class TestDeleteWireFromSchematic:
     def _call(self, tools, schematic_path, wires, **kwargs):
         return asyncio.run(


### PR DESCRIPTION
## Description

Fixes #114: the schematic wire-routing tools built their obstacle set from pins, wire segments, and pin stubs only — label anchors and junction dots were not avoided, so a routed wire whose segment crossed such an anchor would silently merge the anchor's net with the wire's net in KiCad.

- New `_collect_anchor_points(sch)` in `kcaa/tools/wire_edit_tools.py`: collects local/global/hierarchical label anchors and existing junction positions (power-symbol tips are already covered by pin positions). Handles the skip wrapper difference — local/global labels expose an `_elements` list, `hierarchical_label` is a single `ParsedValue` node (mirrors `_iter_schematic_labels` in `symbol_edit_tools.py`).
- Anchors are folded into the `obstacles` set of `connect_points_with_wire` and `connect_pins_with_wire`, flowing through the existing `_PIN_COLLISION_TOL` gates (`pin-on-interior`, `pin-at-corner`).
- Deliberate label endpoints stay allowed: the gates use a strict segment-interior check and exclude the overall route start/end, so routing explicitly to a label anchor is unaffected. `add_wire_to_schematic` is the documented naive straight-line fallback and is intentionally out of scope.

## Related Issue(s)

Closes #114

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing Performed

- [x] Added new unit tests (`tests/unit/tools/test_wire_tools.py::TestWireRoutingAvoidsAnchors`): anchor collection covers all label types + junctions; a route whose straight path crosses a label anchor detours/rejects (no wire through the anchor); a route explicitly ending at a label anchor succeeds.
- [x] Ran affected suites: `test_wire_tools.py`, `test_connect_pins_auto_junction.py`, `test_label_tools.py` — 72 passed (15 skipped are the intentionally-removed `add_wire` tests), no regressions.
- [x] Manually tested on Linux (fixture-based tests)

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass with my changes